### PR TITLE
fix: use correct event for drop item event entry

### DIFF
--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/event/DropItemEventEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/event/DropItemEventEntry.kt
@@ -17,8 +17,7 @@ import com.typewritermc.engine.paper.entry.entries.shouldCancel
 import com.typewritermc.engine.paper.entry.startDialogueWithOrNextDialogue
 import com.typewritermc.engine.paper.utils.item.Item
 import com.typewritermc.engine.paper.utils.item.toItem
-import org.bukkit.entity.Player
-import org.bukkit.event.entity.EntityDropItemEvent
+import org.bukkit.event.player.PlayerDropItemEvent
 import java.util.*
 import kotlin.reflect.KClass
 
@@ -45,10 +44,8 @@ enum class DropItemContextKeys(override val klass: KClass<*>) : EntryContextKey 
 }
 
 @EntryListener(DropItemEventEntry::class)
-fun onDropItem(event: EntityDropItemEvent, query: Query<DropItemEventEntry>) {
-    if (event.entity !is Player) return
-
-    val player = event.entity as Player
+fun onDropItem(event: PlayerDropItemEvent, query: Query<DropItemEventEntry>) {
+    val player = event.player
 
     val entries = query.findWhere { entry ->
         if (entry.item.isPresent && !entry.item.get().get(player)


### PR DESCRIPTION
The `DropItemEventEntry` from the documentation should be triggered when a player drops an item. Currently, it uses `EntityItemDropEvent`, which is only called when an entity drops an item. Examples of this include a chicken laying an egg, a cat bringing a gift, or a villager giving a reward after a raid. This event is not triggered when a player drops an item from their inventory. To fix this, we need to use `PlayerDropItemEvent` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the way item drop events are handled, ensuring more accurate detection when a player drops an item. No changes to user-facing features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->