### PR TITLE
feat: add bukkit event when the typewriter is completely loaded

### DIFF
--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/TypewriterPaperPlugin.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/TypewriterPaperPlugin.kt
@@ -14,6 +14,7 @@ import com.typewritermc.engine.paper.entry.dialogue.DialogueHandler
 import com.typewritermc.engine.paper.entry.entity.EntityHandler
 import com.typewritermc.engine.paper.entry.temporal.TemporalHandler
 import com.typewritermc.engine.paper.entry.temporal.TemporalPlaceholders
+import com.typewritermc.engine.paper.events.TypewriterLoadedEvent
 import com.typewritermc.engine.paper.events.TypewriterUnloadEvent
 import com.typewritermc.engine.paper.extensions.bstats.BStatsMetrics
 import com.typewritermc.engine.paper.extensions.modrinth.Modrinth
@@ -186,6 +187,9 @@ class TypewriterPaperPlugin : KotlinPlugin(), KoinComponent {
         if (server.pluginManager.getPlugin("PlaceholderAPI") != null) {
             PlaceholderExpansion.load()
         }
+
+        TypewriterLoadedEvent().callEvent()
+
     }
 
     suspend fun unload() {

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/events/TypewriterLoadedEvent.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/events/TypewriterLoadedEvent.kt
@@ -1,0 +1,17 @@
+package com.typewritermc.engine.paper.events
+
+import com.typewritermc.engine.paper.utils.server
+import org.bukkit.event.Event
+import org.bukkit.event.HandlerList
+
+class TypewriterLoadedEvent : Event(!server.isPrimaryThread) {
+    override fun getHandlers(): HandlerList = HANDLER_LIST
+
+    companion object {
+        @JvmStatic
+        val HANDLER_LIST = HandlerList()
+
+        @JvmStatic
+        fun getHandlerList(): HandlerList = HANDLER_LIST
+    }
+}


### PR DESCRIPTION
Hello, 
This PR creates the bukkit event triggered when Typewriter is fully loaded (extension included).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new event that signals when the plugin has fully loaded, enabling improved integration with other plugins or components that depend on this state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->