### PR TITLE
Bump EntityLib dependency

### DIFF
--- a/engine/engine-paper/build.gradle.kts
+++ b/engine/engine-paper/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
 
     compileOnlyApi("com.corundumstudio.socketio:netty-socketio:1.7.19") // Keep this on a lower version as the newer version breaks the ping
 
-    api("me.tofaa.entitylib:spigot:+d9aae45-SNAPSHOT")
+    api("me.tofaa.entitylib:spigot:+74871b3-SNAPSHOT")
     compileOnlyApi("com.github.shynixn.mccoroutine:mccoroutine-bukkit-api:2.20.0")
     compileOnlyApi("com.github.shynixn.mccoroutine:mccoroutine-bukkit-core:2.20.0")
 
@@ -61,7 +61,6 @@ tasks.withType<ShadowJar> {
         exclude("kotlin/**")
         exclude("org/intellij/**")
         exclude("org/jetbrains/**")
-        exclude(dependency("com.github.Tofaa2.EntityLib:spigot"))
         exclude(dependency("web::"))
     }
 }


### PR DESCRIPTION
Updates the EntityLib dependency to the latest snapshot, resolving a long-standing bug where adding `Saddled` or `Eating` data to a horse would disconnect the client from the server.

Additionally, this change enables `Ageable` data to be added to horses and camels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated a backend dependency to a newer version for improved stability and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->