### PR TITLE
feat: allow specifying block chat and actionbar message for cinematics

### DIFF
--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/temporal/TemporalCommand.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/temporal/TemporalCommand.kt
@@ -2,10 +2,7 @@ package com.typewritermc.engine.paper.entry.temporal
 
 import com.typewritermc.core.books.pages.PageType
 import com.typewritermc.core.interaction.context
-import com.typewritermc.engine.paper.command.dsl.CommandTree
-import com.typewritermc.engine.paper.command.dsl.executePlayerOrTarget
-import com.typewritermc.engine.paper.command.dsl.page
-import com.typewritermc.engine.paper.command.dsl.withPermission
+import com.typewritermc.engine.paper.command.dsl.*
 import com.typewritermc.engine.paper.entry.entries.InteractionEndTrigger
 import com.typewritermc.engine.paper.entry.triggerFor
 
@@ -16,6 +13,18 @@ fun CommandTree.temporalCommand() = literal("cinematic") {
         page("cinematic", PageType.CINEMATIC) { page ->
             executePlayerOrTarget { target ->
                 TemporalStartTrigger(page().id, emptyList()).triggerFor(target, context())
+            }
+
+            boolean("blockMessage") { blockMessage ->
+                boolean("blockActionBar") { blockActionBar ->
+                    executePlayerOrTarget { target ->
+                        TemporalStartTrigger(
+                            page().id,
+                            emptyList(),
+                            TemporalSettings(blockMessage(), blockActionBar())
+                        ).triggerFor(target, context())
+                    }
+                }
             }
         }
     }

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/action/CinematicEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/action/CinematicEntry.kt
@@ -4,6 +4,7 @@ import com.google.gson.annotations.SerializedName
 import com.typewritermc.core.books.pages.Colors
 import com.typewritermc.core.books.pages.PageType
 import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.extension.annotations.Default
 import com.typewritermc.core.extension.annotations.Entry
 import com.typewritermc.core.extension.annotations.Help
 import com.typewritermc.core.extension.annotations.Page
@@ -13,6 +14,7 @@ import com.typewritermc.engine.paper.entry.TriggerableEntry
 import com.typewritermc.engine.paper.entry.entries.ActionEntry
 import com.typewritermc.engine.paper.entry.entries.ActionTrigger
 import com.typewritermc.engine.paper.entry.entries.EventTrigger
+import com.typewritermc.engine.paper.entry.temporal.TemporalSettings
 import com.typewritermc.engine.paper.entry.temporal.TemporalStartTrigger
 
 
@@ -38,9 +40,15 @@ class CinematicEntry(
     @Page(PageType.CINEMATIC)
     @Help("The cinematic page to start.")
     val pageId: String = "",
+    @Default("true")
+    @Help("Whether to block chat messages from showing to the player while in the cinematic.")
+    val blockChatMessages: Boolean = true,
+    @Default("true")
+    @Help("Whether to block actionbar messages from showing to the player while in the cinematic.")
+    val blockActionBarMessages: Boolean = true
 ) : ActionEntry {
     override val eventTriggers: List<EventTrigger>
-        get() = listOf(TemporalStartTrigger(pageId, super.eventTriggers))
+        get() = listOf(TemporalStartTrigger(pageId, super.eventTriggers, TemporalSettings(blockChatMessages, blockActionBarMessages)))
 
     override fun ActionTrigger.execute() {}
 }


### PR DESCRIPTION
Add a new option for cinematic entries and a corresponding parameter for the cinematic command for allowing users to block players from receiving chat or action bar messages while a cinematic is playing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to control blocking of chat and action bar messages during cinematics.
  * Users can now specify whether to block chat messages and action bar messages when starting a cinematic.

* **Documentation**
  * Enhanced help descriptions for new cinematic blocking options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->