### PR TITLE
feat: add typewriter extensions info command

### DIFF
--- a/engine/engine-core/src/main/kotlin/com/typewritermc/core/extension/DependencyInject.kt
+++ b/engine/engine-core/src/main/kotlin/com/typewritermc/core/extension/DependencyInject.kt
@@ -25,7 +25,6 @@ import org.koin.core.qualifier.named
 import org.koin.core.scope.Scope
 import org.koin.dsl.binds
 import org.koin.dsl.module
-import java.util.logging.Logger
 import kotlin.reflect.KClass
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.findAnnotations
@@ -40,7 +39,7 @@ class DependencyInject : KoinComponent, Reloadable {
 
     override suspend fun load() {
         module = module {
-            extensionLoader.extensions.flatMap { it.dependencyInjections }
+            extensionLoader.loadedExtensions.flatMap { it.dependencyInjections }
                 .map { it to extensionLoader.loadClass(it.className) }
                 .forEach { (blueprint, clazz) ->
                     when (blueprint) {

--- a/engine/engine-loader/src/main/kotlin/com/typewritermc/loader/ExtensionLoader.kt
+++ b/engine/engine-loader/src/main/kotlin/com/typewritermc/loader/ExtensionLoader.kt
@@ -21,169 +21,329 @@ class ExtensionLoader : KoinComponent {
     private val dependencyChecker: DependencyChecker by inject()
     private val gson: Gson by inject(named("dataSerializer"))
     private val globalClassloader: ClassLoader by inject(named("globalClassloader"))
+
     private var classLoader: URLClassLoader? = null
-    var extensions: List<Extension> = emptyList()
-        private set
-    private var entryClasses: Map<String, Class<*>> = emptyMap()
+    private var entryClassCache: MutableMap<String, Class<*>> = mutableMapOf()
 
     // This value is not reset when the extensions are reloaded. Since we don't want to show the big message every time.
-    private var hasShownLoadedMessage = false
+    private var hasShownLoadMessage = false
+
+    var loadedExtensions: List<Extension.LoadedExtension> = emptyList()
+        private set
+
+    var failedExtensions: List<Extension.FailedExtension> = emptyList()
+        private set
+
+    var extensions: List<Extension> = emptyList()
+        private set
 
 
     // TODO: Remove this when the database update is implemented
     var extensionJson: JsonArray = JsonArray()
+        private set
 
-    fun readJsonTexts(json: List<String>): Map<Extension, String> = json.associateBy { extensionJson ->
-        try {
-            gson.fromJson(extensionJson, Extension::class.java)
-        } catch (e: JsonSyntaxException) {
-            logger.severe("Error while loading extension meta: ${e.message}")
-            null
-        }
-    }.filter { it.key != null } as Map<Extension, String>
-
+    /**
+     * Loads extensions from the provided JAR files.
+     * If extensions were previously loaded, they are unloaded first.
+     *
+     * @param jars List of JAR files to load as extensions
+     * @throws IllegalArgumentException if any file is not a readable JAR file
+     */
     fun load(jars: List<File>) {
-        jars.forEach { assert(it.exists() && it.canRead() && it.extension == "jar") }
+        require(jars.all { it.exists() && it.canRead() && it.extension.equals("jar", ignoreCase = true) }) {
+            "All files must be existing, readable JAR files"
+        }
 
         if (classLoader != null) {
             unload()
         }
+        entryClassCache.clear()
+
         classLoader = URLClassLoader(jars.map { it.toURI().toURL() }.toTypedArray(), globalClassloader)
 
-        // In all the jars, there is a file called "extension.json"
-        val extensionJsonTexts = jars.mapNotNull { jar ->
-            ZipFile(jar).use { zip ->
-                val jsonEntry = zip.getEntry("extension.json")
-                if (jsonEntry == null) {
-                    logger.severe("No extension.json file found in jar: ${jar.name}, is this a valid Typewriter extension?")
-                    return@mapNotNull null
-                }
-                zip.getInputStream(jsonEntry).bufferedReader().use { it.readText() }
-            }
+        val loadResults = ExtensionLoadPipeline(version, gson, dependencyChecker).load(jars)
+
+        loadedExtensions = loadResults.successful
+        failedExtensions = loadResults.failed
+        extensions = loadedExtensions + failedExtensions
+        extensionJson = JsonArray().apply {
+            loadResults.successful.forEach { add(JsonParser.parseString(it.jsonText)) }
         }
 
-        // TODO: Remove this when the database update is implemented
-        extensionJson = JsonArray()
-
-        val possibleExtensions = readJsonTexts(extensionJsonTexts).filter { (extension, _) ->
-            if (extension.extension.engineVersion != version) {
-                logger.warning("Extension '${extension.extension.name}Extension' was made for Typewriter ${extension.extension.engineVersion} but you are using Typewriter $version. Ignoring extension.")
-                return@filter false
-            }
-
-            val paper = extension.extension.paper
-            if (paper == null) {
-                logger.warning("Extension '${extension.extension.name}Extension' does not seem to be a paper extension. Ignoring extension.")
-                return@filter false
-            }
-
-            val dependencies = paper.dependencies
-            val missingDependencies = dependencies.filter { !dependencyChecker.hasDependency(it) }
-            if (missingDependencies.isNotEmpty()) {
-                val missing = missingDependencies.joinToString(", ")
-                logger.warning(
-                    "Extension '${extension.extension.name}Extension' is missing external dependencies: '${missing}'. Ignoring extension."
-                )
-                return@filter false
-            }
-
-            true
-        }
-
-        extensions = possibleExtensions
-            .filter { (extension, _) ->
-                // Check if the extension dependencies are met
-                val missingDependencies =
-                    extension.extension.dependencies.filter { (namespace, name) ->
-                        possibleExtensions.none { (extension, _) ->
-                            extension.extension.namespace == namespace && extension.extension.name == name
-                        }
-                    }
-
-                if (missingDependencies.isNotEmpty()) {
-                    val missing = missingDependencies.joinToString(", ") { "${it.namespace}:${it.name}Extension" }
-                    logger.warning(
-                        "Extension '${extension.extension.name}Extension' is missing extension dependencies: '${missing}'. Ignoring extension."
-                    )
-                    return@filter false
-                }
-                true
-            }
-            .map {
-                this.extensionJson.add(JsonParser.parseString(it.value))
-                it.key
-            }
-
-        if (hasShownLoadedMessage) return
-        hasShownLoadedMessage = true
-
-        if (extensions.isEmpty()) {
-            logger.warning(
-                """
-                |
-                |${"-".repeat(15)}{ No Extensions Loaded }${"-".repeat(15)}
-                |
-                |No extensions were loaded.
-                |You should always have at least the BasicExtension loaded.
-                |
-                |${"-".repeat(50)}
-                """.trimMargin()
-            )
-        } else {
-            val unsupportedMessage = if (extensions.any { it.extension.flags.contains(ExtensionFlag.Unsupported) }) {
-                "\nThere are unsupported extensions loaded. You won't get any support for these and should migrate from away them.\n"
-            } else {
-                ""
-            }
-            val maxExtensionLength = extensions.maxOf { it.extension.name.length }
-            val maxVersionLength = extensions.maxOf { it.extension.version.length }
-            val maxDigits = extensions.maxOf { it.entries.size.digits }
-            val extensionsDisplay = extensions.sortedBy { it.extension.name }
-                .joinToString("\n") { it.displayString(maxExtensionLength, maxVersionLength, maxDigits) }
-            logger.info(
-                """
-                |
-                |${"-".repeat(15)}{ Loaded Extensions }${"-".repeat(15)}
-                |
-                |${extensionsDisplay}
-                |$unsupportedMessage
-                |${"-".repeat(50)}
-                """.trimMargin()
-            )
+        if (!hasShownLoadMessage) {
+            hasShownLoadMessage = true
+            displayLoadResults(loadResults)
         }
     }
 
     fun entryClass(blueprintId: String): Class<*>? {
-        val entryClass = entryClasses[blueprintId]
-        if (entryClass != null) return entryClass
+        entryClassCache[blueprintId]?.let { return it }
 
-        val entryClassName = extensions.firstNotNullOfOrNull { extension ->
-            extension.entries.firstOrNull { it.id == blueprintId }?.className
-        }
+        val entryClassName = loadedExtensions
+            .asSequence()
+            .flatMap { it.entries.asSequence() }
+            .firstOrNull { it.id == blueprintId }
+            ?.className
+            ?: return null
 
-        if (entryClassName == null) {
-            return null
-        }
-
-        return loadClass(entryClassName)
+        val clazz = loadClass(entryClassName)
+        entryClassCache[blueprintId] = clazz
+        return clazz
     }
 
     fun loadClass(className: String): Class<*> {
-        classLoader?.let {
-            return it.loadClass(className)
-        }
-        throw IllegalStateException("ExtensionLoader tried to load a class before it was initialized")
+        return classLoader?.loadClass(className)
+            ?: throw IllegalStateException("Cannot load class '$className': ExtensionLoader not initialized")
     }
 
     fun unload() {
         classLoader?.close()
         classLoader = null
+        loadedExtensions = emptyList()
+        failedExtensions = emptyList()
         extensions = emptyList()
-        entryClasses = emptyMap()
+        extensionJson = JsonArray()
+        entryClassCache.clear()
+    }
+
+    private fun displayLoadResults(result: ExtensionLoadResult) {
+        val message = if (result.isEmpty) {
+            buildEmptyMessage()
+        } else {
+            buildResultMessage(result)
+        }
+        logger.info(message)
+    }
+
+    private fun buildEmptyMessage(): String = """
+        |
+        |${"-".repeat(15)}{ No Extensions Found }${"-".repeat(15)}
+        |
+        |No extension jars were found or loaded.
+        |You should always have at least the BasicExtension loaded.
+        |
+        |${"-".repeat(50)}
+    """.trimMargin()
+
+    private fun buildResultMessage(result: ExtensionLoadResult): String = buildString {
+        appendLine()
+        appendLine("${"-".repeat(18)}{ Extensions }${"-".repeat(18)}")
+        appendLine()
+
+        if (result.successful.isNotEmpty()) {
+            appendLine("Loaded:")
+
+            val maxExtensionLength = result.successful.maxOf { it.info.name.length }
+            val maxVersionLength = result.successful.maxOf { it.info.version.length }
+            val maxDigits = result.successful.maxOf { it.entries.size.digits }
+
+            result.successful.sortedBy { it.info.name }.forEach { ext ->
+                appendLine("  ${ext.displayString(maxExtensionLength, maxVersionLength, maxDigits)}")
+            }
+
+            val unsupported = result.successful.count {
+                it.info.flags.contains(ExtensionFlag.Unsupported)
+            }
+            if (unsupported > 0) {
+                appendLine()
+                appendLine(
+                    "⚠️ Unsupported extensions detected. " +
+                            "You won't receive support for these and should migrate away from them."
+                )
+            }
+        }
+
+        if (result.failed.isNotEmpty()) {
+            if (result.successful.isNotEmpty()) appendLine()
+            appendLine("Failed:")
+            result.failed.sortedBy { it.info?.name ?: it.jarName }.forEach { failure ->
+                appendLine("  ${failure.displayString()}")
+            }
+        }
+
+        appendLine()
+        appendLine("-".repeat(50))
     }
 }
 
-data class Extension(
+private class ExtensionLoadPipeline(
+    version: String,
+    private val gson: Gson,
+    dependencyChecker: DependencyChecker
+) {
+    val validator = ExtensionValidator(version, dependencyChecker)
+
+    fun load(jars: List<File>): ExtensionLoadResult {
+        val extensions = jars
+            .map { loadFromJar(it) }
+            .map { validator.validate(it) }
+            .validateExtensionDependencies()
+
+        return ExtensionLoadResult(
+            extensions.filterIsInstance<Extension.LoadedExtension>(),
+            extensions.filterIsInstance<Extension.FailedExtension>()
+        )
+    }
+
+    private fun loadFromJar(jar: File): Extension {
+        val jsonText = try {
+            ZipFile(jar).use { zip ->
+                val entry = zip.getEntry("extension.json") ?: return Extension.FailedExtension(
+                    jar.name,
+                    null,
+                    FailureReason.MissingJsonFile
+                )
+                zip.getInputStream(entry).bufferedReader().use { it.readText() }
+            }
+        } catch (e: Exception) {
+            return Extension.FailedExtension(
+                jar.name, null,
+                FailureReason.ReadError(e.message ?: "Failed to read jar")
+            )
+        }
+
+        return try {
+            val data = gson.fromJson(jsonText, ExtensionData::class.java)
+                ?: throw JsonSyntaxException("Parsed null extension")
+            Extension.LoadedExtension(
+                data.extension,
+                data.entries,
+                data.entryListeners,
+                data.typewriterCommands,
+                data.dependencyInjections,
+                jar.name,
+                jsonText
+            )
+        } catch (e: Exception) {
+            Extension.FailedExtension(
+                jar.name, null,
+                FailureReason.InvalidJson(e.message ?: "Unknown parsing error")
+            )
+        }
+    }
+
+    private fun List<Extension>.validateExtensionDependencies(): List<Extension> {
+        val todo = this.toMutableList()
+        val filtered = mutableListOf<Extension>()
+
+        while (todo.isNotEmpty()) {
+            val removedAny = todo.retainAll { extension ->
+                when (extension) {
+                    is Extension.LoadedExtension -> {
+                        extension.validateWithFilteredDependencies(filtered)?.let {
+                            filtered.add(it)
+                            return@retainAll false
+                        }
+
+                        extension.validateMissingDependencies(this)?.let {
+                            filtered.add(it)
+                            return@retainAll false
+                        }
+
+                        true
+                    }
+
+                    is Extension.FailedExtension -> {
+                        filtered.add(extension)
+                        false
+                    }
+                }
+            }
+
+            if (!removedAny) {
+                require(todo.all { it is Extension.LoadedExtension }) { "FailedExtensions should have been filtered properly" }
+                filtered.addAll(todo.map { extension ->
+                    val loadedExtension = (extension as Extension.LoadedExtension)
+                    val dependencies = loadedExtension.info.dependencies.joinToString { it.key }
+
+                    loadedExtension.asFailed(FailureReason.Undetermined("Could not resolve dependency situation for ${loadedExtension.info.key}! Likely due to a cyclic dependency: $dependencies"))
+                })
+                todo.clear()
+            }
+        }
+
+        return filtered
+    }
+
+    private fun Extension.LoadedExtension.validateWithFilteredDependencies(filtered: List<Extension>): Extension? {
+        val filteredDependencies = this.info.dependencies.map { dependency ->
+            filtered.firstOrNull { it.info?.key == dependency.key }
+        }
+        if (filteredDependencies.contains(null)) {
+            return null
+        }
+        val failedDependencies = filteredDependencies.filterIsInstance<Extension.FailedExtension>()
+        return if (failedDependencies.isEmpty()) {
+            this
+        } else {
+            this.asFailed(
+                FailureReason.ExtensionDependenciesFailed(
+                    failedDependencies
+                )
+            )
+        }
+    }
+
+    private fun Extension.LoadedExtension.validateMissingDependencies(possibleExtension: List<Extension>): Extension? {
+        val missingDependencies = this.info.dependencies.filter { dependency ->
+            possibleExtension.none { dependency.key == it.info?.key }
+        }
+        if (missingDependencies.isEmpty()) return null
+        return asFailed(
+            FailureReason.MissingExtensionDependencies(
+                missingDependencies
+            )
+        )
+    }
+}
+
+/** Validates version compatibility, platform support, and external plugin dependencies. */
+private class ExtensionValidator(
+    private val expectedVersion: String,
+    private val dependencyChecker: DependencyChecker
+) {
+    fun validate(extension: Extension): Extension {
+        if (extension !is Extension.LoadedExtension) return extension
+
+        val failureReason = validate(extension)
+        if (failureReason != null) {
+            return extension.asFailed(failureReason)
+        }
+        return extension
+    }
+
+    fun validate(extension: Extension.LoadedExtension): FailureReason? {
+        if (extension.info.engineVersion != expectedVersion) {
+            return FailureReason.VersionMismatch(
+                expected = expectedVersion,
+                found = extension.info.engineVersion
+            )
+        }
+
+        if (extension.info.paper == null) {
+            return FailureReason.NotPaperExtension
+        }
+
+        val missingDeps = extension.info.paper.dependencies
+            .filter { !dependencyChecker.hasDependency(it) }
+
+        if (missingDeps.isNotEmpty()) {
+            return FailureReason.MissingExternalDependencies(missingDeps)
+        }
+
+        return null
+    }
+}
+
+/** Final result after parsing, validation, and dependency resolution of all extensions. */
+data class ExtensionLoadResult(
+    val successful: List<Extension.LoadedExtension>,
+    val failed: List<Extension.FailedExtension>
+) {
+    val isEmpty: Boolean = successful.isEmpty() && failed.isEmpty()
+}
+
+private data class ExtensionData(
     val extension: ExtensionInfo,
     val entries: List<EntryInfo>,
     val entryListeners: List<EntryListenerInfo>,
@@ -191,6 +351,138 @@ data class Extension(
     val dependencyInjections: List<DependencyInjectionInfo>,
 )
 
+sealed interface Extension {
+    val jarName: String
+    val info: ExtensionInfo?
+
+    /**
+     * Represents a complete extension with all its components.
+     *
+     * @property info Core extension metadata
+     * @property entries List of entry blueprints provided by this extension
+     * @property entryListeners List of entry event listeners
+     * @property typewriterCommands List of custom commands
+     * @property dependencyInjections List of dependency injection definitions
+     */
+    data class LoadedExtension(
+        override val info: ExtensionInfo,
+        val entries: List<EntryInfo>,
+        val entryListeners: List<EntryListenerInfo>,
+        val typewriterCommands: List<TypewriterCommandInfo>,
+        val dependencyInjections: List<DependencyInjectionInfo>,
+        override val jarName: String,
+        /** Raw JSON for legacy database compatibility. */
+        val jsonText: String,
+    ) : Extension {
+        fun asFailed(reason: FailureReason): FailedExtension {
+            return FailedExtension(jarName, info, reason)
+        }
+    }
+
+    /** Extension that failed validation or dependency checks. */
+    data class FailedExtension(
+        override val jarName: String,
+        override val info: ExtensionInfo?,
+        val reason: FailureReason
+    ) : Extension
+}
+
+sealed class FailureReason(val message: String) {
+    /** Extension built for a different engine version with incompatible APIs. */
+    class VersionMismatch(expected: String, found: String) :
+        FailureReason("version mismatch, expected $expected found $found")
+
+    /** Extension targets a different platform. */
+    data object NotPaperExtension :
+        FailureReason("not a Paper extension")
+
+    /** Missing required plugin dependencies (e.g., Vault, PlaceholderAPI). */
+    class MissingExternalDependencies(dependencies: List<String>) :
+        FailureReason("missing dependencies: ${dependencies.joinToString(", ")}")
+
+    /** Missing required Typewriter extensions. */
+    class MissingExtensionDependencies(dependencies: List<ExtensionDependencyInfo>) :
+        FailureReason("missing extensions: ${dependencies.joinToString(", ") { "${it.namespace}:${it.name}" }}")
+
+    /** Transitive Typewriter extensions dependency failed to load. */
+    class ExtensionDependenciesFailed(dependencies: List<Extension.FailedExtension>) :
+        FailureReason(
+            "dependencies extensions: ${
+                dependencies.joinToString(", ") {
+                    "${it.info?.namespace}:${it.info?.name} failed to load because ${it.reason.message}"
+                }
+            }"
+        )
+
+    /** Malformed JSON syntax in extension.json. */
+    class InvalidJson(error: String) :
+        FailureReason("invalid JSON: $error")
+
+    /** I/O errors reading the JAR file itself. */
+    class ReadError(error: String) :
+        FailureReason("read error: $error")
+
+    /** JAR file missing the required extension.json manifest. */
+    data object MissingJsonFile :
+        FailureReason("missing extension.json file")
+
+    /** Undetermined error occurred. */
+    class Undetermined(error: String) :
+        FailureReason(error)
+}
+
+private fun Extension.LoadedExtension.displayString(
+    maxExtensionLength: Int,
+    maxVersionLength: Int,
+    maxDigits: Int
+): String {
+    val ext = info
+
+    var display = "${ext.name}Extension".rightPad(maxExtensionLength + "Extension".length)
+    display += " (${ext.version})".rightPad(maxVersionLength + 2)
+    display += padCount("📚", entries.size, maxDigits)
+    display += padCount("👂", entryListeners.size, maxDigits)
+    display += padCount("🔌", dependencyInjections.size, maxDigits)
+
+    val warnings = ext.flags.filter { it.warning.isNotBlank() }.joinToString { it.warning }
+    if (warnings.isNotBlank()) {
+        display += " ($warnings)"
+    }
+
+    return display
+}
+
+private fun Extension.FailedExtension.displayString(): String {
+    val name = info?.let { "${it.name}Extension" } ?: jarName
+    return "$name - (${reason.message})"
+}
+
+private fun padCount(prefix: String, count: Int, maxDigits: Int): String {
+    val padding = " ".repeat((maxDigits - count.digits).coerceAtLeast(0))
+    return " $prefix: $padding$count"
+}
+
+private fun String.rightPad(length: Int, padChar: Char = ' '): String {
+    return if (this.length >= length) this else this + padChar.toString().repeat(length - this.length)
+}
+
+private val Int.digits: Int
+    get() = if (this == 0) 1 else log10(abs(this.toDouble())).toInt() + 1
+
+
+/**
+ * Core metadata about an extension.
+ *
+ * @property name The display name of the extension
+ * @property shortDescription A brief description of the extension's purpose
+ * @property description A detailed description of the extension
+ * @property version The extension's semantic version
+ * @property engineVersion The required Typewriter engine version
+ * @property namespace The unique namespace for this extension
+ * @property flags Special flags indicating extension status (experimental, deprecated, etc.)
+ * @property dependencies Other extensions this extension depends on
+ * @property paper Paper-specific configuration and dependencies
+ */
 data class ExtensionInfo(
     val name: String = "",
     val shortDescription: String = "",
@@ -201,53 +493,54 @@ data class ExtensionInfo(
     val flags: List<ExtensionFlag> = emptyList(),
     val dependencies: List<ExtensionDependencyInfo> = emptyList(),
     val paper: PaperExtensionInfo? = null,
-)
+) {
+    val key get() = "$namespace:$name"
+}
 
+/**
+ * Identifies a dependency on another extension.
+ *
+ * @property namespace The namespace of the required extension
+ * @property name The name of the required extension
+ */
 data class ExtensionDependencyInfo(
     val namespace: String = "",
     val name: String = "",
-)
+) {
+    val key get() = "$namespace:$name"
+}
 
+/**
+ * Paper platform-specific extension configuration.
+ *
+ * @property dependencies List of Paper plugin dependencies required by this extension
+ */
 data class PaperExtensionInfo(
     val dependencies: List<String> = emptyList(),
 )
 
 /**
- * Returns a string that can be used to display information about the adapter.
- * It is nicely formatted to align the information between adapters.
+ * Metadata for an entry blueprint provided by an extension.
+ *
+ * @property id The unique blueprint identifier
+ * @property className The fully qualified class name implementing this entry
  */
-fun Extension.displayString(maxAdapterLength: Int, maxVersionLength: Int, maxDigits: Int): String {
-    var display = "${extension.name}Extension".rightPad(maxAdapterLength + "Extension".length)
-    display += " (${extension.version})".rightPad(maxVersionLength + 2)
-    display += padCount("📚", entries.size, maxDigits)
-    display += padCount("👂", entryListeners.size, maxDigits)
-    display += padCount("🔌", dependencyInjections.size, maxDigits)
-
-    extension.flags.filter { it.warning.isNotBlank() }.joinToString { it.warning }.let {
-        if (it.isNotBlank()) {
-            display += " ($it)"
-        }
-    }
-
-    return display
-}
-
-private fun padCount(prefix: String, count: Int, maxDigits: Int): String {
-    return " ${prefix}: ${" ".repeat((maxDigits - count.digits).coerceAtLeast(0))}$count"
-}
-
-private fun String.rightPad(length: Int, padChar: Char = ' '): String {
-    return if (this.length >= length) this else this + padChar.toString().repeat(length - this.length)
-}
-
-private val Int.digits: Int
-    get() = if (this == 0) 1 else log10(abs(this.toDouble())).toInt() + 1
-
 data class EntryInfo(
     val id: String,
     val className: String,
 )
 
+/**
+ * Metadata for an event listener on an entry.
+ *
+ * @property entryBlueprintId The blueprint ID this listener is attached to
+ * @property entryClassName The entry class name
+ * @property className The listener class name
+ * @property methodName The listener method name
+ * @property priority The event priority
+ * @property ignoreCancelled Whether to ignore cancelled events
+ * @property arguments The method arguments
+ */
 data class EntryListenerInfo(
     val entryBlueprintId: String,
     val entryClassName: String,
@@ -258,11 +551,25 @@ data class EntryListenerInfo(
     val arguments: List<String>,
 )
 
+/**
+ * Metadata for a custom Typewriter command.
+ *
+ * @property className The class containing the command
+ * @property methodName The method implementing the command logic
+ */
 data class TypewriterCommandInfo(
     val className: String,
     val methodName: String,
 )
 
+/**
+ * Metadata for dialogue messenger implementations.
+ *
+ * @property entryBlueprintId The associated entry blueprint
+ * @property entryClassName The entry class name
+ * @property className The messenger class name
+ * @property priority The messenger priority
+ */
 data class DialogueMessengerInfo(
     val entryBlueprintId: String,
     val entryClassName: String,
@@ -270,18 +577,31 @@ data class DialogueMessengerInfo(
     val priority: Int,
 )
 
+/**
+ * Base interface for dependency injection definitions.
+ *
+ * @property className The class being injected
+ * @property type The injection type (singleton or factory)
+ * @property name Optional qualifier name for the injection
+ */
 sealed interface DependencyInjectionInfo {
     val className: String
     val type: SerializableType
     val name: String?
 }
 
+/**
+ * Dependency injection for a class.
+ */
 data class DependencyInjectionClassInfo(
     override val className: String,
     override val type: SerializableType,
     override val name: String?,
 ) : DependencyInjectionInfo
 
+/**
+ * Dependency injection for a method that provides a dependency.
+ */
 data class DependencyInjectionMethodInfo(
     override val className: String,
     val methodName: String,
@@ -289,15 +609,26 @@ data class DependencyInjectionMethodInfo(
     override val name: String?,
 ) : DependencyInjectionInfo
 
-
+/**
+ * Specifies how a dependency should be instantiated and managed.
+ */
 enum class SerializableType {
+    /**
+     * Single instance shared across all consumers.
+     */
     @SerializedName("singleton")
     SINGLETON,
 
+    /**
+     * New instance created for each consumer.
+     */
     @SerializedName("factory")
     FACTORY,
 }
 
+/**
+ * Special flags indicating an extension's support status or characteristics.
+ */
 enum class ExtensionFlag(val warning: String) {
     /**
      * The extension is not tested and may not work.

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/command/dsl/PaperDsl.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/command/dsl/PaperDsl.kt
@@ -4,6 +4,7 @@ package com.typewritermc.engine.paper.command.dsl
 
 import com.typewritermc.core.entries.Entry
 import com.typewritermc.engine.paper.utils.msg
+import com.typewritermc.loader.Extension
 import io.papermc.paper.command.brigadier.CommandSourceStack
 import io.papermc.paper.command.brigadier.argument.ArgumentTypes
 import io.papermc.paper.command.brigadier.argument.resolvers.selector.PlayerSelectorArgumentResolver
@@ -67,3 +68,8 @@ inline fun <reified E : Entry> CommandTree.entry(
     noinline filter: Predicate<E> = { true },
     noinline block: ArgumentBlock<CommandSourceStack, E> = {},
 ) = argument(name, EntryArgumentType(E::class, filter), E::class, block)
+
+inline fun <reified E : Extension> CommandTree.extension(
+    name: String,
+    noinline block: ArgumentBlock<CommandSourceStack, E> = {},
+) = argument(name, ExtensionArgumentType(E::class), E::class, block)

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/EntryListeners.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/EntryListeners.kt
@@ -45,7 +45,7 @@ class EntryListeners : KoinComponent, Reloadable {
      * Registers all the entry listeners.
      */
     override suspend fun load() {
-        val entryListeners = extensionLoader.extensions.flatMap { it.entryListeners }
+        val entryListeners = extensionLoader.loadedExtensions.flatMap { it.entryListeners }
 
         val activeEventEntries = Query.find<EventEntry>().map { it::class }.distinct()
 

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/extensions/bstats/BStatsMetrics.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/extensions/bstats/BStatsMetrics.kt
@@ -23,7 +23,7 @@ object BStatsMetrics {
         }
 
         metrics.addCustomChart(AdvancedPie("extensions") {
-            get<ExtensionLoader>(ExtensionLoader::class.java).extensions.associate { it.extension.name to 1 }.toMap()
+            get<ExtensionLoader>(ExtensionLoader::class.java).loadedExtensions.associate { it.info.name to 1 }.toMap()
         })
 
         metrics.addCustomChart(AdvancedPie("entries") {


### PR DESCRIPTION
This pull request adds a new `extensions` command that gives users visibility into their loaded extensions and helps them troubleshoot loading issues. The command allows players to run `/tw extensions` to see a summary of all loaded and failed extensions at a glance, or `/tw extensions info <extension_name>` to dive into the details of a specific extension.

On the backend, the extension loader has been significantly refactored to properly track extensions that fail to load and capture detailed information about why they failed. Previously, failed extensions would simply be ignored with log messages, but now they're retained in a `failedExtensions` list that the command can query. This means users can check the status of extensions even after the server has already booted, without having to dig through logs.

The new command displays loaded extensions with their versions and highlights any unsupported extensions that require user attention. For failed extensions, it shows the specific reason for the failure, whether that's a version mismatch, missing dependencies, invalid JSON, or other issues. The extension loader has been reorganized into separate components like `ExtensionLoadPipeline`, `ExtensionValidator`, and various sealed classes to represent different failure scenarios, making the code easier to maintain and extend.

The command output is formatted with colors and interactive elements for better readability, and users can click on extensions in the list to jump to more detailed information about that specific extension.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extensions command: rich listing and inspect views for loaded vs failed extensions; per-extension detail view.
  * Command DSL: select extensions as command arguments with name/key suggestions and validation.

* **Improvements**
  * Centralized extension loading with deterministic dependency resolution and clearer failure reasons.
  * Enhanced extension metadata and flags (Untested/Deprecated/Unsupported) surfaced in UI.
  * Metrics now report only loaded extensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->