### PR TITLE
Various smaller improvements

### DIFF
--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/temporal/TemporalInteraction.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/temporal/TemporalInteraction.kt
@@ -35,7 +35,7 @@ class TemporalInteraction(
     internal var state = STARTING
         private set
     private var playTime = Duration.ofMillis(-1)
-    private val frame: Int get() = (playTime.toMillis() / 50).toInt()
+    val frame: Int get() = (playTime.toMillis() / 50).toInt()
 
     override val priority by lazy { Query.findPageById(pageId)?.priority ?: 0 }
 
@@ -137,6 +137,8 @@ private val Player.temporalInteraction: TemporalInteraction?
     get() = with(KoinJavaComponent.get<PlayerSessionManager>(PlayerSessionManager::class.java)) {
         session?.interaction as? TemporalInteraction
     }
+
+fun Player.currentTemporalFrame(): Int? = temporalInteraction?.frame
 
 fun Player.isPlayingTemporal(pageId: String): Boolean = temporalInteraction?.pageId == pageId
 

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/cinematic/WorldborderCinematicEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/cinematic/WorldborderCinematicEntry.kt
@@ -1,0 +1,79 @@
+package com.typewritermc.basic.entries.cinematic
+
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerWorldBorderSize
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayWorldBorderLerpSize
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Segments
+import com.typewritermc.engine.paper.entry.Criteria
+import com.typewritermc.engine.paper.entry.entries.CinematicAction
+import com.typewritermc.engine.paper.entry.entries.PrimaryCinematicEntry
+import com.typewritermc.engine.paper.entry.entries.Segment
+import com.typewritermc.engine.paper.entry.temporal.SimpleCinematicAction
+import com.typewritermc.engine.paper.extensions.packetevents.sendPacket
+import com.typewritermc.engine.paper.extensions.packetevents.sendPacketTo
+import org.bukkit.entity.Player
+import java.time.Duration
+import java.util.*
+
+@Entry("worldborder_cinematic", "A cinematic that resizes the worldborder over time", Colors.CYAN, "mdi:resize")
+/**
+ * The `Worldborder cinematic` entry can animate the worldborder client-side.
+ * The border animation speed is not linked to the server's tick rate, since the animation fully runs on the client.
+ *
+ * ## How could this be used?
+ *
+ * This entry could be used to show the worldborder changing size during a cinematic, for example to emphasize a narrator talking about
+ * how the border could change on a server based on certain conditions.
+ */
+class WorldborderCinematicEntry(
+    override val id: String = "",
+    override val name: String = "",
+    override val criteria: List<Criteria> = emptyList(),
+    @Segments(icon = "mdi:resize")
+    val segments: List<WorldborderSegment> = emptyList(),
+) : PrimaryCinematicEntry {
+    override fun create(player: Player): CinematicAction {
+        return WorldborderCinematicAction(
+            player,
+            this,
+        )
+    }
+}
+
+data class WorldborderSegment(
+    override val startFrame: Int = 0,
+    override val endFrame: Int = 0,
+    val newSize: Double = 0.0,
+    val oldSize: Optional<Double> = Optional.empty(),
+    val transitionTime: Duration = Duration.ofMillis(1000),
+    val fadeBack: Boolean = false
+) : Segment
+
+class WorldborderCinematicAction(
+    private val player: Player,
+    entry: WorldborderCinematicEntry,
+) : SimpleCinematicAction<WorldborderSegment>() {
+
+    override val segments: List<WorldborderSegment> = entry.segments
+
+    override suspend fun startSegment(segment: WorldborderSegment) {
+        super.startSegment(segment)
+
+        val oldSize = segment.oldSize.orElseGet(this::borderSize)
+        val packet = WrapperPlayWorldBorderLerpSize(oldSize, segment.newSize, segment.transitionTime.toMillis())
+        packet.sendPacketTo(player)
+    }
+
+    private fun borderSize(): Double {
+        return player.world.worldBorder.size
+    }
+
+    override suspend fun stopSegment(segment: WorldborderSegment) {
+        super.stopSegment(segment)
+
+        val packet = if (!segment.fadeBack) WrapperPlayServerWorldBorderSize(borderSize())
+        else WrapperPlayWorldBorderLerpSize(segment.newSize, borderSize(), segment.transitionTime.toMillis())
+        player.sendPacket(packet)
+    }
+}

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/event/PlayerRespawnEventEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/event/PlayerRespawnEventEntry.kt
@@ -39,6 +39,7 @@ class PlayerRespawnEventEntry(
 enum class RespawnLocationType {
     BED,
     ANCHOR,
+    NONE
 }
 
 enum class RespawnContextKeys(override val klass: KClass<*>) : EntryContextKey {
@@ -60,6 +61,7 @@ fun onRespawn(event: PlayerRespawnEvent, query: Query<PlayerRespawnEventEntry>) 
             when (it) {
                 RespawnLocationType.BED -> event.isBedSpawn
                 RespawnLocationType.ANCHOR -> event.isAnchorSpawn
+                RespawnLocationType.NONE -> !event.isBedSpawn && !event.isAnchorSpawn
             }
         }
     }.toList()

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/fact/CinematicSectionFactEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/fact/CinematicSectionFactEntry.kt
@@ -14,7 +14,6 @@ import com.typewritermc.engine.paper.entry.temporal.currentTemporalFrame
 import com.typewritermc.engine.paper.entry.temporal.isPlayingTemporal
 import com.typewritermc.engine.paper.facts.FactData
 import org.bukkit.entity.Player
-import java.util.*
 
 @Entry(
     "cinematic_section_fact",
@@ -50,14 +49,14 @@ class CinematicSectionFactEntry(
     val pageId: String = "",
     val sections: List<CinematicSection> = emptyList(),
     @Help("Will be returned when the player is not in a cinematic, or not in any of the given sections")
-    val default: Optional<Int> = Optional.empty()
+    val default: Int = 0,
 ) : ReadableFactEntry {
     override fun readSinglePlayer(player: Player): FactData {
         val inCinematic = if (pageId.isNotBlank()) player.isPlayingTemporal(pageId) else player.isPlayingTemporal()
-        val default = default.orElse(0)
         if (!inCinematic) return FactData(default)
 
-        val output = sections.firstOrNull { it.frameRange.contains(player.currentTemporalFrame() ?: -1) }?.value
+        val frame = player.currentTemporalFrame() ?: return FactData(default)
+        val output = sections.firstOrNull { it.frameRange.contains(frame) }?.value
         return FactData(output ?: default)
     }
 

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/fact/CinematicSectionFactEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/fact/CinematicSectionFactEntry.kt
@@ -1,0 +1,69 @@
+package com.typewritermc.basic.entries.fact
+
+import com.google.gson.annotations.SerializedName
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.books.pages.PageType
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.entries.emptyRef
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.core.extension.annotations.Page
+import com.typewritermc.engine.paper.entry.entries.GroupEntry
+import com.typewritermc.engine.paper.entry.entries.ReadableFactEntry
+import com.typewritermc.engine.paper.entry.temporal.currentTemporalFrame
+import com.typewritermc.engine.paper.entry.temporal.isPlayingTemporal
+import com.typewritermc.engine.paper.facts.FactData
+import org.bukkit.entity.Player
+import java.util.*
+
+@Entry(
+    "cinematic_section_fact",
+    "Whether the player is within a certain section of a cinematic",
+    Colors.PURPLE,
+    "mdi:camera-burst"
+)
+/**
+ * The 'Cinematic Section Fact' is a fact that can return different values depending
+ * on what part of a cinematic the player is in.
+ *
+ * The specified `sections` can be used to map a certain range of cinematic frames to a value
+ * that will then be returned by the fact if the player is in that range. If none of the ranges
+ * match or the player is not currently in a cinematic, the value from `default` will be returned instead.
+ *
+ * Optionally, a cinematic page can be specified to only check for the given sections
+ * in that page, instead of any active cinematic.
+ *
+ *
+ * <fields.ReadonlyFactInfo />
+ *
+ * ## How could this be used?
+ * With this fact, it is possible to make an entry act differently depending on
+ * what section of a cinematic the player is in.
+ */
+class CinematicSectionFactEntry(
+    override val id: String = "",
+    override val name: String = "",
+    override val comment: String = "",
+    override val group: Ref<GroupEntry> = emptyRef(),
+    @Page(PageType.CINEMATIC)
+    @SerializedName("cinematic")
+    val pageId: String = "",
+    val sections: List<CinematicSection> = emptyList(),
+    @Help("Will be returned when the player is not in a cinematic, or not in any of the given sections")
+    val default: Optional<Int> = Optional.empty()
+) : ReadableFactEntry {
+    override fun readSinglePlayer(player: Player): FactData {
+        val inCinematic = if (pageId.isNotBlank()) player.isPlayingTemporal(pageId) else player.isPlayingTemporal()
+        val default = default.orElse(0)
+        if (!inCinematic) return FactData(default)
+
+        val output = sections.firstOrNull { it.frameRange.contains(player.currentTemporalFrame() ?: -1) }?.value
+        return FactData(output ?: default)
+    }
+
+    data class CinematicSection(
+        @Help("The range of cinematic frames the player has to be in")
+        val frameRange: ClosedRange<Int> = IntRange.EMPTY,
+        val value: Int = 0
+    )
+}

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/fact/InCinematicFactEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/fact/InCinematicFactEntry.kt
@@ -10,19 +10,15 @@ import com.typewritermc.core.extension.annotations.Help
 import com.typewritermc.core.extension.annotations.Page
 import com.typewritermc.engine.paper.entry.entries.GroupEntry
 import com.typewritermc.engine.paper.entry.entries.ReadableFactEntry
-import com.typewritermc.engine.paper.entry.temporal.currentTemporalFrame
 import com.typewritermc.engine.paper.entry.temporal.isPlayingTemporal
 import com.typewritermc.engine.paper.facts.FactData
 import org.bukkit.entity.Player
-import java.util.*
 
 @Entry("in_cinematic_fact", "If the player is in a cinematic", Colors.PURPLE, "eos-icons:storage-class")
 /**
  * The 'In Cinematic Fact' is a fact that returns 1 if the player has an active cinematic, and 0 if not.
  *
  * If no cinematic is referenced, it will filter based on if any cinematic is active.
- * If the player has an active cinematic, this fact can optionally be used to check
- * whether the player is within a certain range of frames.
  *
  * <fields.ReadonlyFactInfo />
  *
@@ -38,8 +34,6 @@ class InCinematicFactEntry(
     @Page(PageType.CINEMATIC)
     @SerializedName("cinematic")
     val pageId: String = "",
-    val beforeFrame: Optional<Int> = Optional.empty(),
-    val afterFrame: Optional<Int> = Optional.empty()
 ) : ReadableFactEntry {
     override fun readSinglePlayer(player: Player): FactData {
         val inCinematic = if (pageId.isNotBlank())
@@ -47,9 +41,6 @@ class InCinematicFactEntry(
         else
             player.isPlayingTemporal()
 
-        val frame = player.currentTemporalFrame() ?: 0
-        val isOutOfRange = (beforeFrame.isPresent && beforeFrame.get() <= frame)
-                || (afterFrame.isPresent && afterFrame.get() > frame)
-        return FactData((inCinematic && !isOutOfRange).toInt())
+        return FactData(inCinematic.toInt())
     }
 }

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/data/minecraft/living/armorstand/InvisibleData.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/data/minecraft/living/armorstand/InvisibleData.kt
@@ -1,0 +1,38 @@
+package com.typewritermc.entity.entries.data.minecraft.living.armorstand
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Tags
+import com.typewritermc.engine.paper.entry.entity.SinglePropertyCollectorSupplier
+import com.typewritermc.engine.paper.entry.entries.EntityData
+import com.typewritermc.engine.paper.entry.entries.EntityProperty
+import com.typewritermc.engine.paper.extensions.packetevents.metas
+import me.tofaa.entitylib.meta.other.ArmorStandMeta
+import me.tofaa.entitylib.wrapper.WrapperEntity
+import org.bukkit.entity.Player
+import java.util.*
+import kotlin.reflect.KClass
+
+@Entry("invisible_data", "Whether the armor stand itself is invisible", Colors.RED, "mdi:mirror-variant")
+@Tags("invisible_data", "armor_stand_data")
+class InvisibleData(
+    override val id: String = "",
+    override val name: String = "",
+    val isInvisible: Boolean = false,
+    override val priorityOverride: Optional<Int> = Optional.empty(),
+) : EntityData<InvisibleProperty> {
+    override fun type(): KClass<InvisibleProperty> = InvisibleProperty::class
+
+    override fun build(player: Player): InvisibleProperty = InvisibleProperty(isInvisible)
+}
+
+data class InvisibleProperty(val isInvisible: Boolean) : EntityProperty {
+    companion object : SinglePropertyCollectorSupplier<InvisibleProperty>(InvisibleProperty::class, InvisibleProperty(false))
+}
+
+fun applyInvisibleData(entity: WrapperEntity, property: InvisibleProperty) {
+    entity.metas {
+        meta<ArmorStandMeta> { isInvisible = property.isInvisible }
+        error("Could not apply InvisibleData to ${entity.entityType} entity.")
+    }
+}

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/data/minecraft/living/armorstand/InvisibleData.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/data/minecraft/living/armorstand/InvisibleData.kt
@@ -18,21 +18,21 @@ import kotlin.reflect.KClass
 class InvisibleData(
     override val id: String = "",
     override val name: String = "",
-    val isInvisible: Boolean = false,
+    val invisible: Boolean = false,
     override val priorityOverride: Optional<Int> = Optional.empty(),
 ) : EntityData<InvisibleProperty> {
     override fun type(): KClass<InvisibleProperty> = InvisibleProperty::class
 
-    override fun build(player: Player): InvisibleProperty = InvisibleProperty(isInvisible)
+    override fun build(player: Player): InvisibleProperty = InvisibleProperty(invisible)
 }
 
-data class InvisibleProperty(val isInvisible: Boolean) : EntityProperty {
+data class InvisibleProperty(val invisible: Boolean) : EntityProperty {
     companion object : SinglePropertyCollectorSupplier<InvisibleProperty>(InvisibleProperty::class, InvisibleProperty(false))
 }
 
 fun applyInvisibleData(entity: WrapperEntity, property: InvisibleProperty) {
     entity.metas {
-        meta<ArmorStandMeta> { isInvisible = property.isInvisible }
+        meta<ArmorStandMeta> { isInvisible = property.invisible }
         error("Could not apply InvisibleData to ${entity.entityType} entity.")
     }
 }

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/ArmorStandEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/ArmorStandEntity.kt
@@ -60,6 +60,7 @@ private class ArmorStandEntity(player: Player) : WrapperFakeEntity(
             is MarkerProperty -> applyMarkerData(entity, property)
             is RotationProperty -> applyRotationData(entity, property)
             is SmallProperty -> applySmallData(entity, property)
+            is InvisibleProperty -> applyInvisibleData(entity, property)
             else -> {}
         }
         if (applyGenericEntityData(entity, property)) return


### PR DESCRIPTION
We've been using Typewriter on our (in-development) server for a while now and really love the plugin, but while using it, we've come across some minor issues or missing features that we needed. Most of those have been implemented in this PR, and we've been using them on the server for a few days now.

Here's a detailed list of the changes made:
- The `PlayerRespawnEventEntry` does not trigger at all if the player doesn't have a respawn point (such as a bed / respawn anchor), so I added a `NONE` respawn location type that covers this case
- The `Invisible` NBT tag can't be applied to "fake" armor stand entities (which would hide the wood frame of the armor stand, but not the worn armor), this can now be achieved using `InvisibleData`
- We wanted to show the worldborder increasing in size in one of the cinematics on our server, which is why I added a new `WorldborderCinematicEntry`. A segment of that cinematic will resize the worldborder client-side for a given amount of time, and return it to the previous size when the segment ends.
- We've been using "in cinematic" facts to hide certain NPCs when the player is in a cinematic, but there has been scenarios where the NPC needs to be visible until some point in the cinematic and only then disappear. I've added `beforeFrame` and `afterFrame` parameters to the fact, which can be used to narrow down the frame range in a cinematic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced cinematic world border animations, allowing smooth resizing effects during cinematic sequences.
  - Added support for managing and applying invisibility to armor stand entities.
  - Added a utility to access the current temporal frame for players.
  - Enhanced respawn event handling with a new "NONE" respawn location type.
  - Added a new cinematic fact entry to detect player presence within specific cinematic frame sections.

- **Improvements**
  - Extended cinematic fact entries to support optional frame range filtering for more precise conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->