### PR TITLE
Allow glowing effect data to have colors

### DIFF
--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/utils/Color.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/utils/Color.kt
@@ -10,6 +10,7 @@ class Color(
         }
 
         val BLACK_BACKGROUND = Color(0x40000000)
+        val WHITE = Color(0xFFFFFFFF.toInt())
     }
 
     val alpha: Int get() = (color shr 24) and 0xFF


### PR DESCRIPTION
Allow the entity glowing effect to have differente colors, on top of this the selected RGB value is downsampled to the nearest TextColor for non-entity display.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new predefined white color option.
	- Enhanced entity glowing effects by enabling customizable glow colors, defaulting to white for an improved visual experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->