### PR TITLE
Add left-click and right-click as valid ConfirmationKey options

### DIFF
--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/dialogue/ConfirmationKey.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/dialogue/ConfirmationKey.kt
@@ -14,7 +14,7 @@ import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
 import org.bukkit.event.block.Action
-import org.bukkit.event.player.PlayerInteractEventhowe
+import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.event.player.PlayerSwapHandItemsEvent
 import org.bukkit.event.player.PlayerToggleSneakEvent
 import org.bukkit.inventory.EquipmentSlot
@@ -50,8 +50,8 @@ enum class ConfirmationKey(val keybind: String) {
             SWAP_HANDS -> SwapHandsHandler(player, block)
             JUMP -> JumpHandler(player, block)
             SNEAK -> SneakHandler(player, block)
-            LEFT_CLICK -> LeftClickHandler(player, block)
-            RIGHT_CLICK -> RightClickHandler(player, block)
+            LEFT_CLICK -> ClickHandler(player, block, Action.LEFT_CLICK_AIR, Action.LEFT_CLICK_BLOCK)
+            RIGHT_CLICK -> ClickHandler(player, block, Action.RIGHT_CLICK_AIR, Action.RIGHT_CLICK_BLOCK)
         }.apply { initialize() }
     }
 
@@ -117,24 +117,14 @@ class SneakHandler(override val player: Player, override val block: () -> Unit) 
     }
 }
 
-class LeftClickHandler(override val player: Player, override val block: () -> Unit) : ConfirmationKeyHandler {
+class ClickHandler(override val player: Player, override val block: () -> Unit, vararg val actions: Action) : ConfirmationKeyHandler {
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     fun onInteract(event: PlayerInteractEvent) {
         if (event.player.uniqueId != player.uniqueId) return
         if (event.hand != EquipmentSlot.HAND) return
-        if (event.action != Action.LEFT_CLICK_AIR && event.action != Action.LEFT_CLICK_BLOCK) return
+        if (event.action !in actions) return
         event.isCancelled = true
         block()
     }
 }
 
-class RightClickHandler(override val player: Player, override val block: () -> Unit) : ConfirmationKeyHandler {
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    fun onInteract(event: PlayerInteractEvent) {
-        if (event.player.uniqueId != player.uniqueId) return
-        if (event.hand != EquipmentSlot.HAND) return
-        if (event.action != Action.RIGHT_CLICK_AIR && event.action != Action.RIGHT_CLICK_BLOCK) return
-        event.isCancelled = true
-        block()
-    }
-}

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/dialogue/ConfirmationKey.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/dialogue/ConfirmationKey.kt
@@ -13,8 +13,12 @@ import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
+import org.bukkit.event.block.Action
+import org.bukkit.event.player.PlayerInteractEventhowe
 import org.bukkit.event.player.PlayerSwapHandItemsEvent
 import org.bukkit.event.player.PlayerToggleSneakEvent
+import org.bukkit.inventory.EquipmentSlot
+
 
 private val confirmationKeyString by config(
     "confirmationKey", ConfirmationKey.JUMP.name, comment = """
@@ -37,6 +41,8 @@ enum class ConfirmationKey(val keybind: String) {
     JUMP("<key:key.jump>"),
     SWAP_HANDS("<key:key.swapOffhand>"),
     SNEAK("<key:key.sneak>"),
+    LEFT_CLICK("<key:key.attack>"),
+    RIGHT_CLICK("<key:key.use>"),
     ;
 
     fun handler(player: Player, block: () -> Unit): ConfirmationKeyHandler {
@@ -44,6 +50,8 @@ enum class ConfirmationKey(val keybind: String) {
             SWAP_HANDS -> SwapHandsHandler(player, block)
             JUMP -> JumpHandler(player, block)
             SNEAK -> SneakHandler(player, block)
+            LEFT_CLICK -> LeftClickHandler(player, block)
+            RIGHT_CLICK -> RightClickHandler(player, block)
         }.apply { initialize() }
     }
 
@@ -104,6 +112,28 @@ class SneakHandler(override val player: Player, override val block: () -> Unit) 
     fun onSneak(event: PlayerToggleSneakEvent) {
         if (event.player.uniqueId != player.uniqueId) return
         if (!event.isSneaking) return
+        event.isCancelled = true
+        block()
+    }
+}
+
+class LeftClickHandler(override val player: Player, override val block: () -> Unit) : ConfirmationKeyHandler {
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    fun onInteract(event: PlayerInteractEvent) {
+        if (event.player.uniqueId != player.uniqueId) return
+        if (event.hand != EquipmentSlot.HAND) return
+        if (event.action != Action.LEFT_CLICK_AIR && event.action != Action.LEFT_CLICK_BLOCK) return
+        event.isCancelled = true
+        block()
+    }
+}
+
+class RightClickHandler(override val player: Player, override val block: () -> Unit) : ConfirmationKeyHandler {
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    fun onInteract(event: PlayerInteractEvent) {
+        if (event.player.uniqueId != player.uniqueId) return
+        if (event.hand != EquipmentSlot.HAND) return
+        if (event.action != Action.RIGHT_CLICK_AIR && event.action != Action.RIGHT_CLICK_BLOCK) return
         event.isCancelled = true
         block()
     }


### PR DESCRIPTION
Adds support for using LEFT_CLICK and RIGHT_CLICK as ConfirmationKey.
Updated ConfirmationKey.kt accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added left-click and right-click confirmation options for interactive dialogues.
  * Click confirmations work for both air and block interactions and now intercept the click to trigger the confirmation action without performing the default click behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->