### PR TITLE
Force default WebSocket port to prevent :0 errors

### DIFF
--- a/app/lib/models/communicator.dart
+++ b/app/lib/models/communicator.dart
@@ -112,8 +112,9 @@ class SocketNotifier extends StateNotifier<Socket?> {
       return;
     }
 
-    var url = secure ? "wss://$hostname" : "ws://$hostname";
-    if (port != null) url += ":$port";
+    var socketPort = (port == null || port == 0) ? (secure ? 443 : 80) : port;
+    var scheme = secure ? "wss" : "ws";
+    var url = "$scheme://$hostname:$socketPort";
     if (token != null) url += "?token=$token";
 
     debugPrint("Initializing socket to $url");

--- a/app/lib/models/communicator.dart
+++ b/app/lib/models/communicator.dart
@@ -112,8 +112,8 @@ class SocketNotifier extends StateNotifier<Socket?> {
       return;
     }
 
-    final int socketPort = (port == null || port == 0) ? (secure ? 443 : 80) : port!;
-    final scheme = secure ? 'wss' : 'ws';
+    final socketPort = (port == null || port == 0) ? (secure ? 443 : 80) : port;
+    final scheme = secure ? "wss" : "ws";
     var url = "$scheme://$hostname:$socketPort";
     if (token != null) url += "?token=$token";
 

--- a/app/lib/models/communicator.dart
+++ b/app/lib/models/communicator.dart
@@ -112,8 +112,8 @@ class SocketNotifier extends StateNotifier<Socket?> {
       return;
     }
 
-    var socketPort = (port == null || port == 0) ? (secure ? 443 : 80) : port;
-    var scheme = secure ? "wss" : "ws";
+    final int socketPort = (port == null || port == 0) ? (secure ? 443 : 80) : port!;
+    final scheme = secure ? 'wss' : 'ws';
     var url = "$scheme://$hostname:$socketPort";
     if (token != null) url += "?token=$token";
 


### PR DESCRIPTION
The web UI failed to connect to the WebSocket server when no port was specified, because the client appended an invalid `:0` port. This is fixed by explicitly using the default port when no port is provided: `443` for `wss://` and `80` for `ws://`.

Linked issue: https://github.com/rikulo/socket.io-client-dart/issues/222

To support more complex setups with custom public port, it would require to be able to specify a custom port or even let the user set the public address manually of both panel and websocket

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket connections now always include an explicit port (defaults to 443 for secure, 80 for non-secure) when none is provided, reducing connection ambiguity.
  * Scheme selection for sockets is now more consistent between secure and non-secure modes, improving connectivity reliability across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->