### PR TITLE
Add negative duration parser tests

### DIFF
--- a/engine/engine-paper/src/test/kotlin/com/typewritermc/utils/DurationParserTest.kt
+++ b/engine/engine-paper/src/test/kotlin/com/typewritermc/utils/DurationParserTest.kt
@@ -40,4 +40,9 @@ class DurationParserTest : FunSpec({
     test("empty duration string parsing") {
         DurationParser.parse("").inWholeSeconds shouldBe 0
     }
+
+    test("negative duration parsing") {
+        DurationParser.parse("-1 hr").inWholeHours shouldBe -1
+        DurationParser.parse("-30min").inWholeMinutes shouldBe -30
+    }
 })


### PR DESCRIPTION
## Summary
- add test for negative values in `DurationParser`

## Testing
- `./gradlew test --no-daemon` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684672469b1883229a74f9fae92857d1