### PR TITLE
fix: avoid component style bleed when using new lines

### DIFF
--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/utils/MiniMessages.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/utils/MiniMessages.kt
@@ -48,6 +48,20 @@ fun String.asMini() = mm.deserialize(this)
 
 fun String.asMiniWithResolvers(vararg resolvers: TagResolver) = mm.deserialize(this, *resolvers)
 
+fun String.replaceTagPlaceholders(placeholder: String, value: String): String =
+    this.replaceTagPlaceholders(mapOf(placeholder to value))
+
+fun String.replaceTagPlaceholders(vararg placeholders: Pair<String, String>): String =
+    replaceTagPlaceholders(placeholders.toMap())
+
+fun String.replaceTagPlaceholders(placeholders: Map<String, String>): String {
+    if (placeholders.isEmpty()) return this
+
+    return placeholders.entries.fold(this) { acc, (placeholder, value) ->
+        acc.replace("<$placeholder>", value)
+    }
+}
+
 fun CommandSender.sendMini(message: String) = sendMessage(message.asMini())
 
 fun CommandSender.sendMiniWithResolvers(message: String, vararg resolvers: TagResolver) =

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/custom/NamedEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/custom/NamedEntity.kt
@@ -10,13 +10,15 @@ import com.typewritermc.engine.paper.entry.entity.*
 import com.typewritermc.engine.paper.entry.entries.*
 import com.typewritermc.engine.paper.extensions.placeholderapi.parsePlaceholders
 import com.typewritermc.engine.paper.snippets.snippet
-import com.typewritermc.engine.paper.utils.*
+import com.typewritermc.engine.paper.utils.Color
+import com.typewritermc.engine.paper.utils.Sound
+import com.typewritermc.engine.paper.utils.isFloodgate
+import com.typewritermc.engine.paper.utils.replaceTagPlaceholders
 import com.typewritermc.entity.entries.data.minecraft.display.BillboardConstraintProperty
 import com.typewritermc.entity.entries.data.minecraft.display.TranslationProperty
 import com.typewritermc.entity.entries.data.minecraft.display.text.BackgroundColorProperty
 import com.typewritermc.entity.entries.entity.minecraft.TextDisplayEntity
 import me.tofaa.entitylib.meta.display.AbstractDisplayMeta
-import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder
 import org.bukkit.entity.Player
 
 
@@ -113,10 +115,10 @@ class NamedEntity(
         val other = property(LinesProperty::class)?.lines ?: ""
         val displayName = this.displayName
 
-        return namePlate.parsePlaceholders(player).asMiniWithResolvers(
-            Placeholder.parsed("other", other),
-            Placeholder.parsed("display_name", displayName.get(player).parsePlaceholders(player)),
-        ).asMini().trim()
+        return namePlate.parsePlaceholders(player).replaceTagPlaceholders(
+            "other" to other,
+            "display_name" to displayName.get(player).parsePlaceholders(player),
+        ).trim()
     }
 
     private fun calculateIndicatorOffset(hologramText: String): Vector {

--- a/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/QuestEntry.kt
+++ b/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/QuestEntry.kt
@@ -12,11 +12,9 @@ import com.typewritermc.engine.paper.extensions.placeholderapi.parsePlaceholders
 import com.typewritermc.engine.paper.facts.FactListenerSubscription
 import com.typewritermc.engine.paper.facts.listenForFacts
 import com.typewritermc.engine.paper.snippets.snippet
-import com.typewritermc.engine.paper.utils.asMini
-import com.typewritermc.engine.paper.utils.asMiniWithResolvers
+import com.typewritermc.engine.paper.utils.replaceTagPlaceholders
 import com.typewritermc.engine.paper.utils.server
 import com.typewritermc.quest.events.AsyncQuestStatusUpdate
-import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder.parsed
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import java.util.*
@@ -88,7 +86,7 @@ interface ObjectiveEntry : AudienceFilterEntry, PlaceholderEntry, PriorityEntry 
         }
         val display = display.get(player) ?: ""
 
-        return text.asMiniWithResolvers(parsed("display", display)).asMini().parsePlaceholders(player)
+        return text.replaceTagPlaceholders("display", display).parsePlaceholders(player)
     }
 
     override fun parser(): PlaceholderParser = placeholderParser {

--- a/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/entries/audience/CompletableObjective.kt
+++ b/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/entries/audience/CompletableObjective.kt
@@ -13,13 +13,11 @@ import com.typewritermc.engine.paper.entry.entries.get
 import com.typewritermc.engine.paper.entry.matches
 import com.typewritermc.engine.paper.extensions.placeholderapi.parsePlaceholders
 import com.typewritermc.engine.paper.snippets.snippet
-import com.typewritermc.engine.paper.utils.asMini
-import com.typewritermc.engine.paper.utils.asMiniWithResolvers
+import com.typewritermc.engine.paper.utils.replaceTagPlaceholders
 import com.typewritermc.quest.ObjectiveEntry
 import com.typewritermc.quest.QuestEntry
 import com.typewritermc.quest.inactiveObjectiveDisplay
 import com.typewritermc.quest.showingObjectiveDisplay
-import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder.parsed
 import org.bukkit.entity.Player
 import java.util.*
 
@@ -65,6 +63,6 @@ class CompletableObjective(
             showCriteria.matches(player) -> showingObjectiveDisplay
             else -> inactiveObjectiveDisplay
         }
-        return text.asMiniWithResolvers(parsed("display", display.get(player) ?: "")).asMini().parsePlaceholders(player)
+        return text.replaceTagPlaceholders("display", display.get(player) ?: "").parsePlaceholders(player)
     }
 }

--- a/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/entries/audience/ObjectiveLinesEntry.kt
+++ b/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/entries/audience/ObjectiveLinesEntry.kt
@@ -5,8 +5,7 @@ import com.typewritermc.core.entries.priority
 import com.typewritermc.core.extension.annotations.*
 import com.typewritermc.engine.paper.entry.entries.LinesEntry
 import com.typewritermc.engine.paper.extensions.placeholderapi.parsePlaceholders
-import com.typewritermc.engine.paper.utils.asMini
-import com.typewritermc.engine.paper.utils.asMiniWithResolvers
+import com.typewritermc.engine.paper.utils.replaceTagPlaceholders
 import com.typewritermc.quest.trackedShowingObjectives
 import org.bukkit.entity.Player
 import java.util.*
@@ -35,12 +34,7 @@ class ObjectiveLinesEntry(
 ) : LinesEntry {
     override fun lines(player: Player): String {
         return player.trackedShowingObjectives().sortedByDescending { it.priority }.joinToString("\n") {
-            format.parsePlaceholders(player).asMiniWithResolvers(
-                net.kyori.adventure.text.minimessage.tag.resolver.Placeholder.parsed(
-                    "objective",
-                    it.display(player)
-                )
-            ).asMini()
+            format.parsePlaceholders(player).replaceTagPlaceholders("objective", it.display(player))
         }
     }
 }


### PR DESCRIPTION
Due to the way MiniMessage handles serialization/deserialization, and how component and MiniMessage strings are passed throughout the codebase, using a new line splitter was causing component styles to bleed into other components. Adding a reset tag on the new line forces the MiniMessage deserializer to close all open tags, which prevents the style bleed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new ways to replace placeholders in text, allowing for easier customization of displayed information using simple tags.

* **Refactor**
  * Simplified and unified how placeholders are handled in quest and entity displays, resulting in more consistent and maintainable text formatting throughout the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->