### PR TITLE
Fix confirmation typo

### DIFF
--- a/documentation/docs/docs/03-creating-stories/07-advanced-interactions/03-interaction-bounds/02-option-bound.mdx
+++ b/documentation/docs/docs/03-creating-stories/07-advanced-interactions/03-interaction-bounds/02-option-bound.mdx
@@ -118,7 +118,7 @@ When players interact with the waiter NPC, they'll see the option menu. As they 
 <Player url={require("../../../assets/interactions/option-bound-result.webm").default} />
 
 :::warning[Confirmation Key]
-While writing these docs a bug was found with the confirmation key. If your conformation key is `SWAP_HANDS`(F) than while inside a interaction bound the dialogue will not continue. You need to press SPACE to do this!
+While writing these docs a bug was found with the confirmation key. If your confirmation key is `SWAP_HANDS`(F) than while inside a interaction bound the dialogue will not continue. You need to press SPACE to do this!
 :::
 
 ## How it Works

--- a/documentation/versioned_docs/version-0.8.0/docs/03-creating-stories/07-advanced-interactions/03-interaction-bounds/02-option-bound.mdx
+++ b/documentation/versioned_docs/version-0.8.0/docs/03-creating-stories/07-advanced-interactions/03-interaction-bounds/02-option-bound.mdx
@@ -118,7 +118,7 @@ When players interact with the waiter NPC, they'll see the option menu. As they 
 <Player url={require("../../../assets/interactions/option-bound-result.webm").default} />
 
 :::warning[Confirmation Key]
-While writing these docs a bug was found with the confirmation key. If your conformation key is `SWAP_HANDS`(F) than while inside a interaction bound the dialogue will not continue. You need to press SPACE to do this!
+While writing these docs a bug was found with the confirmation key. If your confirmation key is `SWAP_HANDS`(F) than while inside a interaction bound the dialogue will not continue. You need to press SPACE to do this!
 :::
 
 ## How it Works


### PR DESCRIPTION
## Summary
- fix spelling of **confirmation key** in Option Bound docs

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_684671e0850483228bb6a93a02f91bf5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typo in the warning text, changing "conformation" to "confirmation" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->