### PR TITLE
Fix DurationParser KDoc formatting

### DIFF
--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/utils/DurationParser.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/utils/DurationParser.kt
@@ -32,18 +32,18 @@ object DurationParser {
 		}
 	}
 
-	/**
-	 * Parses a duration string into a [Duration] object.`
-	 *
-	 * Examples:
-	 * ```
-	 * parse("1 hr 20 mins"'") // => 1 * h + 20 * m
-	 * parse("1.5 hours"'") // => 1.5 * h
-	 * parse("1h20m0s") // => 1 * h + 20 * m
-	 * parse("2hr -40mins") // => 1 * h + 20 * m
-	 * parse("27,681 ms") // => 27681 * ms
-	 * ```
-	 */
+        /**
+         * Parses a duration string into a [Duration] object.
+         *
+         * Examples:
+         * ```
+         * parse("1 hr 20 mins") // => 1 * h + 20 * m
+         * parse("1.5 hours") // => 1.5 * h
+         * parse("1h20m0s") // => 1 * h + 20 * m
+         * parse("2hr -40mins") // => 1 * h + 20 * m
+         * parse("27,681 ms") // => 27681 * ms
+         * ```
+         */
 	fun parse(string: String): Duration {
 		var result: Long = 0
 		val parsable = string.replace(Regex("(\\d)[,_](\\d)"), "\$1\$2")


### PR DESCRIPTION
## Summary
- fix formatting in `DurationParser` KDoc

## Testing
- `./gradlew test --no-daemon` *(fails: could not finish due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_684672367b908322b87f83ee1971ef70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved formatting and style of documentation comments for better readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->