### PR TITLE
Add simple message cinematics

### DIFF
--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/cinematic/ActionBarMessageCinematicEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/cinematic/ActionBarMessageCinematicEntry.kt
@@ -1,0 +1,81 @@
+package com.typewritermc.basic.entries.cinematic
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Colored
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.MultiLine
+import com.typewritermc.core.extension.annotations.Placeholder
+import com.typewritermc.core.extension.annotations.Segments
+import com.typewritermc.engine.paper.entry.Criteria
+import com.typewritermc.engine.paper.entry.entries.CinematicAction
+import com.typewritermc.engine.paper.entry.entries.PrimaryCinematicEntry
+import com.typewritermc.engine.paper.entry.entries.Segment
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.temporal.SimpleCinematicAction
+import com.typewritermc.engine.paper.extensions.placeholderapi.parsePlaceholders
+import com.typewritermc.engine.paper.interaction.acceptActionBarMessage
+import com.typewritermc.engine.paper.interaction.interactionContext
+import com.typewritermc.engine.paper.utils.asMini
+import net.kyori.adventure.text.Component
+import org.bukkit.entity.Player
+
+@Entry("actionbar_message_cinematic", "Show an action bar message", Colors.CYAN, "bxs:message-square-detail")
+/**
+ * The `Action Bar Message Cinematic` entry displays a message in the action bar during a cinematic.
+ *
+ * ## How could this be used?
+ * Use this to quickly show hints or short context without the typing animation from dialogue cinematics.
+ */
+class ActionBarMessageCinematicEntry(
+    override val id: String = "",
+    override val name: String = "",
+    override val criteria: List<Criteria> = emptyList(),
+    @Segments(icon = "bxs:message-square-detail")
+    val segments: List<ActionBarMessageSegment> = emptyList(),
+) : PrimaryCinematicEntry {
+    override fun create(player: Player): CinematicAction = ActionBarMessageCinematicAction(player, this)
+}
+
+data class ActionBarMessageSegment(
+    override val startFrame: Int = 0,
+    override val endFrame: Int = 0,
+    @Placeholder
+    @Colored
+    @MultiLine
+    val message: Var<String> = ConstVar("")
+) : Segment
+
+class ActionBarMessageCinematicAction(
+    private val player: Player,
+    entry: ActionBarMessageCinematicEntry,
+) : SimpleCinematicAction<ActionBarMessageSegment>() {
+
+    override val segments: List<ActionBarMessageSegment> = entry.segments
+
+    private fun send(component: Component) {
+        player.acceptActionBarMessage(component)
+        player.sendActionBar(component)
+    }
+
+    override suspend fun startSegment(segment: ActionBarMessageSegment) {
+        super.startSegment(segment)
+        val context = player.interactionContext
+        val component = segment.message.get(player, context).parsePlaceholders(player).asMini()
+        send(component)
+    }
+
+    override suspend fun tickSegment(segment: ActionBarMessageSegment, frame: Int) {
+        super.tickSegment(segment, frame)
+        if ((frame - segment.startFrame) % 20 == 0) {
+            val context = player.interactionContext
+            val component = segment.message.get(player, context).parsePlaceholders(player).asMini()
+            send(component)
+        }
+    }
+
+    override suspend fun stopSegment(segment: ActionBarMessageSegment) {
+        super.stopSegment(segment)
+        send(Component.empty())
+    }
+}

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/cinematic/MessageCinematicEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/cinematic/MessageCinematicEntry.kt
@@ -1,0 +1,62 @@
+package com.typewritermc.basic.entries.cinematic
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Colored
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.MultiLine
+import com.typewritermc.core.extension.annotations.Placeholder
+import com.typewritermc.core.extension.annotations.Segments
+import com.typewritermc.engine.paper.entry.Criteria
+import com.typewritermc.engine.paper.entry.entries.CinematicAction
+import com.typewritermc.engine.paper.entry.entries.PrimaryCinematicEntry
+import com.typewritermc.engine.paper.entry.entries.Segment
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.temporal.SimpleCinematicAction
+import com.typewritermc.engine.paper.extensions.placeholderapi.parsePlaceholders
+import com.typewritermc.engine.paper.interaction.interactionContext
+import com.typewritermc.engine.paper.utils.sendMiniWithResolvers
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder as MiniPlaceholder
+import org.bukkit.entity.Player
+
+@Entry("message_cinematic", "Send a chat message", Colors.CYAN, "flowbite:message-dots-solid")
+/**
+ * The `Message Cinematic` entry sends a chat message when a cinematic reaches a segment.
+ *
+ * ## How could this be used?
+ * Great for brief instructions or narration without dialogue animations.
+ */
+class MessageCinematicEntry(
+    override val id: String = "",
+    override val name: String = "",
+    override val criteria: List<Criteria> = emptyList(),
+    @Segments(icon = "flowbite:message-dots-solid")
+    val segments: List<MessageSegment> = emptyList(),
+) : PrimaryCinematicEntry {
+    override fun create(player: Player): CinematicAction = MessageCinematicAction(player, this)
+}
+
+data class MessageSegment(
+    override val startFrame: Int = 0,
+    override val endFrame: Int = 0,
+    @Placeholder
+    @Colored
+    @MultiLine
+    val message: Var<String> = ConstVar("")
+) : Segment
+
+class MessageCinematicAction(
+    private val player: Player,
+    entry: MessageCinematicEntry,
+) : SimpleCinematicAction<MessageSegment>() {
+
+    override val segments: List<MessageSegment> = entry.segments
+
+    override suspend fun startSegment(segment: MessageSegment) {
+        super.startSegment(segment)
+        val context = player.interactionContext
+        val text = segment.message.get(player, context).parsePlaceholders(player)
+        val component = MiniPlaceholder.parsed("message", text)
+        player.sendMiniWithResolvers("<message>", component)
+    }
+}


### PR DESCRIPTION
## Summary
- add `ActionBarMessageCinematicEntry` for displaying a single action bar message
- add `MessageCinematicEntry` for sending a chat message
- remove manual docs, rely on KDoc comments for generation

## Testing
- `npm run test`
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6851940dcd808322bb951981be8f7462

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced action bar messages during cinematic sequences, allowing short, dynamic messages to be displayed to players.
  - Added support for sending formatted chat messages to players at specific points in cinematics, with placeholder and color code support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->