### PR TITLE
Fix Log4j2 context inheritance in GlobalClassLoader

### DIFF
--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/GlobalClassloader.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/GlobalClassloader.kt
@@ -18,7 +18,8 @@ import io.papermc.paper.plugin.provider.classloader.PluginClassLoaderGroup
 class GlobalClassloader(
     private val group: PluginClassLoaderGroup,
     private val requester: ConfiguredPluginClassLoader,
-) : ClassLoader() {
+    parent: ClassLoader
+) : ClassLoader(parent) {
     override fun loadClass(name: String, resolve: Boolean): Class<*> {
         return group.getClassByName(name, resolve, requester) ?: super.loadClass(name, resolve)
     }
@@ -30,5 +31,5 @@ internal fun globalClassloader(): GlobalClassloader {
     val group = storage.javaClass.getDeclaredMethod("getGlobalGroup").invoke(storage) as PluginClassLoaderGroup
     val requester = plugin.javaClass.classLoader as ConfiguredPluginClassLoader
 
-    return GlobalClassloader(group, requester)
+    return GlobalClassloader(group, requester, plugin.javaClass.classLoader.parent)
 }


### PR DESCRIPTION
As shown [here](https://discord.com/channels/1054708062520360960/1398393111066972384), I discovered that Log4j2 behaves incorrectly when used inside extensions.

### Problem

Log4j2 was initialized twice - once during server startup and then again during the first logger call from an extension. This caused a second logging context to be created, or fallback to the default context, bypassing the classloader hierarchy.

### Fix

I modified `GlobalClassLoader` to use the **plugin classloader’s parent** instead of having no parent. This ensures the correct context is inherited, avoiding duplicate or default logger contexts.

**Before (broken context):**
Separate logger context were created in extensions.

**After (with fix):** <img width="1143" height="391" alt="fixed_tree" src="https://github.com/user-attachments/assets/5f97cd79-31d6-4e4a-a4e7-fe7373caf863" />

As shown above, both the plugin and the extension now share the same logging context.

### Testing

Tested with:

* Basic extension
* Citizens extension
* Test extension (see code below)

```kotlin
override suspend fun initialize() {
    printContextTree(this::class.java.classLoader)
    printContextTree(Query::class.java.classLoader)
    val ctx = LogManager.getContext(false)
    LoggerFactory.getLogger("test").info("Test message in $ctx")
    val qCtx = LogManager.getContext(Query::class.java.classLoader, false)
    qCtx.getLogger("QueryClassLoaderLogger").info("Test message in $qCtx")
}
```

Everything loads, works, and loggers use correct context. 

### Note

This change avoids recursion and only sets the parent to the plugin classloader’s parent, so the parent of `GlobalClassLoader` do not involves `PluginClassLoaderGroup`.

Also i forgot to enable actions in my fork repository before pushing so there are no alpha builds for this commit



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal classloader handling to improve parent classloader management. No visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->