### PR TITLE
Prevent thread leaks in road network edge recalculation

### DIFF
--- a/extensions/RoadNetworkExtension/src/main/kotlin/com/typewritermc/roadnetwork/RoadNetworkEditor.kt
+++ b/extensions/RoadNetworkExtension/src/main/kotlin/com/typewritermc/roadnetwork/RoadNetworkEditor.kt
@@ -1,23 +1,18 @@
 package com.typewritermc.roadnetwork
 
 import co.touchlab.stately.concurrency.AtomicInt
-import com.github.shynixn.mccoroutine.bukkit.launch
 import com.typewritermc.core.entries.Ref
-import com.typewritermc.engine.paper.plugin
 import com.typewritermc.engine.paper.utils.ThreadType.DISPATCHERS_ASYNC
 import com.typewritermc.roadnetwork.gps.roadNetworkFindPath
 import com.typewritermc.roadnetwork.pathfinding.PFInstanceSpace
 import com.typewritermc.roadnetwork.pathfinding.instanceSpace
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
-import java.util.concurrent.Executors
-import kotlin.math.max
 
 class RoadNetworkEditor(
     private val ref: Ref<out RoadNetworkEntry>,
@@ -65,8 +60,7 @@ class RoadNetworkEditor(
     fun recalculateEdges() {
         jobRecalculateEdges?.cancel()
 
-        val nrOfThreads = max(Runtime.getRuntime().availableProcessors() / 2, 1)
-        jobRecalculateEdges = plugin.launch(Executors.newFixedThreadPool(nrOfThreads).asCoroutineDispatcher()) {
+        jobRecalculateEdges = DISPATCHERS_ASYNC.launch {
             update {
                 it.copy(edges = emptyList())
             }


### PR DESCRIPTION
Each time edges were recalculated, a new thread pool was created for the coroutine dispatcher, but these pools were never properly shut down. According to both the [Kotlin documentation](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/new-fixed-thread-pool-context.html) and [Java documentation](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/concurrent/Executors.html#newFixedThreadPool(int)), thread pools require explicit shutdown using the `shutdown()` or `close()` methods. Simply calling `cancel()` on the coroutine doesn't properly clean up the underlying thread resources.

Over time, these abandoned thread pools would accumulate, eventually exhausting the system's resources and causing the server to crash. The issue became apparent after prolonged use of the road network editor.

This fix replaces the creation of new thread pools with the existing shared plugin thread pool, which is already properly managed. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the background processing for updating road network data to improve clarity and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->