### PR TITLE
feat: add wolf variants

### DIFF
--- a/engine/engine-paper/build.gradle.kts
+++ b/engine/engine-paper/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
 
     compileOnlyApi("com.corundumstudio.socketio:netty-socketio:1.7.19") // Keep this on a lower version as the newer version breaks the ping
 
-    api("me.tofaa.entitylib:spigot:+bff89d2-SNAPSHOT")
+    api("me.tofaa.entitylib:spigot:+598d71f-SNAPSHOT")
     compileOnlyApi("com.github.shynixn.mccoroutine:mccoroutine-bukkit-api:2.22.0")
     compileOnlyApi("com.github.shynixn.mccoroutine:mccoroutine-bukkit-core:2.22.0")
 

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/data/minecraft/living/wolf/WolfVariantData.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/data/minecraft/living/wolf/WolfVariantData.kt
@@ -1,0 +1,52 @@
+package com.typewritermc.entity.entries.data.minecraft.living.wolf
+
+import com.github.retrooper.packetevents.protocol.entity.wolfvariant.WolfVariant
+import com.github.retrooper.packetevents.protocol.entity.wolfvariant.WolfVariants
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Tags
+import com.typewritermc.engine.paper.entry.entity.SinglePropertyCollectorSupplier
+import com.typewritermc.engine.paper.entry.entries.EntityData
+import com.typewritermc.engine.paper.entry.entries.EntityProperty
+import com.typewritermc.engine.paper.extensions.packetevents.metas
+import me.tofaa.entitylib.meta.mobs.tameable.WolfMeta
+import me.tofaa.entitylib.wrapper.WrapperEntity
+import org.bukkit.entity.Player
+import java.util.*
+import kotlin.reflect.KClass
+
+@Entry("wolf_variant_data", "The variant of a wolf.", Colors.RED, "game-icons:sitting-dog")
+@Tags("wolf_data", "wolf_variant_data")
+class WolfVariantData (
+    override val id: String = "",
+    override val name: String = "",
+    val wolfVariant: WolfVariantEnum = WolfVariantEnum.PALE,
+    override val priorityOverride: Optional<Int> = Optional.empty(),
+) : EntityData<WolfVariantProperty> {
+    override fun type(): KClass<WolfVariantProperty> = WolfVariantProperty::class
+
+    override fun build(player: Player): WolfVariantProperty = WolfVariantProperty(wolfVariant)
+}
+
+data class WolfVariantProperty(val wolfVariant: WolfVariantEnum) : EntityProperty {
+    companion object : SinglePropertyCollectorSupplier<WolfVariantProperty>(WolfVariantProperty::class)
+}
+
+fun applyWolfVariantData(entity: WrapperEntity, property: WolfVariantProperty) {
+    entity.metas {
+        meta<WolfMeta> { variant = property.wolfVariant.variant }
+        error("Could not apply WolfVariantData to ${entity.entityType} entity.")
+    }
+}
+
+enum class WolfVariantEnum(val variant: WolfVariant) {
+    PALE(WolfVariants.PALE),
+    SPOTTED(WolfVariants.SPOTTED),
+    SNOWY(WolfVariants.SNOWY),
+    BLACK(WolfVariants.BLACK),
+    ASHEN(WolfVariants.ASHEN),
+    RUSTY(WolfVariants.RUSTY),
+    WOODS(WolfVariants.WOODS),
+    CHESTNUT(WolfVariants.CHESTNUT),
+    STRIPED(WolfVariants.STRIPED);
+}

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/WolfEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/WolfEntity.kt
@@ -21,7 +21,9 @@ import com.typewritermc.entity.entries.data.minecraft.living.applyAgeableData
 import com.typewritermc.entity.entries.data.minecraft.living.applyLivingEntityData
 import com.typewritermc.entity.entries.data.minecraft.living.tameable.applyTameableData
 import com.typewritermc.entity.entries.data.minecraft.living.wolf.BeggingProperty
+import com.typewritermc.entity.entries.data.minecraft.living.wolf.WolfVariantProperty
 import com.typewritermc.entity.entries.data.minecraft.living.wolf.applyBeggingData
+import com.typewritermc.entity.entries.data.minecraft.living.wolf.applyWolfVariantData
 import com.typewritermc.entity.entries.entity.WrapperFakeEntity
 import org.bukkit.entity.Player
 
@@ -65,6 +67,7 @@ class WolfInstance(
 private class WolfEntity(player: Player) : WrapperFakeEntity(EntityTypes.WOLF, player) {
     override fun applyProperty(property: EntityProperty) {
         when (property) {
+            is WolfVariantProperty -> applyWolfVariantData(entity, property)
             is BeggingProperty -> applyBeggingData(entity, property)
             is DyeColorProperty -> applyDyeColorData(entity, property)
             is AgeableProperty -> applyAgeableData(entity, property)


### PR DESCRIPTION
This pull request updates the entitylib dependency to version 598d71f. This change addresses an issue where cat variants were appearing in the wrong order because the registry was not being used. Additionally, this update introduces the capability to add variants for wolves. To support this new feature, it's also included the necessary wolf variant property data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support to customize wolf appearance with selectable variants: Pale, Spotted, Snowy, Black, Ashen, Rusty, Woods, Chestnut, and Striped.
  - Wolf entities now correctly apply the chosen variant in-game.

- Chores
  - Updated underlying EntityLib API dependency for compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->