### PR TITLE
New Locatable Objectives

### DIFF
--- a/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/entries/audience/LocatableObjectivesPathStream.kt
+++ b/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/entries/audience/LocatableObjectivesPathStream.kt
@@ -10,7 +10,7 @@ import com.typewritermc.engine.paper.entry.descendants
 import com.typewritermc.engine.paper.entry.entries.AudienceDisplay
 import com.typewritermc.engine.paper.entry.entries.AudienceEntry
 import com.typewritermc.engine.paper.entry.matches
-import com.typewritermc.quest.entries.audience.objectives.LocationCompletableObjectiveEntry
+import com.typewritermc.quest.entries.interfaces.LocatableObjectivePathStreams
 import com.typewritermc.quest.entries.trackedShowingObjectives
 import com.typewritermc.roadnetwork.RoadNetworkEntry
 import com.typewritermc.roadnetwork.entries.MultiPathStreamDisplay
@@ -19,8 +19,8 @@ import com.typewritermc.roadnetwork.entries.StreamProducer
 import com.typewritermc.roadnetwork.entries.highestPathStreamDisplayEntry
 
 @Entry(
-    "location_completable_objectives_path_stream",
-    "A Path Stream to tracked Completable Location Objectives",
+    "locatable_objectives_path_stream",
+    "A Path Stream to tracked Location Objectives",
     Colors.GREEN,
     "material-symbols:conversion-path"
 )
@@ -31,17 +31,17 @@ import com.typewritermc.roadnetwork.entries.highestPathStreamDisplayEntry
  * ## How could this be used?
  * This could be used to show a path to each location objective in a quest.
  */
-class LocationCompletableObjectivesPathStream(
+class LocatableObjectivesPathStream(
     override val id: String = "",
     override val name: String = "",
     val display: Ref<PathStreamDisplayEntry> = emptyRef(),
     val road: Ref<RoadNetworkEntry> = emptyRef(),
 ) : AudienceEntry {
     // As displays and references can't change (except between reloads) we can just cache all relevant ones here for quick access.
-    private val objectiveDisplays: Map<Ref<LocationCompletableObjectiveEntry>, List<Ref<PathStreamDisplayEntry>>> by lazy(
+    private val objectiveDisplays: Map<Ref<LocatableObjectivePathStreams>, List<Ref<PathStreamDisplayEntry>>> by lazy(
         LazyThreadSafetyMode.NONE
     ) {
-        Query.findWhere<LocationCompletableObjectiveEntry>() { true }.associate { objective ->
+        Query.findWhere<LocatableObjectivePathStreams>() { true }.associate { objective ->
             val displays = mutableListOf<Ref<PathStreamDisplayEntry>>()
 
             displays.addAll(objective.descendants(PathStreamDisplayEntry::class))
@@ -53,7 +53,7 @@ class LocationCompletableObjectivesPathStream(
     }
 
     override suspend fun display(): AudienceDisplay = MultiPathStreamDisplay(road, streams = { player ->
-        player.trackedShowingObjectives().filterIsInstance<LocationCompletableObjectiveEntry>()
+        player.trackedShowingObjectives().filterIsInstance<LocatableObjectivePathStreams>()
             .filter { objective -> !objective.completedCriteria.matches(player) } // Skip if objective is completed
             .map { objective ->
                 StreamProducer(

--- a/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/entries/audience/LocationCompletableObjectivesPathStream.kt
+++ b/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/entries/audience/LocationCompletableObjectivesPathStream.kt
@@ -1,0 +1,66 @@
+package com.typewritermc.quest.entries.audience
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Query
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.entries.emptyRef
+import com.typewritermc.core.entries.ref
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.engine.paper.entry.descendants
+import com.typewritermc.engine.paper.entry.entries.AudienceDisplay
+import com.typewritermc.engine.paper.entry.entries.AudienceEntry
+import com.typewritermc.engine.paper.entry.matches
+import com.typewritermc.quest.entries.audience.objectives.LocationCompletableObjectiveEntry
+import com.typewritermc.quest.entries.trackedShowingObjectives
+import com.typewritermc.roadnetwork.RoadNetworkEntry
+import com.typewritermc.roadnetwork.entries.MultiPathStreamDisplay
+import com.typewritermc.roadnetwork.entries.PathStreamDisplayEntry
+import com.typewritermc.roadnetwork.entries.StreamProducer
+import com.typewritermc.roadnetwork.entries.highestPathStreamDisplayEntry
+
+@Entry(
+    "location_completable_objectives_path_stream",
+    "A Path Stream to tracked Completable Location Objectives",
+    Colors.GREEN,
+    "material-symbols:conversion-path"
+)
+/**
+ * The `Location Completable Objectives Path Stream` entry is a path stream that shows the path to each tracked location objective.
+ * When the player has a location objective, and the quest for the objective is tracked, a path stream will be displayed.
+ *
+ * ## How could this be used?
+ * This could be used to show a path to each location objective in a quest.
+ */
+class LocationCompletableObjectivesPathStream(
+    override val id: String = "",
+    override val name: String = "",
+    val display: Ref<PathStreamDisplayEntry> = emptyRef(),
+    val road: Ref<RoadNetworkEntry> = emptyRef(),
+) : AudienceEntry {
+    // As displays and references can't change (except between reloads) we can just cache all relevant ones here for quick access.
+    private val objectiveDisplays: Map<Ref<LocationCompletableObjectiveEntry>, List<Ref<PathStreamDisplayEntry>>> by lazy(
+        LazyThreadSafetyMode.NONE
+    ) {
+        Query.findWhere<LocationCompletableObjectiveEntry>() { true }.associate { objective ->
+            val displays = mutableListOf<Ref<PathStreamDisplayEntry>>()
+
+            displays.addAll(objective.descendants(PathStreamDisplayEntry::class))
+            displays.addAll(objective.quest.descendants(PathStreamDisplayEntry::class))
+            displays.add(display)
+
+            objective.ref() to displays
+        }
+    }
+
+    override suspend fun display(): AudienceDisplay = MultiPathStreamDisplay(road, streams = { player ->
+        player.trackedShowingObjectives().filterIsInstance<LocationCompletableObjectiveEntry>()
+            .filter { objective -> !objective.completedCriteria.matches(player) } // Skip if objective is completed
+            .map { objective ->
+                StreamProducer(
+                    objective.id,
+                    objectiveDisplays[objective.ref()]?.highestPathStreamDisplayEntry(player) ?: display,
+                    endPosition = objective.targetLocation::get
+                )
+            }.toList()
+    })
+}

--- a/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/entries/audience/LocationObjectivesPathStream.kt
+++ b/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/entries/audience/LocationObjectivesPathStream.kt
@@ -30,6 +30,7 @@ import com.typewritermc.roadnetwork.entries.highestPathStreamDisplayEntry
  * ## How could this be used?
  * This could be used to show a path to each location objective in a quest.
  */
+@Deprecated("Use LocatableObjectivesPathStream")
 class LocationObjectivesPathStream(
     override val id: String = "",
     override val name: String = "",

--- a/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/entries/audience/objectives/LocatableCompletableObjectiveEntry.kt
+++ b/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/entries/audience/objectives/LocatableCompletableObjectiveEntry.kt
@@ -15,10 +15,9 @@ import com.typewritermc.engine.paper.entry.entries.get
 import com.typewritermc.engine.paper.extensions.placeholderapi.parsePlaceholders
 import com.typewritermc.engine.paper.snippets.snippet
 import com.typewritermc.engine.paper.utils.replaceTagPlaceholders
-import com.typewritermc.quest.entries.ObjectiveEntry
 import com.typewritermc.quest.entries.QuestEntry
+import com.typewritermc.quest.entries.interfaces.LocatableObjectivePathStreams
 import com.typewritermc.quest.entries.inactiveObjectiveDisplay
-import com.typewritermc.quest.entries.interfaces.LocatableObjective
 import com.typewritermc.quest.entries.showingObjectiveDisplay
 import org.bukkit.entity.Player
 import java.util.*
@@ -29,7 +28,7 @@ private val completedObjectiveDisplay by snippet(
 )
 
 @Entry(
-    "location_completable_objective",
+    "locatable_completable_objective",
     "A location objective definition that can show a completed stage",
     Colors.BLUE_VIOLET,
     "streamline:target-solid"
@@ -44,7 +43,7 @@ private val completedObjectiveDisplay by snippet(
  * The order in which the player collects the items does not matter.
  * But you want to show the player which items they have collected.
  */
-class LocationCompletableObjectiveEntry(
+class LocatableCompletableObjectiveEntry(
     override val id: String = "",
     override val name: String = "",
     override val quest: Ref<QuestEntry> = emptyRef(),
@@ -52,17 +51,15 @@ class LocationCompletableObjectiveEntry(
     @Help("The criteria need to be met for the objective to be able to be shown.")
     val showCriteria: List<Criteria> = emptyList(),
     @Help("The criteria to display the objective as completed.")
-    val completedCriteria: List<Criteria> = emptyList(),
+    override val completedCriteria: List<Criteria> = emptyList(),
     override val display: Var<String> = ConstVar(""),
     override val priorityOverride: Optional<Int> = Optional.empty(),
-    val targetLocation: Var<Position> = ConstVar(Position.ORIGIN),
-) : LocatableObjective, ObjectiveEntry {
+    override val targetLocation: Var<Position> = ConstVar(Position.ORIGIN),
+) : LocatableObjectivePathStreams {
 
     override val criteria: List<Criteria> get() = showCriteria
 
     override fun parser(): PlaceholderParser = placeholderParser {
-        include(super<LocatableObjective>.parser())
-
         literal("location") {
             string("format") { format ->
                 supply {

--- a/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/entries/audience/objectives/LocatableCompletableObjectiveEntry.kt
+++ b/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/entries/audience/objectives/LocatableCompletableObjectiveEntry.kt
@@ -60,6 +60,7 @@ class LocatableCompletableObjectiveEntry(
     override val criteria: List<Criteria> get() = showCriteria
 
     override fun parser(): PlaceholderParser = placeholderParser {
+        include(super.parser())
         literal("location") {
             string("format") { format ->
                 supply {

--- a/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/entries/audience/objectives/LocationCompletableObjectiveEntry.kt
+++ b/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/entries/audience/objectives/LocationCompletableObjectiveEntry.kt
@@ -1,0 +1,91 @@
+package com.typewritermc.quest.entries.audience.objectives
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.entries.emptyRef
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.formatted
+import com.typewritermc.engine.paper.entry.*
+import com.typewritermc.engine.paper.entry.entries.AudienceEntry
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.entry.entries.get
+import com.typewritermc.engine.paper.extensions.placeholderapi.parsePlaceholders
+import com.typewritermc.engine.paper.snippets.snippet
+import com.typewritermc.engine.paper.utils.replaceTagPlaceholders
+import com.typewritermc.quest.entries.ObjectiveEntry
+import com.typewritermc.quest.entries.QuestEntry
+import com.typewritermc.quest.entries.inactiveObjectiveDisplay
+import com.typewritermc.quest.entries.interfaces.LocatableObjective
+import com.typewritermc.quest.entries.showingObjectiveDisplay
+import org.bukkit.entity.Player
+import java.util.*
+
+private val completedObjectiveDisplay by snippet(
+    "quest.objectives.completable.completed",
+    "<green>✔</green> <gray><display></gray>"
+)
+
+@Entry(
+    "location_completable_objective",
+    "A location objective definition that can show a completed stage",
+    Colors.BLUE_VIOLET,
+    "streamline:target-solid"
+)
+/**
+ * The `Completable Objective` entry is an objective that can show a completed stage.
+ * It is shown to the player when the show criteria are met, regardless of if the completed criteria are met.
+ *
+ * ## How could this be used?
+ * This is useful when the quest has multiple objectives that can be completed in different orders.
+ * For example, the player needs to collect wheat, eggs, and milk to make a cake.
+ * The order in which the player collects the items does not matter.
+ * But you want to show the player which items they have collected.
+ */
+class LocationCompletableObjectiveEntry(
+    override val id: String = "",
+    override val name: String = "",
+    override val quest: Ref<QuestEntry> = emptyRef(),
+    override val children: List<Ref<AudienceEntry>> = emptyList(),
+    @Help("The criteria need to be met for the objective to be able to be shown.")
+    val showCriteria: List<Criteria> = emptyList(),
+    @Help("The criteria to display the objective as completed.")
+    val completedCriteria: List<Criteria> = emptyList(),
+    override val display: Var<String> = ConstVar(""),
+    override val priorityOverride: Optional<Int> = Optional.empty(),
+    val targetLocation: Var<Position> = ConstVar(Position.ORIGIN),
+) : LocatableObjective, ObjectiveEntry {
+
+    override val criteria: List<Criteria> get() = showCriteria
+
+    override fun parser(): PlaceholderParser = placeholderParser {
+        include(super<LocatableObjective>.parser())
+
+        literal("location") {
+            string("format") { format ->
+                supply {
+                    targetLocation.get(it)?.formatted(format())
+                }
+            }
+
+            supply { targetLocation.get(it)?.formatted() }
+        }
+    }
+
+    override fun positions(player: Player?): List<Position> {
+        val position = targetLocation.get(player) ?: return emptyList()
+        return listOf(position)
+    }
+
+    override fun display(player: Player?): String {
+        val text = when {
+            player == null -> inactiveObjectiveDisplay
+            completedCriteria.matches(player) -> completedObjectiveDisplay
+            showCriteria.matches(player) -> showingObjectiveDisplay
+            else -> inactiveObjectiveDisplay
+        }
+        return text.replaceTagPlaceholders("display", display.get(player) ?: "").parsePlaceholders(player)
+    }
+}

--- a/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/entries/audience/objectives/concrete/LocatableObjectiveEntry.kt
+++ b/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/entries/audience/objectives/concrete/LocatableObjectiveEntry.kt
@@ -13,10 +13,11 @@ import com.typewritermc.engine.paper.entry.entries.Var
 import com.typewritermc.engine.paper.entry.entries.get
 import com.typewritermc.quest.entries.QuestEntry
 import com.typewritermc.quest.entries.interfaces.LocatableObjective
+import com.typewritermc.quest.entries.interfaces.LocatableObjectivePathStreams
 import org.bukkit.entity.Player
 import java.util.*
 
-@Entry("location_objective", "A location objective definition", Colors.BLUE_VIOLET, "streamline:target-solid")
+@Entry("locatable_objective", "A location objective definition", Colors.BLUE_VIOLET, "streamline:target-solid")
 /**
  * The `LocationObjective` entry is a task that the player can complete by reaching a specific location.
  * It is mainly for displaying the progress to a player.
@@ -33,17 +34,16 @@ import java.util.*
  * This could be used to guide the players to a specific location.
  * Showing the players where they need to go with a path stream.
  */
-@Deprecated("Use LocatableObjectiveEntry")
-class LocationObjectiveEntry(
+class LocatableObjectiveEntry(
     override val id: String = "",
     override val name: String = "",
     override val quest: Ref<QuestEntry> = emptyRef(),
     override val children: List<Ref<AudienceEntry>> = emptyList(),
     override val criteria: List<Criteria> = emptyList(),
     override val display: Var<String> = ConstVar(""),
-    val targetLocation: Var<Position> = ConstVar(Position.ORIGIN),
+    override val targetLocation: Var<Position> = ConstVar(Position.ORIGIN),
     override val priorityOverride: Optional<Int> = Optional.empty(),
-) : LocatableObjective {
+) : LocatableObjectivePathStreams {
     override fun parser(): PlaceholderParser = placeholderParser {
         include(super.parser())
 

--- a/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/entries/interfaces/LocatableObjectivePathStreams.kt
+++ b/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/entries/interfaces/LocatableObjectivePathStreams.kt
@@ -1,0 +1,11 @@
+package com.typewritermc.quest.entries.interfaces
+
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.engine.paper.entry.Criteria
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.quest.entries.ObjectiveEntry
+
+interface LocatableObjectivePathStreams : ObjectiveEntry, LocatableObjective {
+    val targetLocation: Var<Position>
+    val completedCriteria: List<Criteria> get() = emptyList()
+}


### PR DESCRIPTION
`LocationObjectivesPathStream` and `LocationObjectiveEntry` Deprecated

`LocatableObjectivesPathStream`, `LocatableCompletableObjectiveEntry`,  `LocatableObjectiveEntry` and `LocatableObjectivePathStreams(Interface)` is added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added locatable quest objective path stream displays for tracking objective locations on road networks.
  * Introduced locatable objective entries with location formatting and per-player position support.
  * Added a locatable completable objective type that can render completed state independently of completion order.

* **Deprecations**
  * Existing location-based path stream and objective entry types are deprecated; use the locatable equivalents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->