### PR TITLE
[Engine] Add StackOverFlowError catch

### DIFF
--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/AudienceManager.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/AudienceManager.kt
@@ -220,7 +220,7 @@ fun <E : AudienceEntry> List<Ref<out AudienceEntry>>.descendants(klass: KClass<E
             }
         }
     } catch (e: StackOverflowError) {
-        logger.severe("[CRITICAL] StackOverflowError for entries: " + this.joinToString(", ") { it.id } + "due to circular references.")
+        logger.severe("[CRITICAL] StackOverflowError for entries: " + this.joinToString(", ") { it.id } + " due to circular references.")
         throw e
     }
 }


### PR DESCRIPTION
Adds a simple catch (:

Merge whenever you want or are there any improvements needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness when traversing audience hierarchies by catching stack overflows caused by circular references, preventing silent failures.

* **Chores**
  * Added critical logging with detailed context when a stack overflow occurs during audience traversal, aiding faster diagnosis of configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->