### PR TITLE
Add docs for CancelableEventEntry

### DIFF
--- a/documentation/docs/develop/02-extensions/04-entries/trigger/event.mdx
+++ b/documentation/docs/develop/02-extensions/04-entries/trigger/event.mdx
@@ -18,3 +18,13 @@ An optional `Query` parameter can be added to easily fetch all the different eve
 Sometimes you want to pass some information to the context so that subsequent entries can use it.
 
 <CodeSnippet tag="event_entry_with_context_keys" json={require("../../../snippets.json")} />
+
+## CancelableEventEntry
+Sometimes you may want the underlying Bukkit event to be cancelled after triggering your entries.
+For this the `CancelableEventEntry` interface extends `EventEntry` with a single `cancel` field.
+
+<CodeSnippet tag="cancelable_event_entry" json={require("../../../snippets.json")} />
+
+Inside your event listener you can inspect all matching entries and decide whether to cancel the Bukkit event.
+
+<CodeSnippet tag="cancelable_event_listener" json={require("../../../snippets.json")} />

--- a/extensions/_DocsExtension/src/main/kotlin/com/typewritermc/example/entries/trigger/ExampleEventEntry.kt
+++ b/extensions/_DocsExtension/src/main/kotlin/com/typewritermc/example/entries/trigger/ExampleEventEntry.kt
@@ -11,9 +11,10 @@ import com.typewritermc.core.interaction.EntryContextKey
 import com.typewritermc.core.interaction.context
 import com.typewritermc.core.utils.point.Position
 import com.typewritermc.engine.paper.entry.TriggerableEntry
-import com.typewritermc.engine.paper.entry.entries.EventEntry
+import com.typewritermc.engine.paper.entry.entries.*
 import com.typewritermc.engine.paper.entry.triggerAllFor
 import org.bukkit.entity.Player
+import org.bukkit.event.Cancellable
 import org.bukkit.event.HandlerList
 import org.bukkit.event.player.PlayerEvent
 import kotlin.reflect.KClass
@@ -38,7 +39,12 @@ fun onEvent(event: SomeBukkitEvent, query: Query<ExampleEventEntry>) {
 //</code-block:event_entry_listener>
 
 //<code-block:event_entry_with_context_keys>
-@Entry("example_event_with_context_keys", "An example event entry with context keys.", Colors.YELLOW, "material-symbols:bigtop-updates")
+@Entry(
+    "example_event_with_context_keys",
+    "An example event entry with context keys.",
+    Colors.YELLOW,
+    "material-symbols:bigtop-updates"
+)
 // This tells Typewriter that this entry exposes some context
 // highlight-next-line
 @ContextKeys(ExampleContextKeys::class)
@@ -80,8 +86,41 @@ fun onEventAddContext(event: SomeBukkitEvent, query: Query<ExampleEventEntryWith
 }
 //</code-block:event_entry_with_context_keys>
 
-class SomeBukkitEvent(player: Player) : PlayerEvent(player) {
+//<code-block:cancelable_event_entry>
+@Entry("example_cancelable_event", "An example cancelable event.", Colors.YELLOW, "material-symbols:block")
+class ExampleCancelableEventEntry(
+    override val id: String = "",
+    override val name: String = "",
+    override val triggers: List<Ref<TriggerableEntry>> = emptyList(),
+    // highlight-start
+    override val cancel: Var<Boolean> = ConstVar(false),
+) : CancelableEventEntry
+// highlight-end
+//</code-block:cancelable_event_entry>
+
+//<code-block:cancelable_event_listener>
+@EntryListener(ExampleCancelableEventEntry::class)
+fun onCancelableEvent(event: SomeBukkitEvent, query: Query<ExampleCancelableEventEntry>) {
+    val entries = query.find().toList()
+    entries.triggerAllFor(event.player, context())
+
+    // highlight-start
+    if (entries.shouldCancel(event.player)) {
+        event.isCancelled = true
+    }
+    // highlight-end
+}
+//</code-block:cancelable_event_listener>
+
+class SomeBukkitEvent(player: Player) : PlayerEvent(player), Cancellable {
     override fun getHandlers(): HandlerList = HANDLER_LIST
+
+    private var cancelled: Boolean = false
+    override fun isCancelled(): Boolean = cancelled
+
+    override fun setCancelled(cancelled: Boolean) {
+        this@SomeBukkitEvent.cancelled = cancelled
+    }
 
     companion object {
         @JvmStatic


### PR DESCRIPTION
## Summary
- document CancelableEventEntry in the EventEntry docs
- show how to implement and use it with new snippets

## Testing
- `npm ci`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684e9bb1366c832293999d09f1c23a29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for cancelable event entries, allowing certain events to be cancelled based on entry conditions.
- **Documentation**
	- Added detailed documentation and examples explaining how to use and implement cancelable event entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->