### PR TITLE
Add SetFakeBlockAudienceEntry

### DIFF
--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/SetFakeBlockAudienceEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/SetFakeBlockAudienceEntry.kt
@@ -2,21 +2,12 @@ package com.typewritermc.basic.entries.audience
 
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerBlockChange
 import com.typewritermc.core.books.pages.Colors
-import com.typewritermc.core.extension.annotations.Entry
-import com.typewritermc.core.extension.annotations.Help
-import com.typewritermc.core.extension.annotations.MaterialProperties
-import com.typewritermc.core.extension.annotations.MaterialProperty
+import com.typewritermc.core.extension.annotations.*
 import com.typewritermc.core.utils.point.Position
-import com.typewritermc.engine.paper.entry.entries.AudienceDisplay
-import com.typewritermc.engine.paper.entry.entries.AudienceEntry
-import com.typewritermc.engine.paper.entry.entries.ConstVar
-import com.typewritermc.engine.paper.entry.entries.TickableDisplay
-import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.entry.entries.*
 import com.typewritermc.engine.paper.extensions.packetevents.sendPacketTo
 import com.typewritermc.engine.paper.interaction.interactionContext
-import com.typewritermc.engine.paper.utils.server
-import com.typewritermc.engine.paper.utils.toBukkitLocation
-import com.typewritermc.engine.paper.utils.toPacketVector3i
+import com.typewritermc.engine.paper.utils.*
 import io.github.retrooper.packetevents.util.SpigotConversionUtil
 import org.bukkit.Material
 import org.bukkit.entity.Player
@@ -39,12 +30,10 @@ class SetFakeBlockAudienceEntry(
     @Help("The block to fake.")
     val block: Var<Material> = ConstVar(Material.AIR),
 ) : AudienceEntry {
-    override suspend fun display(): AudienceDisplay {
-        return SetFakeBlockDisplay(location, block)
-    }
+    override suspend fun display() = SetFakeBlockDisplay(location, block)
 }
 
-private data class PlayerBlockState(
+private data class PlayerBlock(
     val position: Position,
     val material: Material
 )
@@ -53,22 +42,20 @@ class SetFakeBlockDisplay(
     private val position: Var<Position>,
     private val block: Var<Material>,
 ) : AudienceDisplay(), TickableDisplay {
-    private val blocks = ConcurrentHashMap<UUID, PlayerBlockState>()
+    private val blocks = ConcurrentHashMap<UUID, PlayerBlock>()
 
     override fun tick() {
-        for ((playerId, state) in blocks) {
-            val player = server.getPlayer(playerId) ?: continue
+        blocks.forEach { (playerId, state) ->
+            val player = server.getPlayer(playerId) ?: return@forEach
             val context = player.interactionContext
-
             val currentPosition = position.get(player, context)
             val currentMaterial = block.get(player, context)
-
             val realBlock = currentPosition.toBukkitLocation().block.type
 
-            if ((currentPosition != state.position) || (currentMaterial != state.material)) {
-                resetBlockChange(player, state.position)
+            if (currentPosition != state.position || currentMaterial != state.material) {
+                sendBlockChange(player, state.position, state.position.toBukkitLocation().block.type)
                 sendBlockChange(player, currentPosition, currentMaterial)
-                blocks[playerId] = PlayerBlockState(currentPosition, currentMaterial)
+                blocks[playerId] = PlayerBlock(currentPosition, currentMaterial)
             } else if (realBlock != currentMaterial) {
                 sendBlockChange(player, currentPosition, currentMaterial)
             }
@@ -79,27 +66,18 @@ class SetFakeBlockDisplay(
         val context = player.interactionContext
         val position = position.get(player, context)
         val material = block.get(player, context)
-
-        blocks[player.uniqueId] = PlayerBlockState(position, material)
+        blocks[player.uniqueId] = PlayerBlock(position, material)
         sendBlockChange(player, position, material)
     }
 
     override fun onPlayerRemove(player: Player) {
-        val state = blocks.remove(player.uniqueId) ?: return
-        val position = state.position
-        resetBlockChange(player, position)
+        blocks.remove(player.uniqueId)?.let { sendBlockChange(player, it.position, it.position.toBukkitLocation().block.type) }
     }
 
     private fun sendBlockChange(player: Player, position: Position, material: Material) {
-        val packet = WrapperPlayServerBlockChange(
+        WrapperPlayServerBlockChange(
             position.toPacketVector3i(),
             SpigotConversionUtil.fromBukkitBlockData(material.createBlockData())
-        )
-        packet.sendPacketTo(player)
-    }
-
-    private fun resetBlockChange(player: Player, position: Position) {
-        val bukkitLocation = position.toBukkitLocation()
-        player.sendBlockChange(bukkitLocation, bukkitLocation.block.blockData)
+        ).sendPacketTo(player)
     }
 }

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/SetFakeBlockAudienceEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/SetFakeBlockAudienceEntry.kt
@@ -4,6 +4,8 @@ import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerBl
 import com.typewritermc.core.books.pages.Colors
 import com.typewritermc.core.extension.annotations.Entry
 import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.core.extension.annotations.MaterialProperties
+import com.typewritermc.core.extension.annotations.MaterialProperty
 import com.typewritermc.core.utils.point.Position
 import com.typewritermc.engine.paper.entry.entries.AudienceDisplay
 import com.typewritermc.engine.paper.entry.entries.AudienceEntry
@@ -33,7 +35,8 @@ class SetFakeBlockAudienceEntry(
     override val name: String = "",
     @Help("The location where the fake block will be set")
     val location: Var<Position> = ConstVar(Position.ORIGIN),
-    @Help("The fake block material to set.")
+    @MaterialProperties(MaterialProperty.BLOCK)
+    @Help("The block to fake.")
     val block: Var<Material> = ConstVar(Material.AIR),
 ) : AudienceEntry {
     override suspend fun display(): AudienceDisplay {
@@ -60,9 +63,14 @@ class SetFakeBlockDisplay(
             val currentPosition = position.get(player, context)
             val currentMaterial = block.get(player, context)
 
-            if (currentPosition != state.position || currentMaterial != state.material) {
+            val realBlock = currentPosition.toBukkitLocation().block.type
+
+            if ((currentPosition != state.position) || (currentMaterial != state.material)) {
+                resetBlockChange(player, state.position)
                 sendBlockChange(player, currentPosition, currentMaterial)
                 blocks[playerId] = PlayerBlockState(currentPosition, currentMaterial)
+            } else if (realBlock != currentMaterial) {
+                sendBlockChange(player, currentPosition, currentMaterial)
             }
         }
     }
@@ -78,8 +86,8 @@ class SetFakeBlockDisplay(
 
     override fun onPlayerRemove(player: Player) {
         val state = blocks.remove(player.uniqueId) ?: return
-        val originalBlock = state.position.toBukkitLocation().block
-        sendBlockChange(player, state.position, originalBlock.type)
+        val position = state.position
+        resetBlockChange(player, position)
     }
 
     private fun sendBlockChange(player: Player, position: Position, material: Material) {
@@ -88,5 +96,10 @@ class SetFakeBlockDisplay(
             SpigotConversionUtil.fromBukkitBlockData(material.createBlockData())
         )
         packet.sendPacketTo(player)
+    }
+
+    private fun resetBlockChange(player: Player, position: Position) {
+        val bukkitLocation = position.toBukkitLocation()
+        player.sendBlockChange(bukkitLocation, bukkitLocation.block.blockData)
     }
 }

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/SetFakeBlockAudienceEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/SetFakeBlockAudienceEntry.kt
@@ -1,0 +1,92 @@
+package com.typewritermc.basic.entries.audience
+
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerBlockChange
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.engine.paper.entry.entries.AudienceDisplay
+import com.typewritermc.engine.paper.entry.entries.AudienceEntry
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.TickableDisplay
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.extensions.packetevents.sendPacketTo
+import com.typewritermc.engine.paper.interaction.interactionContext
+import com.typewritermc.engine.paper.utils.server
+import com.typewritermc.engine.paper.utils.toBukkitLocation
+import com.typewritermc.engine.paper.utils.toPacketVector3i
+import io.github.retrooper.packetevents.util.SpigotConversionUtil
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+@Entry("set_fake_block_audience", "Set a fake block for an audience", Colors.GREEN, "mingcute:cube-3d-fill")
+/**
+ * The `SetFakeBlockAudienceEntry` is an audience entry that would set a fake block.
+ *
+ * ## How could this be used?
+ * This could be used to create illusions or special effects for players.
+ */
+class SetFakeBlockAudienceEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("The location where the fake block will be set")
+    val location: Var<Position> = ConstVar(Position.ORIGIN),
+    @Help("The fake block material to set.")
+    val block: Var<Material> = ConstVar(Material.AIR),
+) : AudienceEntry {
+    override suspend fun display(): AudienceDisplay {
+        return SetFakeBlockDisplay(location, block)
+    }
+}
+
+private data class PlayerBlockState(
+    val position: Position,
+    val material: Material
+)
+
+class SetFakeBlockDisplay(
+    private val position: Var<Position>,
+    private val block: Var<Material>,
+) : AudienceDisplay(), TickableDisplay {
+    private val blocks = ConcurrentHashMap<UUID, PlayerBlockState>()
+
+    override fun tick() {
+        for ((playerId, state) in blocks) {
+            val player = server.getPlayer(playerId) ?: continue
+            val context = player.interactionContext
+
+            val currentPosition = position.get(player, context)
+            val currentMaterial = block.get(player, context)
+
+            if (currentPosition != state.position || currentMaterial != state.material) {
+                sendBlockChange(player, currentPosition, currentMaterial)
+                blocks[playerId] = PlayerBlockState(currentPosition, currentMaterial)
+            }
+        }
+    }
+
+    override fun onPlayerAdd(player: Player) {
+        val context = player.interactionContext
+        val position = position.get(player, context)
+        val material = block.get(player, context)
+
+        blocks[player.uniqueId] = PlayerBlockState(position, material)
+        sendBlockChange(player, position, material)
+    }
+
+    override fun onPlayerRemove(player: Player) {
+        val state = blocks.remove(player.uniqueId) ?: return
+        val originalBlock = state.position.toBukkitLocation().block
+        sendBlockChange(player, state.position, originalBlock.type)
+    }
+
+    private fun sendBlockChange(player: Player, position: Position, material: Material) {
+        val packet = WrapperPlayServerBlockChange(
+            position.toPacketVector3i(),
+            SpigotConversionUtil.fromBukkitBlockData(material.createBlockData())
+        )
+        packet.sendPacketTo(player)
+    }
+}


### PR DESCRIPTION
Heya!
I've noticed that many people sometimes only want to change one or two blocks during their interactions. This means they have to use the ``FastAsyncWorldEditExtension`` to do something that doesn't even use FastAsyncWorldEdit to work (which I don't mind, on the contrary :p but it could be simplified).
Furthermore, given the existence of ``SetFakeBlockCinematicEntry``, this seems like a rather logical addition to me.
I hope you like it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audience extension to display fake blocks to targeted players.
  * Configurable block material and position per entry.
  * Per-player, real-time synchronization keeps each viewer’s block state consistent.
  * Automatically sends updates when configuration or the real-world block changes.
  * Initializes and resets per-player state on join/leave.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->