### PR TITLE
feat: add restore velocity option after cinematic finishes

### DIFF
--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/temporal/TemporalInteraction.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/temporal/TemporalInteraction.kt
@@ -12,7 +12,9 @@ import com.typewritermc.engine.paper.entry.entries.CinematicAction
 import com.typewritermc.engine.paper.entry.entries.CinematicEntry
 import com.typewritermc.engine.paper.entry.entries.EventTrigger
 import com.typewritermc.engine.paper.entry.matches
-import com.typewritermc.engine.paper.entry.temporal.TemporalState.*
+import com.typewritermc.engine.paper.entry.temporal.TemporalState.ENDING
+import com.typewritermc.engine.paper.entry.temporal.TemporalState.PLAYING
+import com.typewritermc.engine.paper.entry.temporal.TemporalState.STARTING
 import com.typewritermc.engine.paper.entry.triggerFor
 import com.typewritermc.engine.paper.events.AsyncCinematicEndEvent
 import com.typewritermc.engine.paper.events.AsyncCinematicStartEvent

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/utils/PlayerState.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/utils/PlayerState.kt
@@ -11,6 +11,7 @@ import com.github.retrooper.packetevents.util.Dummy
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetSlot
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerTimeUpdate
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerWindowItems
+import com.typewritermc.core.utils.point.Vector
 import com.typewritermc.engine.paper.extensions.packetevents.sendPacketTo
 import com.typewritermc.engine.paper.interaction.InterceptionBundle
 import com.typewritermc.engine.paper.plugin
@@ -45,6 +46,7 @@ enum class GenericPlayerStateProvider(private val store: Player.() -> Any, priva
         resetPlayerTime()
         WrapperPlayServerTimeUpdate(world.gameTime, playerTime).sendPacketTo(this)
     }),
+    VELOCITY({ velocity.toVector() }, { velocity = (it as Vector).toBukkitVector() }),
 
     // All Players that are visible to the player
     VISIBLE_PLAYERS({
@@ -122,6 +124,10 @@ fun Player.state(vararg keys: PlayerStateProvider): PlayerState = state(keys)
 
 @JvmName("stateArray")
 fun Player.state(keys: Array<out PlayerStateProvider>): PlayerState {
+    return PlayerState(keys.associateWith { it.store(this) })
+}
+
+fun Player.state(keys: List<PlayerStateProvider>): PlayerState {
     return PlayerState(keys.associateWith { it.store(this) })
 }
 

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/cinematic/CameraCinematicEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/cinematic/CameraCinematicEntry.kt
@@ -82,6 +82,7 @@ class CameraCinematicEntry(
     @Segments(icon = "fa6-solid:video")
     @InnerMin(Min(10))
     val segments: List<CameraSegment> = emptyList(),
+    val advancedCameraSettings: AdvancedCameraSettings = AdvancedCameraSettings(),
 ) : PrimaryCinematicEntry {
     override fun create(player: Player): CinematicAction {
         return CameraCinematicAction(
@@ -105,6 +106,16 @@ data class CameraSegment(
     override val endFrame: Int = 0,
     val path: List<PathPoint> = emptyList(),
 ) : Segment
+
+/**
+ * Advanced settings for camera cinematics.
+ *
+ * @property restoreVelocity When true, restores the player's velocity to its pre-cinematic value
+ *                           after the cinematic finishes.
+ */
+data class AdvancedCameraSettings(
+    val restoreVelocity: Boolean = false
+)
 
 data class PathPoint(
     @WithRotation
@@ -187,12 +198,15 @@ class CameraCinematicAction(
 
         if (originalState == null) {
             originalState = state(
-                LOCATION,
-                ALLOW_FLIGHT,
-                FLYING,
-                VISIBLE_PLAYERS,
-                SHOWING_PLAYER,
-                EffectStateProvider(INVISIBILITY)
+                listOfNotNull(
+                    LOCATION,
+                    ALLOW_FLIGHT,
+                    FLYING,
+                    VISIBLE_PLAYERS,
+                    SHOWING_PLAYER,
+                    EffectStateProvider(INVISIBILITY),
+                    VELOCITY.takeIf { entry.advancedCameraSettings.restoreVelocity }
+                )
             )
             context[PlayerPositionOverride] = position
         }


### PR DESCRIPTION
This PR adds the option to restore the player's velocity to its pre-cinematic value after the cinematic finishes. By default this is set to false to avoid breaking existing setups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advanced camera cinematic settings: creators can opt to restore player velocity when a cinematic ends, preserving movement state during transitions.
  * Player state composition: state can now include velocity as part of saved/restored player state and supports composing state from a list of components for finer control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds advanced camera settings with an option to restore player velocity post-cinematic, backed by a new VELOCITY PlayerState and list-based state capture.
> 
> - **Cinematics**:
>   - `CameraCinematicEntry`: Introduces `advancedCameraSettings` with `restoreVelocity`; conditionally captures/restores `VELOCITY` during setup/teardown.
> - **Player State Utilities**:
>   - `PlayerState`: Adds `VELOCITY` provider and `state(keys: List<PlayerStateProvider>)` overload to capture/restore velocity and support dynamic key lists.
> - **Misc**:
>   - `TemporalInteraction`: Replaces wildcard import with explicit `TemporalState` constants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fec5d7f5897d7dd9d3880a05f861ab92b360e40f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->