### PR TITLE
fix: avoid reversing chat history messages

### DIFF
--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/interaction/ChatHistoryHandler.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/interaction/ChatHistoryHandler.kt
@@ -256,7 +256,7 @@ class ChatHistory {
             }
 
             is BlockingStatus.PartialBlocking -> {
-                messages.reversed().take(status.newMessages).forEach { it.send(player) }
+                messages.toList().takeLast(status.newMessages).forEach { it.send(player) }
             }
         }
         blockingState = BlockingStatus.PartialBlocking(0)


### PR DESCRIPTION
This fixes an issue where chat messages were being sent in reverse order during partial blocking resends, causing Minecraft clients to disconnect. The problem was in the `resendMessages` method which was using `reversed().take()` instead of `takeLast()` to get recent messages, resulting in messages being delivered with incorrect sequential ordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resent chat messages during partial blocking now appear in chronological order (oldest to newest) for a natural reading flow.
  * This replaces the previous newest-first delivery that could be confusing when catching up on recent messages.
  * No changes to features, settings, or permissions—only the display order of resent messages was refined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->