### PR TITLE
feat: add missing minimessage tags resolvers

### DIFF
--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/utils/MiniMessages.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/utils/MiniMessages.kt
@@ -35,6 +35,8 @@ private val mm = MiniMessage.builder()
                 StandardTags.selector(),
                 StandardTags.score(),
                 StandardTags.nbt(),
+                StandardTags.pride(),
+                StandardTags.shadowColor(),
             )
             .tag("confirmation_key") { _, _ -> Tag.preProcessParsed(confirmationKey.keybind) }
             .resolver(Placeholder.parsed("line", "<#ECFFF8><bold>│</bold></#ECFFF8><white>"))


### PR DESCRIPTION
Add the missing minimessage tags resolver that were added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for "pride" and "shadowColor" tags in MiniMessage formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->