### PR TITLE
fix: avoid merging chat messages over the nbt size limit

### DIFF
--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/interaction/ChatHistoryHandler.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/interaction/ChatHistoryHandler.kt
@@ -255,7 +255,9 @@ class ChatHistory {
     fun shouldBlockMessage(): Boolean = blocking
 
     // Because addMessage is internal and is called after findMessage,
-    // it's never the case that we will get an oversized message
+    // individual messages passed here will not exceed NBT_SIZE_LIMIT.
+    // However, when messages are merged into batches elsewhere, those batches might exceed the limit,
+    // which is why batching logic exists outside this function.
     internal fun addMessage(message: Message) {
         message.onAddedToHistory(blocking)
         if (blocking) {


### PR DESCRIPTION
This PR fixes a bug in the chat history resend logic where messages were being merged into a single message, which could exceed the NBT size limit in some scenarios. Instead of merging all messages together, we now measure the NBT size of each message and check if adding it to the current batch would exceed the limit. If it would, we split the messages into multiple batches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Chat messages now include size-aware handling and smarter batching to prevent oversized packets, improving reliability during bulk message delivery.
  * Resend logic reorganized to merge and flush messages based on estimated payload size for more consistent performance under load.

* **Deprecations**
  * An internal message composition API has been deprecated (use newer delivery flow).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->