### PR TITLE
Add display interpolation duration data

### DIFF
--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/data/minecraft/display/DisplayData.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/data/minecraft/display/DisplayData.kt
@@ -15,6 +15,7 @@ fun applyDisplayEntityData(entity: WrapperEntity, property: EntityProperty): Boo
         is Scale3DProperty -> applyScale3DData(entity, property)
         is PreRotationProperty -> applyPreRotationData(entity, property)
         is PostRotationProperty -> applyPostRotationData(entity, property)
+        is InterpolationDurationProperty -> applyInterpolationDurationData(entity, property)
         is BrightnessProperty -> applyBrightnessData(entity, property)
         else -> return false
     }

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/data/minecraft/display/InterpolationDurationData.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/data/minecraft/display/InterpolationDurationData.kt
@@ -1,0 +1,43 @@
+package com.typewritermc.entity.entries.data.minecraft.display
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Tags
+import com.typewritermc.engine.paper.entry.entity.SinglePropertyCollectorSupplier
+import com.typewritermc.engine.paper.entry.entries.EntityProperty
+import com.typewritermc.engine.paper.extensions.packetevents.metas
+import com.typewritermc.engine.paper.utils.toTicks
+import me.tofaa.entitylib.meta.display.AbstractDisplayMeta
+import me.tofaa.entitylib.wrapper.WrapperEntity
+import org.bukkit.entity.Player
+import java.time.Duration
+import java.util.*
+import kotlin.reflect.KClass
+
+@Entry("interpolation_duration_data", "Interpolation duration of a Display.", Colors.RED, "mdi:timeline-clock")
+@Tags("interpolation_duration_data")
+class InterpolationDurationData(
+    override val id: String = "",
+    override val name: String = "",
+    val duration: Duration = Duration.ZERO,
+    override val priorityOverride: Optional<Int> = Optional.empty(),
+) : DisplayEntityData<InterpolationDurationProperty> {
+    override fun type(): KClass<InterpolationDurationProperty> = InterpolationDurationProperty::class
+
+    override fun build(player: Player): InterpolationDurationProperty =
+        InterpolationDurationProperty(duration)
+}
+
+data class InterpolationDurationProperty(val duration: Duration) : EntityProperty {
+    companion object : SinglePropertyCollectorSupplier<InterpolationDurationProperty>(
+        InterpolationDurationProperty::class,
+        InterpolationDurationProperty(Duration.ZERO)
+    )
+}
+
+fun applyInterpolationDurationData(entity: WrapperEntity, property: InterpolationDurationProperty) {
+    entity.metas {
+        meta<AbstractDisplayMeta> { positionRotationInterpolationDuration = property.duration.toTicks().toInt() }
+        error("Could not apply InterpolationDurationData to ${'$'}{entity.entityType} entity.")
+    }
+}


### PR DESCRIPTION
## Summary
- add `InterpolationDurationData` to control `positionRotationInterpolationDuration` on display entities
- hook new property into `DisplayData` so it is applied with other display properties
- use `Duration` for the interpolation data and convert to ticks

## Testing
- `./gradlew build -x test` *(fails: Could not resolve io.lumine:Mythic-Dist:5.8.2)*

------
https://chatgpt.com/codex/tasks/task_e_6846c2d58f6c8322a2039259d2bd469e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring interpolation duration on display entities, allowing more precise control over animation timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->