### PR TITLE
Slight README Fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Typewriter is a plugin for **Paper** Minecraft servers that allows for custom pl
 NPC chat, Create branching story with ease, Creating Cinematic with camera paths, and more. It is easily configurable using the web panel specifically
 designed for this plugin.
 
-The plugin can also be extended using adapters, which are [pre-made](https://gabber235.github.io/TypeWriter/docs/pre-made-adapters) or can be custom-made by developers.
+The plugin can also be extended using adapters, which are [pre-made](https://gabber235.github.io/TypeWriter/docs/adapters) or can be custom-made by developers.
 
 To get started with Typewriter, see the [Getting Started](#getting-started) section.
 
@@ -39,7 +39,7 @@ The web panel for Typewriter, where you can create quests, NPCs, and more.
 - Create cinematic sequences with camera movements, dialogue, animated NPCs, and more...
 - Configure interactions using a custom written visual interface
 - Extend the plugin using adapters
-  - [Pre-made adapters](https://gabber235.github.io/TypeWriter/docs/pre-made-adapters) available for popular plugins
+  - [Pre-made adapters](https://gabber235.github.io/TypeWriter/docs/adapters) available for popular plugins
   - Custom adapters can be made by developers
 
 ## Getting started
@@ -51,14 +51,14 @@ Also be sure to download ProtocolLib from [here](https://ci.dmulloy2.net/job/Pro
 
 Then, use the app to configure your custom interactions as desired.
 
-You can also utilize the [pre-made adapters](https://gabber235.github.io/TypeWriter/docs/pre-made-adapters) or create your own custom adapters to extend the
+You can also utilize the [pre-made adapters](https://gabber235.github.io/TypeWriter/docs/adapters) or create your own custom adapters to extend the
 capabilities of the plugin. See [First Interaction](https://gabber235.github.io/TypeWriter/docs/first-interaction) for more information.
 
 ## For administrators
 
 As an administrator, you can easily configure Typewriter using the custom web panel. 
 Simply input your desired interactions and let the plugin handle the rest. 
-You can also take advantage of the [pre-made adapters](https://gabber235.github.io/TypeWriter/docs/pre-made-adapters) or create your own custom
+You can also take advantage of the [pre-made adapters](https://gabber235.github.io/TypeWriter/docs/adapters) or create your own custom
 adapters to further customize the plugin for your server.
 
 ## For developers


### PR DESCRIPTION
Noticed that the links to the pre-made adapters on the README were invalid, resulting in a 404 not found.

Just forked and made it link to https://gabber235.github.io/TypeWriter/docs/adapters instead.
Hope this is okay :)