### PR TITLE
Add sleeping data for foxes

### DIFF
--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/data/minecraft/living/DefendingData.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/data/minecraft/living/DefendingData.kt
@@ -1,0 +1,40 @@
+package com.typewritermc.entity.entries.data.minecraft.living
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Tags
+import com.typewritermc.engine.paper.entry.entity.SinglePropertyCollectorSupplier
+import com.typewritermc.engine.paper.entry.entries.EntityData
+import com.typewritermc.engine.paper.entry.entries.EntityProperty
+import com.typewritermc.engine.paper.extensions.packetevents.metas
+import me.tofaa.entitylib.meta.mobs.FoxMeta
+import me.tofaa.entitylib.wrapper.WrapperEntity
+import org.bukkit.entity.Player
+import java.util.*
+import kotlin.reflect.KClass
+
+@Entry("defending_data", "If the entity is defending", Colors.RED, "game-icons:shield")
+@Tags("defending_data", "fox_data")
+class DefendingData(
+    override val id: String = "",
+    override val name: String = "",
+    @Default("true")
+    val defending: Boolean = true,
+    override val priorityOverride: Optional<Int> = Optional.empty(),
+) : EntityData<DefendingProperty> {
+    override fun type(): KClass<DefendingProperty> = DefendingProperty::class
+
+    override fun build(player: Player): DefendingProperty = DefendingProperty(defending)
+}
+
+data class DefendingProperty(val defending: Boolean) : EntityProperty {
+    companion object : SinglePropertyCollectorSupplier<DefendingProperty>(DefendingProperty::class, DefendingProperty(false))
+}
+
+fun applyDefendingData(entity: WrapperEntity, property: DefendingProperty) {
+    entity.metas {
+        meta<FoxMeta> { isDefending = property.defending }
+        error("Could not apply DefendingData to ${entity.entityType} entity.")
+    }
+}

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/data/minecraft/living/FaceplantedData.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/data/minecraft/living/FaceplantedData.kt
@@ -1,0 +1,40 @@
+package com.typewritermc.entity.entries.data.minecraft.living
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Tags
+import com.typewritermc.engine.paper.entry.entity.SinglePropertyCollectorSupplier
+import com.typewritermc.engine.paper.entry.entries.EntityData
+import com.typewritermc.engine.paper.entry.entries.EntityProperty
+import com.typewritermc.engine.paper.extensions.packetevents.metas
+import me.tofaa.entitylib.meta.mobs.FoxMeta
+import me.tofaa.entitylib.wrapper.WrapperEntity
+import org.bukkit.entity.Player
+import java.util.*
+import kotlin.reflect.KClass
+
+@Entry("faceplanted_data", "If the entity is faceplanted", Colors.RED, "mdi:emoticon-dead")
+@Tags("faceplanted_data", "fox_data")
+class FaceplantedData(
+    override val id: String = "",
+    override val name: String = "",
+    @Default("true")
+    val faceplanted: Boolean = true,
+    override val priorityOverride: Optional<Int> = Optional.empty(),
+) : EntityData<FaceplantedProperty> {
+    override fun type(): KClass<FaceplantedProperty> = FaceplantedProperty::class
+
+    override fun build(player: Player): FaceplantedProperty = FaceplantedProperty(faceplanted)
+}
+
+data class FaceplantedProperty(val faceplanted: Boolean) : EntityProperty {
+    companion object : SinglePropertyCollectorSupplier<FaceplantedProperty>(FaceplantedProperty::class, FaceplantedProperty(false))
+}
+
+fun applyFaceplantedData(entity: WrapperEntity, property: FaceplantedProperty) {
+    entity.metas {
+        meta<FoxMeta> { isFaceplanted = property.faceplanted }
+        error("Could not apply FaceplantedData to ${entity.entityType} entity.")
+    }
+}

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/data/minecraft/living/InterestedData.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/data/minecraft/living/InterestedData.kt
@@ -1,0 +1,40 @@
+package com.typewritermc.entity.entries.data.minecraft.living
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Tags
+import com.typewritermc.engine.paper.entry.entity.SinglePropertyCollectorSupplier
+import com.typewritermc.engine.paper.entry.entries.EntityData
+import com.typewritermc.engine.paper.entry.entries.EntityProperty
+import com.typewritermc.engine.paper.extensions.packetevents.metas
+import me.tofaa.entitylib.meta.mobs.FoxMeta
+import me.tofaa.entitylib.wrapper.WrapperEntity
+import org.bukkit.entity.Player
+import java.util.*
+import kotlin.reflect.KClass
+
+@Entry("interested_data", "If the entity is interested", Colors.RED, "mdi:eye")
+@Tags("interested_data", "fox_data")
+class InterestedData(
+    override val id: String = "",
+    override val name: String = "",
+    @Default("true")
+    val interested: Boolean = true,
+    override val priorityOverride: Optional<Int> = Optional.empty(),
+) : EntityData<InterestedProperty> {
+    override fun type(): KClass<InterestedProperty> = InterestedProperty::class
+
+    override fun build(player: Player): InterestedProperty = InterestedProperty(interested)
+}
+
+data class InterestedProperty(val interested: Boolean) : EntityProperty {
+    companion object : SinglePropertyCollectorSupplier<InterestedProperty>(InterestedProperty::class, InterestedProperty(false))
+}
+
+fun applyInterestedData(entity: WrapperEntity, property: InterestedProperty) {
+    entity.metas {
+        meta<FoxMeta> { isInterested = property.interested }
+        error("Could not apply InterestedData to ${entity.entityType} entity.")
+    }
+}

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/data/minecraft/living/PouncingData.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/data/minecraft/living/PouncingData.kt
@@ -1,0 +1,40 @@
+package com.typewritermc.entity.entries.data.minecraft.living
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Tags
+import com.typewritermc.engine.paper.entry.entity.SinglePropertyCollectorSupplier
+import com.typewritermc.engine.paper.entry.entries.EntityData
+import com.typewritermc.engine.paper.entry.entries.EntityProperty
+import com.typewritermc.engine.paper.extensions.packetevents.metas
+import me.tofaa.entitylib.meta.mobs.FoxMeta
+import me.tofaa.entitylib.wrapper.WrapperEntity
+import org.bukkit.entity.Player
+import java.util.*
+import kotlin.reflect.KClass
+
+@Entry("pouncing_data", "If the entity is pouncing", Colors.RED, "game-icons:pounce")
+@Tags("pouncing_data", "fox_data")
+class PouncingData(
+    override val id: String = "",
+    override val name: String = "",
+    @Default("true")
+    val pouncing: Boolean = true,
+    override val priorityOverride: Optional<Int> = Optional.empty(),
+) : EntityData<PouncingProperty> {
+    override fun type(): KClass<PouncingProperty> = PouncingProperty::class
+
+    override fun build(player: Player): PouncingProperty = PouncingProperty(pouncing)
+}
+
+data class PouncingProperty(val pouncing: Boolean) : EntityProperty {
+    companion object : SinglePropertyCollectorSupplier<PouncingProperty>(PouncingProperty::class, PouncingProperty(false))
+}
+
+fun applyPouncingData(entity: WrapperEntity, property: PouncingProperty) {
+    entity.metas {
+        meta<FoxMeta> { isPouncing = property.pouncing }
+        error("Could not apply PouncingData to ${entity.entityType} entity.")
+    }
+}

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/data/minecraft/living/SleepingData.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/data/minecraft/living/SleepingData.kt
@@ -1,0 +1,44 @@
+package com.typewritermc.entity.entries.data.minecraft.living
+
+import com.github.retrooper.packetevents.protocol.entity.pose.EntityPose
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Tags
+import com.typewritermc.engine.paper.entry.entity.SinglePropertyCollectorSupplier
+import com.typewritermc.engine.paper.entry.entries.EntityData
+import com.typewritermc.engine.paper.entry.entries.EntityProperty
+import com.typewritermc.engine.paper.extensions.packetevents.metas
+import me.tofaa.entitylib.meta.EntityMeta
+import me.tofaa.entitylib.meta.mobs.FoxMeta
+import me.tofaa.entitylib.wrapper.WrapperEntity
+import org.bukkit.entity.Player
+import java.util.*
+import kotlin.reflect.KClass
+
+@Entry("sleeping_data", "If the entity is sleeping", Colors.RED, "mdi:bed")
+@Tags("sleeping_data", "fox_data")
+class SleepingData(
+    override val id: String = "",
+    override val name: String = "",
+    @Default("true")
+    val sleeping: Boolean = true,
+    override val priorityOverride: Optional<Int> = Optional.empty(),
+) : EntityData<SleepingProperty> {
+    override fun type(): KClass<SleepingProperty> = SleepingProperty::class
+
+    override fun build(player: Player): SleepingProperty = SleepingProperty(sleeping)
+}
+
+data class SleepingProperty(val sleeping: Boolean) : EntityProperty {
+    companion object : SinglePropertyCollectorSupplier<SleepingProperty>(SleepingProperty::class, SleepingProperty(false))
+}
+
+fun applySleepingData(entity: WrapperEntity, property: SleepingProperty) {
+    entity.metas {
+        meta<EntityMeta> { pose = if (property.sleeping) EntityPose.SLEEPING else EntityPose.STANDING }
+        meta<FoxMeta> { isSleeping = property.sleeping }
+        error("Could not apply SleepingData to ${entity.entityType} entity.")
+    }
+}
+

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/data/minecraft/living/fox/FoxTypeData.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/data/minecraft/living/fox/FoxTypeData.kt
@@ -1,0 +1,38 @@
+package com.typewritermc.entity.entries.data.minecraft.living.fox
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Tags
+import com.typewritermc.engine.paper.entry.entity.SinglePropertyCollectorSupplier
+import com.typewritermc.engine.paper.entry.entries.EntityData
+import com.typewritermc.engine.paper.entry.entries.EntityProperty
+import com.typewritermc.engine.paper.extensions.packetevents.metas
+import me.tofaa.entitylib.meta.mobs.FoxMeta
+import me.tofaa.entitylib.wrapper.WrapperEntity
+import org.bukkit.entity.Player
+import java.util.*
+import kotlin.reflect.KClass
+
+@Entry("fox_type_data", "The type of the fox", Colors.RED, "mdi:fox")
+@Tags("fox_type_data", "fox_data")
+class FoxTypeData(
+    override val id: String = "",
+    override val name: String = "",
+    val foxType: FoxMeta.Type = FoxMeta.Type.RED,
+    override val priorityOverride: Optional<Int> = Optional.empty(),
+) : EntityData<FoxTypeProperty> {
+    override fun type(): KClass<FoxTypeProperty> = FoxTypeProperty::class
+
+    override fun build(player: Player): FoxTypeProperty = FoxTypeProperty(foxType)
+}
+
+data class FoxTypeProperty(val foxType: FoxMeta.Type) : EntityProperty {
+    companion object : SinglePropertyCollectorSupplier<FoxTypeProperty>(FoxTypeProperty::class)
+}
+
+fun applyFoxTypeData(entity: WrapperEntity, property: FoxTypeProperty) {
+    entity.metas {
+        meta<FoxMeta> { type = property.foxType }
+        error("Could not apply FoxTypeData to ${entity.entityType} entity.")
+    }
+}

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/data/minecraft/living/tameable/SittingData.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/data/minecraft/living/tameable/SittingData.kt
@@ -8,6 +8,7 @@ import com.typewritermc.engine.paper.entry.entity.SinglePropertyCollectorSupplie
 import com.typewritermc.engine.paper.entry.entries.EntityData
 import com.typewritermc.engine.paper.entry.entries.EntityProperty
 import com.typewritermc.engine.paper.extensions.packetevents.metas
+import me.tofaa.entitylib.meta.mobs.FoxMeta
 import me.tofaa.entitylib.meta.types.TameableMeta
 import me.tofaa.entitylib.wrapper.WrapperEntity
 import org.bukkit.entity.Player
@@ -15,7 +16,7 @@ import java.util.*
 import kotlin.reflect.KClass
 
 @Entry("sitting_data", "Have a tameable entity sit", Colors.RED, "pepicons-pop:folding-stool")
-@Tags("sitting_data")
+@Tags("sitting_data", "fox_data")
 class SittingData(
     override val id: String = "",
     override val name: String = "",
@@ -34,6 +35,8 @@ data class SittingProperty(val sitting: Boolean) : EntityProperty {
 fun applySittingData(entity: WrapperEntity, property: SittingProperty) {
     entity.metas {
         meta<TameableMeta> { isSitting = property.sitting }
+        meta<FoxMeta> { isSitting = property.sitting }
         error("Could not apply SittingData to ${entity.entityType} entity.")
     }
 }
+

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/FoxEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/FoxEntity.kt
@@ -1,0 +1,77 @@
+package com.typewritermc.entity.entries.entity.minecraft
+
+import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.entries.emptyRef
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.OnlyTags
+import com.typewritermc.core.extension.annotations.Tags
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.engine.paper.entry.entity.FakeEntity
+import com.typewritermc.engine.paper.entry.entity.SimpleEntityDefinition
+import com.typewritermc.engine.paper.entry.entity.SimpleEntityInstance
+import com.typewritermc.engine.paper.entry.entries.*
+import com.typewritermc.engine.paper.utils.Sound
+import com.typewritermc.entity.entries.data.minecraft.applyGenericEntityData
+import com.typewritermc.entity.entries.data.minecraft.living.AgeableProperty
+import com.typewritermc.entity.entries.data.minecraft.living.applyAgeableData
+import com.typewritermc.entity.entries.data.minecraft.living.applyLivingEntityData
+import com.typewritermc.entity.entries.data.minecraft.living.DefendingProperty
+import com.typewritermc.entity.entries.data.minecraft.living.FaceplantedProperty
+import com.typewritermc.entity.entries.data.minecraft.living.InterestedProperty
+import com.typewritermc.entity.entries.data.minecraft.living.PouncingProperty
+import com.typewritermc.entity.entries.data.minecraft.living.applyDefendingData
+import com.typewritermc.entity.entries.data.minecraft.living.applyFaceplantedData
+import com.typewritermc.entity.entries.data.minecraft.living.applyInterestedData
+import com.typewritermc.entity.entries.data.minecraft.living.applyPouncingData
+import com.typewritermc.entity.entries.data.minecraft.living.SleepingProperty
+import com.typewritermc.entity.entries.data.minecraft.living.applySleepingData
+import com.typewritermc.entity.entries.data.minecraft.living.fox.FoxTypeProperty
+import com.typewritermc.entity.entries.data.minecraft.living.fox.applyFoxTypeData
+import com.typewritermc.entity.entries.data.minecraft.living.tameable.SittingProperty
+import com.typewritermc.entity.entries.data.minecraft.living.tameable.applyTameableData
+import com.typewritermc.entity.entries.entity.WrapperFakeEntity
+import org.bukkit.entity.Player
+
+@Entry("fox_definition", "A fox entity", Colors.ORANGE, "mdi:fox")
+@Tags("fox_definition")
+class FoxDefinition(
+    override val id: String = "",
+    override val name: String = "",
+    override val displayName: Var<String> = ConstVar(""),
+    override val sound: Sound = Sound.EMPTY,
+    @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "ageable_data", "fox_data")
+    override val data: List<Ref<EntityData<*>>> = emptyList(),
+) : SimpleEntityDefinition {
+    override fun create(player: Player): FakeEntity = FoxEntity(player)
+}
+
+@Entry("fox_instance", "An instance of a fox entity", Colors.YELLOW, "mdi:fox")
+class FoxInstance(
+    override val id: String = "",
+    override val name: String = "",
+    override val definition: Ref<FoxDefinition> = emptyRef(),
+    override val spawnLocation: Position = Position.ORIGIN,
+    @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "ageable_data", "fox_data")
+    override val data: List<Ref<EntityData<*>>> = emptyList(),
+    override val activity: Ref<out SharedEntityActivityEntry> = emptyRef(),
+) : SimpleEntityInstance
+
+private class FoxEntity(player: Player) : WrapperFakeEntity(EntityTypes.FOX, player) {
+    override fun applyProperty(property: EntityProperty) {
+        when (property) {
+            is FoxTypeProperty -> applyFoxTypeData(entity, property)
+            is AgeableProperty -> applyAgeableData(entity, property)
+            is SittingProperty -> applyTameableData(entity, property)
+            is InterestedProperty -> applyInterestedData(entity, property)
+            is PouncingProperty -> applyPouncingData(entity, property)
+            is SleepingProperty -> applySleepingData(entity, property)
+            is FaceplantedProperty -> applyFaceplantedData(entity, property)
+            is DefendingProperty -> applyDefendingData(entity, property)
+        }
+        if (applyGenericEntityData(entity, property)) return
+        if (applyLivingEntityData(entity, property)) return
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement `SleepingData` for generic sleeping pose
- update SittingData tags for fox support
- hook sleeping property into Fox entity
- fix missing tags annotation and remove redundant else branch

## Testing
- `./gradlew build --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_685281eff4bc8322a233c6071c8e079c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for fox entities, enabling creation and management of foxes with customizable properties.
  - Added new properties for foxes, including defending, faceplanted, interested, pouncing, sleeping, and fox type.
  - Extended sitting state support to foxes.
- **Enhancements**
  - Improved property handling for fox entities, allowing detailed behavior customization and state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->