### PR TITLE
refactor: improve extension version mismatch error message

### DIFF
--- a/engine/engine-loader/src/main/kotlin/com/typewritermc/loader/ExtensionLoader.kt
+++ b/engine/engine-loader/src/main/kotlin/com/typewritermc/loader/ExtensionLoader.kt
@@ -390,7 +390,7 @@ sealed interface Extension {
 sealed class FailureReason(val message: String) {
     /** Extension built for a different engine version with incompatible APIs. */
     class VersionMismatch(expected: String, found: String) :
-        FailureReason("version mismatch, expected $expected found $found")
+        FailureReason("version mismatch, typewriter version is $expected but extension was made for $found")
 
     /** Extension targets a different platform. */
     data object NotPaperExtension :


### PR DESCRIPTION
Improve the clarity of the version mismatch error message when loading extensions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clarity of version compatibility error messages to better communicate which version of Typewriter is required and which version an extension was built for.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->