### PR TITLE
Add code highlighting docs

### DIFF
--- a/documentation/AGENTS.md
+++ b/documentation/AGENTS.md
@@ -49,3 +49,11 @@ Reusable React components live in `src/components/`. Commonly used elements are
 the `Admonition` component or the Markdown `::note`/`::warning` syntax depending
 on the context. Import these when interactive UI is required.
 
+## Code Highlighting
+
+Code blocks support line highlighting via Prism "magic comments" configured in
+`docusaurus.config.ts`. Prefix a line with `// highlight-next-line` or wrap
+multiple lines with `// highlight-start` and `// highlight-end`. Colored
+variants (`-red`, `-green`, `-blue`) are also available and map to CSS classes in
+`src/css/custom.css`.
+


### PR DESCRIPTION
## Summary
- explain how line highlighting works for docs authors

## Testing
- `npm ci`
- `npm run test` *(fails: cannot finish build)*

------
https://chatgpt.com/codex/tasks/task_e_6846ac577f4883228a901e76636a57d7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the documentation to explain how to use code highlighting in code blocks, including support for colored highlight variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->