### PR TITLE
Fix Generic compareTo return values

### DIFF
--- a/engine/engine-core/src/main/kotlin/com/typewritermc/core/utils/Generic.kt
+++ b/engine/engine-core/src/main/kotlin/com/typewritermc/core/utils/Generic.kt
@@ -40,10 +40,10 @@ class Generic(
             return data.asString.compareTo(other.data.asString)
         }
         if (data.isJsonObject && other.data.isJsonObject) {
-            data.asJsonObject.size().compareTo(other.data.asJsonObject.size())
+            return data.asJsonObject.size().compareTo(other.data.asJsonObject.size())
         }
         if (data.isJsonArray && other.data.isJsonArray) {
-            data.asJsonArray.size().compareTo(other.data.asJsonArray.size())
+            return data.asJsonArray.size().compareTo(other.data.asJsonArray.size())
         }
         return 0
     }


### PR DESCRIPTION
## Summary
- ensure `compareTo` in `Generic` returns size comparison results when comparing objects or arrays

## Testing
- `./gradlew test --no-daemon` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6846721b94788322b580263c998951b4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where comparisons of JSON objects and arrays did not return correct results, ensuring accurate comparison behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->