### PR TITLE
feat: allow variables in sounds

### DIFF
--- a/documentation/docs/develop/02-extensions/09-api-changes/0.9.mdx
+++ b/documentation/docs/develop/02-extensions/09-api-changes/0.9.mdx
@@ -2,10 +2,6 @@
 title: 0.9.X API changes
 ---
 
----
-title: 0.9.X API changes
----
-
 # 0.9.X API changes
 
 ## `ThreadType` Deprecation
@@ -45,3 +41,109 @@ Dispatchers.UntickedAsync.launch {}
 ```
 
 If working in **IntelliJ**, it will automatically suggest the correct replacements.
+
+## `SpeakerEntry` and `EntityInstanceEntry` Changes
+
+The way sound is handled in `SpeakerEntry` and, by extension, `EntityInstanceEntry` has been updated to use variables.
+
+
+### Introduction of `InteractionContext`
+
+Many updated methods now require a nullable `InteractionContext`. This context is essential for resolving `Var` values, allowing properties like sound or volume to be dynamic based on the current game state.
+
+You can typically obtain the `InteractionContext` in two ways:
+
+1.  **From the `Player` object using the `interactionContext` extension property:**
+    ```kotlin showLineNumbers
+    val interactionContext: InteractionContext? = player.interactionContext
+    ```
+
+2.  **From the execution scope of an entry**, where it is often provided as a `context` property (e.g., in `ActionTrigger`).
+    ```kotlin showLineNumbers
+    override fun ActionTrigger.execute() {
+        // The 'context' property is directly available here
+        val dynamicSound = sound.get(player, context)
+        player.playSound(dynamicSound, context)
+    }
+    ```
+
+### Sound Field
+
+The `sound` field now utilizes a `Var<Sound>` type. This change affects how you set and get sound values.
+
+```kotlin showLineNumbers
+// highlight-red
+class CustomEntityDefinition(
+    ...
+    override val sound: Sound = Sound.EMPTY,
+    ...
+) : SimpleEntityDefinition {
+// highlight-green
+class CustomEntityDefinition(
+    ...
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
+    ...
+) : SimpleEntityDefinition {
+```
+
+**To get the sound:**
+Retrieving the sound now requires the context of a `player` and an optional `interactionContext`.
+
+```kotlin showLineNumbers
+// highlight-red
+val sound: Sound = entry.sound
+// highlight-green
+val sound: Sound = entry.sound.get(player, interactionContext)
+```
+
+## `Sound` Class Changes
+
+Several fields and methods within the `Sound` class have been updated.
+
+### Volume and Pitch Fields
+
+The `volume` and `pitch` fields have been changed from `Float` to `Var<Float>`.
+
+**To set the volume and pitch:**
+When creating a new `Sound` instance, you now need to wrap the `volume` and `pitch` values in a `Var`, such as `ConstVar`.
+
+```kotlin showLineNumbers
+// highlight-red
+val sound = Sound(DefaultSoundId("minecraft:ambient.cave"), SelfSoundSource, AdventureSound.Source.MASTER, 1.0f, 1.0f)
+// highlight-green
+val sound = Sound(DefaultSoundId("minecraft:ambient.cave"), SelfSoundSource, AdventureSound.Source.MASTER, ConstVar(1.0f), ConstVar(1.0f))
+```
+
+**To get the volume and pitch:**
+Accessing the `volume` and `pitch` now requires a `player` and an optional `interactionContext`.
+
+```kotlin showLineNumbers
+// highlight-red
+val volume: Float = sound.volume
+val pitch: Float = sound.pitch
+// highlight-green
+val volume: Float = sound.volume.get(player, interactionContext)
+val pitch: Float = sound.pitch.get(player, interactionContext)
+```
+
+### `play` Method
+
+The `play` method's signature has been updated. It now takes a `Player` and a nullable `InteractionContext` instead of an `Audience`.
+
+```kotlin showLineNumbers
+// highlight-red
+sound.play(audience)
+// highlight-green
+sound.play(player, interactionContext)
+```
+
+The corresponding extension functions have also been updated to reflect this change.
+
+```kotlin showLineNumbers
+// highlight-red
+fun Audience.playSound(sound: Sound)
+fun Audience.stopSound(sound: Sound)
+// highlight-green
+fun Player.playSound(sound: Sound, context: InteractionContext?)
+fun Player.stopSound(sound: Sound)
+```

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/dialogue/DialogueInteraction.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/dialogue/DialogueInteraction.kt
@@ -149,9 +149,9 @@ val Player.speakersInDialogue: Set<Ref<SpeakerEntry>>
         return sequence.speakers
     }
 
-fun Player.playSpeakerSound(speaker: SpeakerEntry?) {
+fun Player.playSpeakerSound(speaker: SpeakerEntry?, context: InteractionContext? = this.interactionContext) {
     val sound = speaker?.sound ?: return
-    playSound(sound)
+    playSound(sound, context)
 }
 
 enum class DialogueTrigger : EventTrigger {

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/dialogue/DialogueInteraction.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/dialogue/DialogueInteraction.kt
@@ -150,7 +150,7 @@ val Player.speakersInDialogue: Set<Ref<SpeakerEntry>>
     }
 
 fun Player.playSpeakerSound(speaker: SpeakerEntry?, context: InteractionContext? = this.interactionContext) {
-    val sound = speaker?.sound ?: return
+    val sound = speaker?.sound?.get(this, context) ?: return
     playSound(sound, context)
 }
 

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/entries/EntityEntry.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/entries/EntityEntry.kt
@@ -21,7 +21,7 @@ interface SpeakerEntry : PlaceholderEntry {
     val displayName: Var<String>
 
     @Help("The sound that will be played when the entity speaks.")
-    val sound: Sound
+    val sound: Var<Sound>
 
     override fun parser(): PlaceholderParser = placeholderParser {
         supply { player -> displayName.get(player) }
@@ -84,8 +84,8 @@ interface EntityInstanceEntry : AudienceFilterEntry, SoundSourceEntry, SpeakerEn
                 ?: ""
         }
 
-    override val sound: Sound
-        get() = definition.get()?.sound ?: Sound.EMPTY
+    override val sound: Var<Sound>
+        get() = definition.get()?.sound ?: ConstVar(Sound.EMPTY)
 
     override fun getEmitter(player: Player): SoundEmitter {
         val display = ref().findDisplay() as? AudienceEntityDisplay ?: return SoundEmitter(player.entityId)

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/action/PlaySoundActionEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/action/PlaySoundActionEntry.kt
@@ -1,10 +1,10 @@
 package com.typewritermc.basic.entries.action
 
 import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Ref
 import com.typewritermc.core.extension.annotations.Entry
 import com.typewritermc.engine.paper.entry.Criteria
 import com.typewritermc.engine.paper.entry.Modifier
-import com.typewritermc.core.entries.Ref
 import com.typewritermc.engine.paper.entry.TriggerableEntry
 import com.typewritermc.engine.paper.entry.entries.ActionEntry
 import com.typewritermc.engine.paper.entry.entries.ActionTrigger
@@ -12,7 +12,6 @@ import com.typewritermc.engine.paper.entry.entries.ConstVar
 import com.typewritermc.engine.paper.entry.entries.Var
 import com.typewritermc.engine.paper.utils.Sound
 import com.typewritermc.engine.paper.utils.playSound
-import org.bukkit.entity.Player
 
 @Entry("play_sound", "Play sound at player, or location", Colors.RED, "fa6-solid:volume-high")
 /**
@@ -31,6 +30,6 @@ class PlaySoundActionEntry(
     val sound: Var<Sound> = ConstVar(Sound.EMPTY),
 ) : ActionEntry {
     override fun ActionTrigger.execute() {
-        player.playSound(sound.get(player, context))
+        player.playSound(sound.get(player, context), context)
     }
 }

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/cinematic/SoundCinematicEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/cinematic/SoundCinematicEntry.kt
@@ -1,12 +1,15 @@
 package com.typewritermc.basic.entries.cinematic
 
 import com.typewritermc.core.books.pages.Colors
-import com.typewritermc.engine.paper.entry.Criteria
 import com.typewritermc.core.extension.annotations.Entry
 import com.typewritermc.core.extension.annotations.Segments
+import com.typewritermc.engine.paper.entry.Criteria
 import com.typewritermc.engine.paper.entry.entries.*
 import com.typewritermc.engine.paper.entry.temporal.SimpleCinematicAction
-import com.typewritermc.engine.paper.utils.*
+import com.typewritermc.engine.paper.interaction.interactionContext
+import com.typewritermc.engine.paper.utils.Sound
+import com.typewritermc.engine.paper.utils.playSound
+import com.typewritermc.engine.paper.utils.stopSound
 import org.bukkit.entity.Player
 
 @Entry("sound_cinematic", "Play a sound during a cinematic", Colors.YELLOW, "fa6-solid:music")
@@ -48,7 +51,7 @@ class SoundCinematicAction(
     override suspend fun startSegment(segment: SoundSegment) {
         super.startSegment(segment)
         previousSound = segment.sound.get(player)
-        player.playSound(previousSound!!)
+        player.playSound(previousSound!!, player.interactionContext)
     }
 
     override suspend fun stopSegment(segment: SoundSegment) {

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/static/SelfSpeaker.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/static/SelfSpeaker.kt
@@ -21,7 +21,7 @@ import java.util.*
 class SelfSpeaker(
     override val id: String = "",
     override val name: String = "",
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     val overrideName: Optional<Var<String>> = Optional.empty(),
 ) : SpeakerEntry, SoundSourceEntry, StaticEntry {
     override val displayName: Var<String>

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/static/SimpleSpeakerEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/static/SimpleSpeakerEntry.kt
@@ -20,5 +20,5 @@ class SimpleSpeakerEntry(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
 ) : SpeakerEntry, StaticEntry

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/variables/RangedVariable.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/variables/RangedVariable.kt
@@ -49,6 +49,17 @@ class RangedVariable(
                 return context.cast(value)
             }
 
+            Float::class -> {
+                val start = data.range.start.get(Float::class) ?: 0.0f
+                val end = data.range.endInclusive.get(Float::class) ?: 0.0f
+                val step = data.step.get(Float::class) ?: 1.0f
+
+                val numberOfSteps = (((end - start) / step) + 1).roundToInt()
+                val randomStep = Random.nextInt(numberOfSteps)
+                val value = start + randomStep * step
+                return context.cast(value)
+            }
+
             Duration::class -> {
                 val start = data.range.start.get(Duration::class) ?: Duration.ZERO
                 val end = data.range.endInclusive.get(Duration::class) ?: Duration.ZERO

--- a/extensions/CitizensExtension/src/main/kotlin/com/typewritermc/citizens/entries/entity/ReferenceNpcEntry.kt
+++ b/extensions/CitizensExtension/src/main/kotlin/com/typewritermc/citizens/entries/entity/ReferenceNpcEntry.kt
@@ -23,7 +23,7 @@ class ReferenceNpcEntry(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @Help("The id of the NPC in the Citizens plugin.")
     val npcId: Int = 0,
 ) : SoundSourceEntry, SpeakerEntry, StaticEntry {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/AmbientSoundActivity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/AmbientSoundActivity.kt
@@ -9,6 +9,7 @@ import com.typewritermc.core.extension.annotations.Help
 import com.typewritermc.engine.paper.entry.entity.*
 import com.typewritermc.engine.paper.entry.entries.EntityActivityEntry
 import com.typewritermc.engine.paper.entry.entries.GenericEntityActivityEntry
+import com.typewritermc.engine.paper.interaction.interactionContext
 import com.typewritermc.engine.paper.utils.Sound
 import java.time.Duration
 import kotlin.math.max
@@ -64,7 +65,7 @@ class AmbientSoundActivity(
             nextPlay = System.currentTimeMillis() + delay.random().toMillis()
             val sound = sounds.weightedRandom().sound
             context.viewers.forEach { viewer ->
-                sound.play(viewer)
+                sound.play(viewer, viewer.interactionContext)
             }
         }
         return super.tick(context)

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/custom/HitBoxEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/custom/HitBoxEntity.kt
@@ -37,7 +37,7 @@ class HitBoxDefinition(
     val height: Double = 1.0,
 ) : EntityDefinitionEntry {
     override val displayName: Var<String> get() = baseEntity.get()?.displayName ?: ConstVar("")
-    override val sound: Sound get() = baseEntity.get()?.sound ?: Sound.EMPTY
+    override val sound: Var<Sound> get() = baseEntity.get()?.sound ?: ConstVar(Sound.EMPTY)
     override val data: List<Ref<EntityData<*>>> get() = baseEntity.get()?.data ?: emptyList()
 
     override fun create(player: Player): FakeEntity {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/custom/InteractionIndicator.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/custom/InteractionIndicator.kt
@@ -41,7 +41,7 @@ class InteractionIndicatorDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     val definition: Ref<EntityDefinitionEntry> = emptyRef(),
     @OnlyTags("generic_entity_data", "display_data", "text_display_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/custom/NamedEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/custom/NamedEntity.kt
@@ -51,7 +51,7 @@ class NamedEntityDefinition(
     val baseEntity: Ref<EntityDefinitionEntry> = emptyRef(),
 ) : SimpleEntityDefinition {
     override val displayName: Var<String> get() = baseEntity.get()?.displayName ?: ConstVar("")
-    override val sound: Sound get() = baseEntity.get()?.sound ?: Sound.EMPTY
+    override val sound: Var<Sound> get() = baseEntity.get()?.sound ?: ConstVar(Sound.EMPTY)
     override val data: List<Ref<EntityData<*>>> get() = baseEntity.get()?.data ?: emptyList()
 
     override fun create(player: Player): FakeEntity {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/custom/Npc.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/custom/Npc.kt
@@ -33,7 +33,7 @@ class NpcDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @Help("The skin of the npc.")
     val skin: Var<SkinProperty> = ConstVar(SkinProperty()),
     @OnlyTags("generic_entity_data", "living_entity_data", "lines", "player_data")

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/custom/SelfNpc.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/custom/SelfNpc.kt
@@ -27,7 +27,7 @@ class SelfNpcDefinition(
     override val name: String = "",
     @Help("Overrides the display name of the speaker")
     val overrideName: Optional<Var<String>> = Optional.empty(),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "player_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/custom/StackedEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/custom/StackedEntity.kt
@@ -1,9 +1,9 @@
 package com.typewritermc.entity.entries.entity.custom
 
 import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Ref
 import com.typewritermc.core.extension.annotations.Entry
 import com.typewritermc.core.extension.annotations.Help
-import com.typewritermc.core.entries.Ref
 import com.typewritermc.engine.paper.entry.entity.EntityState
 import com.typewritermc.engine.paper.entry.entity.FakeEntity
 import com.typewritermc.engine.paper.entry.entity.PositionProperty
@@ -33,7 +33,7 @@ class StackedEntityDefinition(
     val definitions: List<Ref<EntityDefinitionEntry>> = emptyList(),
 ) : EntityDefinitionEntry {
     override val displayName: Var<String> get() = definitions.firstOrNull()?.get()?.displayName ?: ConstVar("")
-    override val sound: Sound get() = definitions.firstOrNull()?.get()?.sound ?: Sound.EMPTY
+    override val sound: Var<Sound> get() = definitions.firstOrNull()?.get()?.sound ?: ConstVar(Sound.EMPTY)
     override val data: List<Ref<EntityData<*>>>
         get() = definitions.mapNotNull { it.get() }.flatMap { it.data }
 

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/AllayEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/AllayEntity.kt
@@ -30,7 +30,7 @@ class AllayDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "allay_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/ArmorStandEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/ArmorStandEntity.kt
@@ -13,7 +13,7 @@ import com.typewritermc.engine.paper.entry.entity.SimpleEntityDefinition
 import com.typewritermc.engine.paper.entry.entity.SimpleEntityInstance
 import com.typewritermc.engine.paper.entry.entries.*
 import com.typewritermc.engine.paper.utils.Sound
-import com.typewritermc.entity.entries.data.minecraft.*
+import com.typewritermc.entity.entries.data.minecraft.applyGenericEntityData
 import com.typewritermc.entity.entries.data.minecraft.living.applyLivingEntityData
 import com.typewritermc.entity.entries.data.minecraft.living.armorstand.*
 import com.typewritermc.entity.entries.entity.WrapperFakeEntity
@@ -31,7 +31,7 @@ class ArmorStandDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "armor_stand_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/BeeEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/BeeEntity.kt
@@ -17,12 +17,7 @@ import com.typewritermc.entity.entries.data.minecraft.applyGenericEntityData
 import com.typewritermc.entity.entries.data.minecraft.living.AgeableProperty
 import com.typewritermc.entity.entries.data.minecraft.living.applyAgeableData
 import com.typewritermc.entity.entries.data.minecraft.living.applyLivingEntityData
-import com.typewritermc.entity.entries.data.minecraft.living.bee.AngryProperty
-import com.typewritermc.entity.entries.data.minecraft.living.bee.NectarProperty
-import com.typewritermc.entity.entries.data.minecraft.living.bee.StungProperty
-import com.typewritermc.entity.entries.data.minecraft.living.bee.applyBeeAngryData
-import com.typewritermc.entity.entries.data.minecraft.living.bee.applyBeeStungData
-import com.typewritermc.entity.entries.data.minecraft.living.bee.applyBeeNectarData
+import com.typewritermc.entity.entries.data.minecraft.living.bee.*
 import com.typewritermc.entity.entries.entity.WrapperFakeEntity
 import org.bukkit.entity.Player
 
@@ -38,7 +33,7 @@ class BeeDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "ageable_data", "bee_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/BlockDisplayEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/BlockDisplayEntity.kt
@@ -12,14 +12,12 @@ import com.typewritermc.engine.paper.entry.entity.FakeEntity
 import com.typewritermc.engine.paper.entry.entity.SimpleEntityDefinition
 import com.typewritermc.engine.paper.entry.entity.SimpleEntityInstance
 import com.typewritermc.engine.paper.entry.entries.*
-import com.typewritermc.engine.paper.extensions.packetevents.meta
 import com.typewritermc.engine.paper.utils.Sound
 import com.typewritermc.entity.entries.data.minecraft.applyGenericEntityData
 import com.typewritermc.entity.entries.data.minecraft.display.applyDisplayEntityData
 import com.typewritermc.entity.entries.data.minecraft.display.block.BlockProperty
 import com.typewritermc.entity.entries.data.minecraft.display.block.applyBlockData
 import com.typewritermc.entity.entries.entity.WrapperFakeEntity
-import me.tofaa.entitylib.meta.display.BlockDisplayMeta
 import org.bukkit.entity.Player
 
 @Entry("block_display_definition", "A block display entity", Colors.ORANGE, "heroicons:cube-transparent-16-solid")
@@ -34,7 +32,7 @@ class BlockDisplayDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "display_data", "block_display_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/BreezeEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/BreezeEntity.kt
@@ -30,7 +30,7 @@ class BreezeDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "breeze_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/CatEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/CatEntity.kt
@@ -37,7 +37,7 @@ class CatDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "ageable_data", "tameable_data", "cat_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/CaveSpiderEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/CaveSpiderEntity.kt
@@ -30,7 +30,7 @@ class CaveSpiderDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "spider_data", "cave_spider_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/ChickenEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/ChickenEntity.kt
@@ -32,7 +32,7 @@ class ChickenDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "ageable_data", "chicken_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/CowEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/CowEntity.kt
@@ -32,7 +32,7 @@ class CowDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "ageable_data", "cow_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/DroppedItemEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/DroppedItemEntity.kt
@@ -25,7 +25,7 @@ class DroppedItemEntityDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "item_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/ElderGuardianEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/ElderGuardianEntity.kt
@@ -32,7 +32,7 @@ class ElderGuardianDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "guardian_data", "elder_guardian_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/EnderDragonEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/EnderDragonEntity.kt
@@ -32,7 +32,7 @@ class EnderDragonDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "ender_dragon_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/EndermanEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/EndermanEntity.kt
@@ -30,7 +30,7 @@ class EndermanDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/FoxEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/FoxEntity.kt
@@ -14,19 +14,7 @@ import com.typewritermc.engine.paper.entry.entity.SimpleEntityInstance
 import com.typewritermc.engine.paper.entry.entries.*
 import com.typewritermc.engine.paper.utils.Sound
 import com.typewritermc.entity.entries.data.minecraft.applyGenericEntityData
-import com.typewritermc.entity.entries.data.minecraft.living.AgeableProperty
-import com.typewritermc.entity.entries.data.minecraft.living.applyAgeableData
-import com.typewritermc.entity.entries.data.minecraft.living.applyLivingEntityData
-import com.typewritermc.entity.entries.data.minecraft.living.DefendingProperty
-import com.typewritermc.entity.entries.data.minecraft.living.FaceplantedProperty
-import com.typewritermc.entity.entries.data.minecraft.living.InterestedProperty
-import com.typewritermc.entity.entries.data.minecraft.living.PouncingProperty
-import com.typewritermc.entity.entries.data.minecraft.living.applyDefendingData
-import com.typewritermc.entity.entries.data.minecraft.living.applyFaceplantedData
-import com.typewritermc.entity.entries.data.minecraft.living.applyInterestedData
-import com.typewritermc.entity.entries.data.minecraft.living.applyPouncingData
-import com.typewritermc.entity.entries.data.minecraft.living.SleepingProperty
-import com.typewritermc.entity.entries.data.minecraft.living.applySleepingData
+import com.typewritermc.entity.entries.data.minecraft.living.*
 import com.typewritermc.entity.entries.data.minecraft.living.fox.FoxTypeProperty
 import com.typewritermc.entity.entries.data.minecraft.living.fox.applyFoxTypeData
 import com.typewritermc.entity.entries.data.minecraft.living.tameable.SittingProperty
@@ -40,7 +28,7 @@ class FoxDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "ageable_data", "fox_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/FrogEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/FrogEntity.kt
@@ -14,7 +14,9 @@ import com.typewritermc.engine.paper.entry.entity.SimpleEntityInstance
 import com.typewritermc.engine.paper.entry.entries.*
 import com.typewritermc.engine.paper.utils.Sound
 import com.typewritermc.entity.entries.data.minecraft.applyGenericEntityData
-import com.typewritermc.entity.entries.data.minecraft.living.*
+import com.typewritermc.entity.entries.data.minecraft.living.AgeableProperty
+import com.typewritermc.entity.entries.data.minecraft.living.applyAgeableData
+import com.typewritermc.entity.entries.data.minecraft.living.applyLivingEntityData
 import com.typewritermc.entity.entries.data.minecraft.living.frog.FrogVariantProperty
 import com.typewritermc.entity.entries.data.minecraft.living.frog.applyFrogVariantData
 import com.typewritermc.entity.entries.entity.WrapperFakeEntity
@@ -32,7 +34,7 @@ class FrogDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "ageable_data", "frog_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/GuardianEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/GuardianEntity.kt
@@ -32,7 +32,7 @@ class GuardianDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "guardian_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/HoglinEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/HoglinEntity.kt
@@ -30,7 +30,7 @@ class HoglinDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "ageable_data", "trembling_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/HorseEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/HorseEntity.kt
@@ -14,12 +14,13 @@ import com.typewritermc.engine.paper.entry.entity.SimpleEntityInstance
 import com.typewritermc.engine.paper.entry.entries.*
 import com.typewritermc.engine.paper.utils.Sound
 import com.typewritermc.entity.entries.data.minecraft.applyGenericEntityData
-import com.typewritermc.entity.entries.data.minecraft.living.AgeableProperty
 import com.typewritermc.entity.entries.data.minecraft.living.SaddledProperty
-import com.typewritermc.entity.entries.data.minecraft.living.applyAgeableData
 import com.typewritermc.entity.entries.data.minecraft.living.applyLivingEntityData
 import com.typewritermc.entity.entries.data.minecraft.living.applySaddledData
-import com.typewritermc.entity.entries.data.minecraft.living.horse.*
+import com.typewritermc.entity.entries.data.minecraft.living.horse.EatingProperty
+import com.typewritermc.entity.entries.data.minecraft.living.horse.HorseVariantProperty
+import com.typewritermc.entity.entries.data.minecraft.living.horse.applyHorseEatingData
+import com.typewritermc.entity.entries.data.minecraft.living.horse.applyHorseVariantData
 import com.typewritermc.entity.entries.entity.WrapperFakeEntity
 import org.bukkit.entity.Player
 
@@ -35,7 +36,7 @@ class HorseDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "horse_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/HuskEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/HuskEntity.kt
@@ -32,7 +32,7 @@ class HuskDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "ageable_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/InteractionEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/InteractionEntity.kt
@@ -41,7 +41,7 @@ class InteractionEntityDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "interaction_data", "box_size_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
     @Default("1.0")

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/IronGolemEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/IronGolemEntity.kt
@@ -30,7 +30,7 @@ class IronGolemDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/ItemDisplayEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/ItemDisplayEntity.kt
@@ -34,7 +34,7 @@ class ItemDisplayDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "display_data", "item_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/LlamaEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/LlamaEntity.kt
@@ -14,8 +14,6 @@ import com.typewritermc.engine.paper.entry.entity.SimpleEntityInstance
 import com.typewritermc.engine.paper.entry.entries.*
 import com.typewritermc.engine.paper.utils.Sound
 import com.typewritermc.entity.entries.data.minecraft.applyGenericEntityData
-import com.typewritermc.entity.entries.data.minecraft.living.AgeableProperty
-import com.typewritermc.entity.entries.data.minecraft.living.applyAgeableData
 import com.typewritermc.entity.entries.data.minecraft.living.applyLivingEntityData
 import com.typewritermc.entity.entries.data.minecraft.living.horse.*
 import com.typewritermc.entity.entries.entity.WrapperFakeEntity
@@ -33,7 +31,7 @@ class LlamaDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "horse_data", "chested_horse_data", "llama_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/MagmaCubeEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/MagmaCubeEntity.kt
@@ -32,7 +32,7 @@ class MagmaCubeDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "slime_data", "magma_cube_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/MooshroomEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/MooshroomEntity.kt
@@ -34,7 +34,7 @@ class MooshroomDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "ageable_data", "mooshroom_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/ParrotEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/ParrotEntity.kt
@@ -13,8 +13,6 @@ import com.typewritermc.engine.paper.entry.entity.SimpleEntityDefinition
 import com.typewritermc.engine.paper.entry.entity.SimpleEntityInstance
 import com.typewritermc.engine.paper.entry.entries.*
 import com.typewritermc.engine.paper.utils.Sound
-import com.typewritermc.entity.entries.data.minecraft.DyeColorProperty
-import com.typewritermc.entity.entries.data.minecraft.applyDyeColorData
 import com.typewritermc.entity.entries.data.minecraft.applyGenericEntityData
 import com.typewritermc.entity.entries.data.minecraft.living.applyLivingEntityData
 import com.typewritermc.entity.entries.data.minecraft.living.parrot.ParrotColorProperty
@@ -34,7 +32,7 @@ class ParrotDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "parrot_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/PiglinBruteEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/PiglinBruteEntity.kt
@@ -32,7 +32,7 @@ class PiglinBruteDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "trembling_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/PiglinEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/PiglinEntity.kt
@@ -32,7 +32,7 @@ class PiglinDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags(
         "generic_entity_data",
         "living_entity_data",

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/PillagerEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/PillagerEntity.kt
@@ -30,7 +30,7 @@ class PillagerDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/PlayerEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/PlayerEntity.kt
@@ -47,7 +47,7 @@ class PlayerDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "player_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/RabbitEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/RabbitEntity.kt
@@ -35,7 +35,7 @@ class RabbitDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "ageable_data", "rabbit_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/RavagerEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/RavagerEntity.kt
@@ -32,7 +32,7 @@ class RavagerDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "raider_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/SheepEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/SheepEntity.kt
@@ -36,7 +36,7 @@ class SheepDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "ageable_data", "sheep_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/ShulkerEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/ShulkerEntity.kt
@@ -36,7 +36,7 @@ class ShulkerDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "shulker_data", "dye_color_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/SkeletonEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/SkeletonEntity.kt
@@ -30,7 +30,7 @@ class SkeletonDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "skeleton_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/SlimeEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/SlimeEntity.kt
@@ -32,7 +32,7 @@ class SlimeDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "slime_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/SnowGolemEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/SnowGolemEntity.kt
@@ -32,7 +32,7 @@ class SnowGolemDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "snow_golem_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/SpiderEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/SpiderEntity.kt
@@ -30,7 +30,7 @@ class SpiderDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "spider_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/TextDisplayEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/TextDisplayEntity.kt
@@ -34,7 +34,7 @@ class TextDisplayDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "display_data", "lines", "text_display_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/TraderLlamaEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/TraderLlamaEntity.kt
@@ -33,7 +33,7 @@ class TraderLlamaDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "ageable_data", "llama_data", "chested_horse_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/VillagerEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/VillagerEntity.kt
@@ -35,7 +35,7 @@ class VillagerDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "ageable_data", "villager_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/VindicatorEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/VindicatorEntity.kt
@@ -30,7 +30,7 @@ class VindicatorDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/WardenEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/WardenEntity.kt
@@ -32,7 +32,7 @@ class WardenDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/WitchEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/WitchEntity.kt
@@ -30,7 +30,7 @@ class WitchDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/WolfEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/WolfEntity.kt
@@ -37,7 +37,7 @@ class WolfDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "ageable_data", "tameable_data", "wolf_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/ZombieEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/ZombieEntity.kt
@@ -32,7 +32,7 @@ class ZombieDefinition(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
     @OnlyTags("generic_entity_data", "living_entity_data", "mob_data", "ageable_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {

--- a/extensions/_DocsExtension/src/main/kotlin/com/typewritermc/example/entries/static/ExampleSpeakerEntry.kt
+++ b/extensions/_DocsExtension/src/main/kotlin/com/typewritermc/example/entries/static/ExampleSpeakerEntry.kt
@@ -13,6 +13,6 @@ class ExampleSpeakerEntry(
     override val id: String = "",
     override val name: String = "",
     override val displayName: Var<String> = ConstVar(""),
-    override val sound: Sound = Sound.EMPTY,
+    override val sound: Var<Sound> = ConstVar(Sound.EMPTY),
 ) : SpeakerEntry
 //</code-block:speaker_entry>


### PR DESCRIPTION
This pull request introduces the ability to use variables for sound pitch and volume. It also updates the entity definition to accept sounds as variables and fixes an issue with the ranged variable to ensure it generates float values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sound properties for entities and speakers are now reactive variables, enabling dynamic and context-aware sound playback.
  * Sound playback methods now consider the player's interaction context for a more immersive experience.

* **Improvements**
  * Volume and pitch of sounds are variable and resolved dynamically based on player and context.
  * Unified sound handling with updated APIs requiring player and optional interaction context parameters.
  * Expanded dynamic sound support across all entity and speaker types.

* **Bug Fixes**
  * Improved sound playback consistency by making all sound properties context-sensitive and reactive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->