### PR TITLE
Prevent ClassNotFoundException of jackson

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -27,7 +27,6 @@ val centralDependencies = listOf(
     "org.jetbrains.kotlin:kotlin-stdlib:1.8.20",
     "org.jetbrains.kotlin:kotlin-reflect:1.8.20",
     "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1",
-    "com.corundumstudio.socketio:netty-socketio:1.7.19", // Keep this on a lower version as the newer version breaks the ping
 )
 
 dependencies {
@@ -42,6 +41,7 @@ dependencies {
     implementation("io.ktor:ktor-server-core:2.3.0")
     implementation("io.ktor:ktor-server-netty:2.3.0")
     implementation("io.insert-koin:koin-core:3.4.0")
+    implementation("com.corundumstudio.socketio:netty-socketio:1.7.19") // Keep this on a lower version as the newer version breaks the ping
 
     compileOnly("com.github.shynixn.mccoroutine:mccoroutine-bukkit-api:2.11.0")
     compileOnly("com.github.shynixn.mccoroutine:mccoroutine-bukkit-core:2.11.0")


### PR DESCRIPTION
To implementation dependency "com.corundumstudio.socketio:netty-socketio:1.7.19" instead of CompileOnly, to prevent ClassNotFoundException error of Jackson when running TypeWriter plugin on some server software.