### PR TITLE
Add support for secure websocket connections (flutter)

### DIFF
--- a/app/lib/models/communicator.dart
+++ b/app/lib/models/communicator.dart
@@ -16,6 +16,7 @@ import "package:typewriter/models/staging.dart";
 import "package:typewriter/models/writers.dart";
 import "package:typewriter/utils/passing_reference.dart";
 import "package:typewriter/widgets/components/general/toasts.dart";
+import "package:web/web.dart";
 
 part "communicator.g.dart";
 part "communicator.freezed.dart";
@@ -112,7 +113,9 @@ class SocketNotifier extends StateNotifier<Socket?> {
       return;
     }
 
-    var url = "//$hostname";
+    // `io` uses wss or ws if `uri` begins with https or http respectively
+    final protocol = document.location?.protocol ?? "http:";
+    var url = "$protocol//$hostname";
     if (port != null) url += ":$port";
     if (token != null) url += "?token=$token";
 

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1251,7 +1251,7 @@ packages:
     source: hosted
     version: "1.1.0"
   web:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: web
       sha256: d43c1d6b787bf0afad444700ae7f4db8827f701bc61c255ac8d328c6f4d52062

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
       ref: master
   indent: ^2.0.0
   dart_casing: ^3.0.1
+  web: ^1.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
In this PR I match the websocket protocol for [socket_io_client](https://pub.dev/packages/socket_io_client) to the protocol of the current browser, `document.location.protocol`.

This adds secure websocket support as in #251, and should not introduce breaking changes.

I tested navigating to `/#/connect?host=localhost?token=abc` locally copying the files I built with `flutter build web` to an nginx server. 
- Console output without certificates (out-of-the-box): new connection to `ws://...`
- Console output after adding certificates and turning ssl on: new connection to `wss://...`