### PR TITLE
fix: out of bound loop range in restoreInventory

### DIFF
--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/utils/PlayerState.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/utils/PlayerState.kt
@@ -168,7 +168,7 @@ fun Player.fakeClearInventory() {
 fun Player.restoreInventory() {
     // I can't be bother to transform the ids from the normal version to the weird version need for the WrapperPlayServerWindowItems
     // So we just send many packets instead
-    for (i in 0..46) {
+    for (i in 0..45) {
         val item = inventory.getItem(i) ?: ItemStack.empty()
 
         val packet = WrapperPlayServerSetSlot(-2, 0, i, SpigotReflectionUtil.decodeBukkitItemStack(item))


### PR DESCRIPTION
For example currently GrimAC will eventually throw an exception on it's CompensatedInventory related checks, might cause issues for other plugins too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an inventory restoration issue so only valid inventory slots are processed, improving consistency when fake inventories are cleared and restored.
  * Reduced the chance of extra slot updates being sent to players, which should help prevent visual inventory glitches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->