### PR TITLE
Fix: Resolve chat history duplication and disconnect errors

### DIFF
--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/TypewriterPaperPlugin.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/TypewriterPaperPlugin.kt
@@ -105,6 +105,7 @@ class TypewriterPaperPlugin : KotlinPlugin(), KoinComponent {
             singleOf<AssetStorage>(::LocalAssetStorage)
             singleOf<AssetManager>(::AssetManager)
             singleOf(::ChatHistoryHandler)
+            singleOf(::ResendTokenRegistry)
             singleOf(::ActionBarBlockerHandler)
             singleOf(::PacketInterceptor)
             singleOf(::EntityHandler)

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/interaction/ChatHistoryHandler.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/interaction/ChatHistoryHandler.kt
@@ -215,6 +215,7 @@ class ChatHistory {
     fun shouldBlockMessage(): Boolean = blocking
 
     internal fun addMessage(message: Message) {
+        message.onAddedToHistory(blocking)
         if (blocking) {
             blockingState = blockingState.addMessage()
         }
@@ -308,6 +309,8 @@ internal interface Message : KoinComponent {
         return TextMessage(message.append(Component.text("\n")).append(other.message))
     }
 
+    fun onAddedToHistory(isBlocking: Boolean) {}
+
     object Empty : Message {
         override val message: Component = Component.empty()
         override val darkenMessage: Component = Component.empty()
@@ -343,6 +346,12 @@ internal interface Message : KoinComponent {
 
         override val darkenMessage: Component by lazy(LazyThreadSafetyMode.NONE) {
             Component.text("${message.plainText()}\n").color(TextColor.color(0x7d8085))
+        }
+
+        override fun onAddedToHistory(isBlocking: Boolean) {
+            if (!isBlocking) {
+                packet = null
+            }
         }
 
         override fun send(player: Player) {


### PR DESCRIPTION
This pull request fixes two problems with the chat history system. First, there was a race condition that caused resent chat messages to be added back into the history, leading to exponential growth that would eventually freeze the client. Second, there was a disconnect error that happened when resending player chat packets that had outdated message indices.

The original implementation used a simple boolean "ignore" flag to prevent chat messages from being re-added during resends. However, this didn't account for asynchronous packet processing. The ignore flag would reset to false before client-bound packets were processed by the listener, causing all resent messages to be captured and added back into the history. This created duplicates that kept building up with each dialogue interaction until the client stopped responding.

The second issue had to do with how we stored and resent player chat packets using their original indices. When other messages arrived between the original message and the resend, the client would receive packets out of order. For example, resending a message with index 0 after the client had already received index 2 would cause validation failures and disconnect the player.

The solution implements two key changes. First, the ignore flag has been replaced with a token-based system called ResendTokenRegistry. Before resendMessages sends any message, it generates a unique token and registers it in a thread-safe cache using AtomicInteger to handle multiple identical messages. When the packet send listener intercepts a message, it generates a token using the same method. If the token exists in the registry, the message is identified as resent, the token is consumed by decrementing its count, and the packet is ignored. The cache automatically cleans up after two seconds to prevent memory leaks.

Second, packet storage has been made conditional. Raw PlayerMessage packet data is now only stored when chat is actively blocked. If a player message arrives while chat isn't blocked, the packet data is immediately discarded. This prevents resending player chat packets with stale indices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat message handling to prevent duplicate messages during chat history resends.
* **Refactor**
  * Simplified chat history management by replacing internal tracking with a token-based system for message processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->