### PR TITLE
fix(docs): expired discord invites

### DIFF
--- a/documentation/docs/docs/01-home.md
+++ b/documentation/docs/docs/01-home.md
@@ -9,5 +9,5 @@ Then you can follow the [First Interaction](./03-creating-stories/01-interaction
 
 :::caution[In beta]
 Typewriter is currently in beta. This means that the plugin is still in development and may contain bugs. If you find
-any bugs, please report them in our [discord](https://discord.gg/p7WH9VvdMQ)
+any bugs, please report them in our [discord](https://discord.gg/HtbKyuDDBw)
 :::

--- a/documentation/docs/docs/02-getting-started/01-installation.mdx
+++ b/documentation/docs/docs/02-getting-started/01-installation.mdx
@@ -45,7 +45,7 @@ When updating the plugin, it's crucial to **always** install the corresponding e
 ## Configuring the Web Panel
 
 :::caution[External server providers]
-Typewriter's web panel does **not** support external server providers such as Minehut, Aternos, or Apex. You can still use everything else in TypeWriter. It is still possible to use the panel still by setting up a local server with Typewriter installed. For more information, please create a question in our [Discord](https://discord.gg/p7WH9VvdMQ).
+Typewriter's web panel does **not** support external server providers such as Minehut, Aternos, or Apex. You can still use everything else in TypeWriter. It is still possible to use the panel still by setting up a local server with Typewriter installed. For more information, please create a question in our [Discord](https://discord.gg/HtbKyuDDBw).
 :::
 :::info[Resource consumption]
 Please note that the web panel and web socket use precious resources on your server, and it is best to host the panel on your development server instead of on a production server.

--- a/documentation/versioned_docs/version-0.4.2/docs/02-installation-guide.md
+++ b/documentation/versioned_docs/version-0.4.2/docs/02-installation-guide.md
@@ -6,7 +6,7 @@ Typewriter only works on **Paper** Spigot servers. It will not work on Spigot or
 
 :::caution
 Typewriter is currently in beta. This means that the plugin is still in development and may contain bugs. If you find
-any bugs, please report them [here](https://discord.gg/p7WH9VvdMQ)
+any bugs, please report them [here](https://discord.gg/HtbKyuDDBw)
 :::
 
 ## Installing the Plugin
@@ -39,7 +39,7 @@ When updating the plugin, it's crucial to **always** install the corresponding a
 
 ## Configuring the Web Panel
 :::caution
-Typewriter's web panel does **not** support external server providers such as Minehut, Aternos, or Apex. You can still use everthing else in Typewriter. It is possible to use the panel still by setting up a local server with Typewriter installed. For more information, please visit the [Discord](https://discord.gg/p7WH9VvdMQ).
+Typewriter's web panel does **not** support external server providers such as Minehut, Aternos, or Apex. You can still use everthing else in Typewriter. It is possible to use the panel still by setting up a local server with Typewriter installed. For more information, please visit the [Discord](https://discord.gg/HtbKyuDDBw).
 :::
 
 The web panel to configure your server's interactions. The web panel is preinstalled inside the plugin, though it is

--- a/documentation/versioned_docs/version-0.5.0/docs/01-home.md
+++ b/documentation/versioned_docs/version-0.5.0/docs/01-home.md
@@ -9,5 +9,5 @@ can follow the [First Interaction](./03-creating-stories/01-interactions/index.m
 
 :::caution[In beta]
 Typewriter is currently in beta. This means that the plugin is still in development and may contain bugs. If you find
-any bugs, please report them in our [discord](https://discord.gg/p7WH9VvdMQ)
+any bugs, please report them in our [discord](https://discord.gg/HtbKyuDDBw)
 :::

--- a/documentation/versioned_docs/version-0.5.0/docs/02-getting-started/01-installation.mdx
+++ b/documentation/versioned_docs/version-0.5.0/docs/02-getting-started/01-installation.mdx
@@ -45,7 +45,7 @@ When updating the plugin, it's crucial to **always** install the corresponding a
 ## Configuring the Web Panel
 
 :::caution[External server providers]
-Typewriter's web panel does **not** support external server providers such as Minehut, Aternos, or Apex. You can still use everything else in TypeWriter. It is still possible to use the panel still by setting up a local server with Typewriter installed. For more information, please create a question in our [Discord](https://discord.gg/p7WH9VvdMQ).
+Typewriter's web panel does **not** support external server providers such as Minehut, Aternos, or Apex. You can still use everything else in TypeWriter. It is still possible to use the panel still by setting up a local server with Typewriter installed. For more information, please create a question in our [Discord](https://discord.gg/HtbKyuDDBw).
 :::
 :::info[Resource consumption]
 Please note that the web panel and web socket use precious resources on your server, and it is best to host the panel on your development server instead of on a production server.


### PR DESCRIPTION
Some links to join the discord were expired in the docs, this replaces them with working links that were grabbed from the docs itself