### PR TITLE
Location Completable Objective

### DIFF
--- a/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/entries/audience/LocationCompletableObjectivesPathStream.kt
+++ b/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/entries/audience/LocationCompletableObjectivesPathStream.kt
@@ -1,0 +1,66 @@
+package com.typewritermc.quest.entries.audience
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Query
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.entries.emptyRef
+import com.typewritermc.core.entries.ref
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.engine.paper.entry.descendants
+import com.typewritermc.engine.paper.entry.entries.AudienceDisplay
+import com.typewritermc.engine.paper.entry.entries.AudienceEntry
+import com.typewritermc.engine.paper.entry.matches
+import com.typewritermc.quest.entries.audience.objectives.LocationCompletableObjectiveEntry
+import com.typewritermc.quest.entries.trackedShowingObjectives
+import com.typewritermc.roadnetwork.RoadNetworkEntry
+import com.typewritermc.roadnetwork.entries.MultiPathStreamDisplay
+import com.typewritermc.roadnetwork.entries.PathStreamDisplayEntry
+import com.typewritermc.roadnetwork.entries.StreamProducer
+import com.typewritermc.roadnetwork.entries.highestPathStreamDisplayEntry
+
+@Entry(
+    "location_completable_objectives_path_stream",
+    "A Path Stream to tracked Completable Location Objectives",
+    Colors.GREEN,
+    "material-symbols:conversion-path"
+)
+/**
+ * The `Location Completable Objectives Path Stream` entry is a path stream that shows the path to each tracked location objective.
+ * When the player has a location objective, and the quest for the objective is tracked, a path stream will be displayed.
+ *
+ * ## How could this be used?
+ * This could be used to show a path to each location objective in a quest.
+ */
+class LocationCompletableObjectivesPathStream(
+    override val id: String = "",
+    override val name: String = "",
+    val display: Ref<PathStreamDisplayEntry> = emptyRef(),
+    val road: Ref<RoadNetworkEntry> = emptyRef(),
+) : AudienceEntry {
+    // As displays and references can't change (except between reloads) we can just cache all relevant ones here for quick access.
+    private val objectiveDisplays: Map<Ref<LocationCompletableObjectiveEntry>, List<Ref<PathStreamDisplayEntry>>> by lazy(
+        LazyThreadSafetyMode.NONE
+    ) {
+        Query.findWhere<LocationCompletableObjectiveEntry>() { true }.associate { objective ->
+            val displays = mutableListOf<Ref<PathStreamDisplayEntry>>()
+
+            displays.addAll(objective.descendants(PathStreamDisplayEntry::class))
+            displays.addAll(objective.quest.descendants(PathStreamDisplayEntry::class))
+            displays.add(display)
+
+            objective.ref() to displays
+        }
+    }
+
+    override suspend fun display(): AudienceDisplay = MultiPathStreamDisplay(road, streams = { player ->
+        player.trackedShowingObjectives().filterIsInstance<LocationCompletableObjectiveEntry>()
+            .filter { objective -> !objective.completedCriteria.matches(player) } // Skip if objective is completed
+            .map { objective ->
+                StreamProducer(
+                    objective.id,
+                    objectiveDisplays[objective.ref()]?.highestPathStreamDisplayEntry(player) ?: display,
+                    endPosition = objective.targetLocation::get
+                )
+            }.toList()
+    })
+}

--- a/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/entries/audience/objectives/LocationCompletableObjectiveEntry.kt
+++ b/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/entries/audience/objectives/LocationCompletableObjectiveEntry.kt
@@ -1,0 +1,91 @@
+package com.typewritermc.quest.entries.audience.objectives
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.entries.emptyRef
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.formatted
+import com.typewritermc.engine.paper.entry.*
+import com.typewritermc.engine.paper.entry.entries.AudienceEntry
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.entry.entries.get
+import com.typewritermc.engine.paper.extensions.placeholderapi.parsePlaceholders
+import com.typewritermc.engine.paper.snippets.snippet
+import com.typewritermc.engine.paper.utils.replaceTagPlaceholders
+import com.typewritermc.quest.entries.ObjectiveEntry
+import com.typewritermc.quest.entries.QuestEntry
+import com.typewritermc.quest.entries.inactiveObjectiveDisplay
+import com.typewritermc.quest.entries.interfaces.LocatableObjective
+import com.typewritermc.quest.entries.showingObjectiveDisplay
+import org.bukkit.entity.Player
+import java.util.*
+
+private val completedObjectiveDisplay by snippet(
+    "quest.objectives.completable.completed",
+    "<green>✔</green> <gray><display></gray>"
+)
+
+@Entry(
+    "location_completable_objective",
+    "A location objective definition that can show a completed stage",
+    Colors.BLUE_VIOLET,
+    "streamline:target-solid"
+)
+/**
+ * The `Completable Objective` entry is an objective that can show a completed stage.
+ * It is shown to the player when the show criteria are met, regardless of if the completed criteria are met.
+ *
+ * ## How could this be used?
+ * This is useful when the quest has multiple objectives that can be completed in different orders.
+ * For example, the player needs to collect wheat, eggs, and milk to make a cake.
+ * The order in which the player collects the items does not matter.
+ * But you want to show the player which items they have collected.
+ */
+class LocationCompletableObjectiveEntry(
+    override val id: String = "",
+    override val name: String = "",
+    override val quest: Ref<QuestEntry> = emptyRef(),
+    override val children: List<Ref<AudienceEntry>> = emptyList(),
+    @Help("The criteria need to be met for the objective to be able to be shown.")
+    val showCriteria: List<Criteria> = emptyList(),
+    @Help("The criteria to display the objective as completed.")
+    val completedCriteria: List<Criteria> = emptyList(),
+    override val display: Var<String> = ConstVar(""),
+    override val priorityOverride: Optional<Int> = Optional.empty(),
+    val targetLocation: Var<Position> = ConstVar(Position.ORIGIN),
+) : LocatableObjective, ObjectiveEntry {
+
+    override val criteria: List<Criteria> get() = showCriteria
+
+    override fun parser(): PlaceholderParser = placeholderParser {
+        include(super<LocatableObjective>.parser())
+
+        literal("location") {
+            string("format") { format ->
+                supply {
+                    targetLocation.get(it)?.formatted(format())
+                }
+            }
+
+            supply { targetLocation.get(it)?.formatted() }
+        }
+    }
+
+    override fun positions(player: Player?): List<Position> {
+        val position = targetLocation.get(player) ?: return emptyList()
+        return listOf(position)
+    }
+
+    override fun display(player: Player?): String {
+        val text = when {
+            player == null -> inactiveObjectiveDisplay
+            completedCriteria.matches(player) -> completedObjectiveDisplay
+            showCriteria.matches(player) -> showingObjectiveDisplay
+            else -> inactiveObjectiveDisplay
+        }
+        return text.replaceTagPlaceholders("display", display.get(player) ?: "").parsePlaceholders(player)
+    }
+}


### PR DESCRIPTION
This is combination of **Completable Objective** and **Location Objective Entry**.

The purpose here is to send the player to a specific location and mark the objective as completed when the player reaches that point, while also stopping the path display.

**completedCriteria** is used to stop showing the path when the objective is completed, but without completely hiding the objective. This way, when a player with multiple objectives finishes the go to location objective, it will get a checkmark and continue to appear in the sidebar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual path streams for tracking location-based objectives, displaying routes to targeted locations on the road network
  * Introduced a new location objective type with configurable display states and completion criteria
  * Enhanced quest system with improved location-based objective handling and player tracking capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->