### PR TITLE
Remove unused confirmation entry snippet

### DIFF
--- a/documentation/docs/develop/02-extensions/04-entries/trigger/dialogue.mdx
+++ b/documentation/docs/develop/02-extensions/04-entries/trigger/dialogue.mdx
@@ -24,6 +24,13 @@ The `state` of the messenger determines what happens to the messenger.
 
 The state object can be changed inside the `tick` method or from outside. It can even be changed from the plugin itself. For example when the user runs a command the dialogue will be cancelled.
 
+### Confirmation Key
+Some dialogue messengers may wait for the player to press a key before continuing. This key is configured globally in the plugin's `config.yml` under `confirmationKey`.
+Available values are `JUMP`, `SWAP_HANDS`, and `SNEAK`. Use the `<confirmation_key>` tag in your messages to display the correct keybind to the player.
+
+Here is a minimal example of a dialogue that waits for the configured confirmation key before moving on.
+<CodeSnippet tag="dialogue_confirmation_messenger" json={require("../../../snippets.json")} />
+
 There are some additional lifecycle methods that can be overridden.
 - `init` - Called when the messenger is initialized. Will be called before the first `tick` call.
 - `dispose` - Called when the messenger is disposed. By default this will unregister any listeners that were registered by the messenger.

--- a/documentation/plugins/code-snippets/snippets.json
+++ b/documentation/plugins/code-snippets/snippets.json
@@ -214,5 +214,9 @@
   "temporal_triggers": {
     "file": "src\\main\\kotlin\\com\\typewritermc\\example\\TriggerExample.kt",
     "content": "    // To start a temporal sequence\n    TemporalStartTrigger(\n        pageId = \"some_id\",\n        eventTriggers = listOf<EventTrigger>(),\n        settings = TemporalSettings(\n            blockChatMessages = true,\n            blockActionBarMessages = true\n        )\n    ).triggerFor(player, context())\n\n    // To stop the temporal sequence and trigger the following entries.\n    TemporalStopTrigger.triggerFor(player, player.interactionContext ?: context())"
+  },
+  "dialogue_confirmation_messenger": {
+    "file": "src\\main\\kotlin\\com\\typewritermc\\example\\entries\\trigger\\ExampleDialogueEntry.kt",
+    "content": "class ExampleConfirmationDialogueMessenger(\n    player: Player,\n    context: InteractionContext,\n    entry: ExampleConfirmationDialogueEntry,\n) : DialogueMessenger<ExampleConfirmationDialogueEntry>(player, context, entry) {\n\n    private var confirmationKeyHandler: ConfirmationKeyHandler? = null\n\n    override fun init() {\n        super.init()\n        player.sendMessage(\"${entry.speakerDisplayName}: ${entry.text}\".parsePlaceholders(player).asMini())\n        // highlight-start\n        confirmationKeyHandler = confirmationKey.handler(player) {\n            state = MessengerState.FINISHED\n        }\n        // highlight-end\n    }\n\n    override fun dispose() {\n        super.dispose()\n        // highlight-next-line\n        confirmationKeyHandler?.dispose()\n        confirmationKeyHandler = null\n    }\n}"
   }
 }

--- a/extensions/_DocsExtension/src/main/kotlin/com/typewritermc/example/entries/trigger/ExampleDialogueEntry.kt
+++ b/extensions/_DocsExtension/src/main/kotlin/com/typewritermc/example/entries/trigger/ExampleDialogueEntry.kt
@@ -8,9 +8,7 @@ import com.typewritermc.core.interaction.InteractionContext
 import com.typewritermc.engine.paper.entry.Criteria
 import com.typewritermc.engine.paper.entry.Modifier
 import com.typewritermc.engine.paper.entry.TriggerableEntry
-import com.typewritermc.engine.paper.entry.dialogue.DialogueMessenger
-import com.typewritermc.engine.paper.entry.dialogue.MessengerState
-import com.typewritermc.engine.paper.entry.dialogue.TickContext
+import com.typewritermc.engine.paper.entry.dialogue.*
 import com.typewritermc.engine.paper.entry.entries.DialogueEntry
 import com.typewritermc.engine.paper.entry.entries.SpeakerEntry
 import com.typewritermc.engine.paper.extensions.placeholderapi.parsePlaceholders
@@ -57,3 +55,50 @@ class ExampleDialogueDialogueMessenger(player: Player, context: InteractionConte
     }
 }
 //</code-block:dialogue_messenger>
+
+@Entry("example_confirmation_dialogue", "A dialogue requiring confirmation.", Colors.BLUE, "material-symbols:chat-rounded")
+class ExampleConfirmationDialogueEntry(
+    override val id: String = "",
+    override val name: String = "",
+    override val criteria: List<Criteria> = emptyList(),
+    override val modifiers: List<Modifier> = emptyList(),
+    override val triggers: List<Ref<TriggerableEntry>> = emptyList(),
+    override val speaker: Ref<SpeakerEntry> = emptyRef(),
+    @MultiLine
+    @Placeholder
+    @Colored
+    @Help("The text to display to the player.")
+    val text: String = "",
+) : DialogueEntry {
+    override fun messenger(player: Player, context: InteractionContext): DialogueMessenger<*>? {
+        return ExampleConfirmationDialogueMessenger(player, context, this)
+    }
+}
+
+//<code-block:dialogue_confirmation_messenger>
+class ExampleConfirmationDialogueMessenger(
+    player: Player,
+    context: InteractionContext,
+    entry: ExampleConfirmationDialogueEntry,
+) : DialogueMessenger<ExampleConfirmationDialogueEntry>(player, context, entry) {
+
+    private var confirmationKeyHandler: ConfirmationKeyHandler? = null
+
+    override fun init() {
+        super.init()
+        player.sendMessage("${entry.speakerDisplayName}: ${entry.text}".parsePlaceholders(player).asMini())
+        // highlight-start
+        confirmationKeyHandler = confirmationKey.handler(player) {
+            state = MessengerState.FINISHED
+        }
+        // highlight-end
+    }
+
+    override fun dispose() {
+        super.dispose()
+        // highlight-next-line
+        confirmationKeyHandler?.dispose()
+        confirmationKeyHandler = null
+    }
+}
+//</code-block:dialogue_confirmation_messenger>

--- a/extensions/_DocsExtension/src/main/kotlin/com/typewritermc/example/entries/trigger/ExampleDialogueEntry.kt
+++ b/extensions/_DocsExtension/src/main/kotlin/com/typewritermc/example/entries/trigger/ExampleDialogueEntry.kt
@@ -56,7 +56,12 @@ class ExampleDialogueDialogueMessenger(player: Player, context: InteractionConte
 }
 //</code-block:dialogue_messenger>
 
-@Entry("example_confirmation_dialogue", "A dialogue requiring confirmation.", Colors.BLUE, "material-symbols:chat-rounded")
+@Entry(
+    "example_confirmation_dialogue",
+    "A dialogue requiring confirmation.",
+    Colors.BLUE,
+    "material-symbols:chat-rounded"
+)
 class ExampleConfirmationDialogueEntry(
     override val id: String = "",
     override val name: String = "",
@@ -82,11 +87,16 @@ class ExampleConfirmationDialogueMessenger(
     entry: ExampleConfirmationDialogueEntry,
 ) : DialogueMessenger<ExampleConfirmationDialogueEntry>(player, context, entry) {
 
+    // highlight-next-line
     private var confirmationKeyHandler: ConfirmationKeyHandler? = null
 
     override fun init() {
         super.init()
-        player.sendMessage("${entry.speakerDisplayName}: ${entry.text}".parsePlaceholders(player).asMini())
+        player.sendMessage(
+            "${entry.speakerDisplayName}: ${entry.text} <gray><confirmation_key>".parsePlaceholders(
+                player
+            ).asMini()
+        )
         // highlight-start
         confirmationKeyHandler = confirmationKey.handler(player) {
             state = MessengerState.FINISHED
@@ -96,9 +106,10 @@ class ExampleConfirmationDialogueMessenger(
 
     override fun dispose() {
         super.dispose()
-        // highlight-next-line
+        // highlight-start
         confirmationKeyHandler?.dispose()
         confirmationKeyHandler = null
+        // highlight-end
     }
 }
 //</code-block:dialogue_confirmation_messenger>


### PR DESCRIPTION
## Summary
- keep the confirmation messenger example but remove the unused entry snippet
- move confirmation entry/messenger into `ExampleDialogueEntry.kt`
- highlight the confirmation key handling code
- update generated snippets

## Testing
- `./extensions/gradlew :_DocsExtension:compileKotlin --console=plain -x test` *(fails: Directory does not contain a Gradle build)*
- `npm ci`
- `npm run build` *(interrupted: build did not finish)*

------
https://chatgpt.com/codex/tasks/task_e_68467d35c7088322a9f3495c12590718

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new section explaining the "Confirmation Key" feature for dialogue messengers, including usage instructions and an example.
- **New Features**
  - Introduced an example dialogue entry and messenger that pauses until the player presses a configurable confirmation key.
- **Chores**
  - Added a code snippet demonstrating how to implement confirmation key handling in a dialogue messenger.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->