### PR TITLE
fix(engine-paper,entity-extension): stop an entity from breaking on data it cannot take

### DIFF
--- a/engine/engine-paper/build.gradle.kts
+++ b/engine/engine-paper/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
 
     compileOnlyApi("com.corundumstudio.socketio:netty-socketio:1.7.19") // Keep this on a lower version as the newer version breaks the ping
 
-    api("me.tofaa2:spigot:3.3.4-SNAPSHOT")
+    api("me.tofaa2:spigot:3.3.6-SNAPSHOT")
     compileOnlyApi("com.github.shynixn.mccoroutine:mccoroutine-bukkit-api:2.22.0")
     compileOnlyApi("com.github.shynixn.mccoroutine:mccoroutine-bukkit-core:2.22.0")
 

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/extensions/packetevents/PlayerPackets.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/extensions/packetevents/PlayerPackets.kt
@@ -8,6 +8,7 @@ import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerCa
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerEntityAnimation
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerEntityAnimation.EntityAnimationType.SWING_MAIN_ARM
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerEntityAnimation.EntityAnimationType.SWING_OFF_HAND
+import com.typewritermc.engine.paper.logger
 import io.github.retrooper.packetevents.util.SpigotConversionUtil
 import me.tofaa.entitylib.meta.EntityMeta
 import me.tofaa.entitylib.wrapper.WrapperEntity
@@ -73,12 +74,17 @@ class Metas(val meta: EntityMeta) {
     }
 }
 
+/**
+ * Applies the editor that fits the meta this entity has, and reports it when none of them does.
+ *
+ * Data is put together in the panel, where nothing ties a value to the entity types it fits: a pose can be
+ * one the type never strikes, an equipment slot one it has nowhere to wear. That is the user's to hear about
+ * rather than the entity's to break on, so the entity goes without this and keeps everything else.
+ */
 fun WrapperEntity.metas(editor: Metas.() -> Unit) {
-    val meta = entityMeta
-    val metas = Metas(meta).apply(editor)
-    if (!metas.hasBeenHandled) {
-        throw IllegalStateException(metas.error ?: "No meta was handled")
-    }
+    val metas = Metas(entityMeta).apply(editor)
+    if (metas.hasBeenHandled) return
+    logger.warning(metas.error ?: "A $entityType entity cannot take this data, so it is left out.")
 }
 
 fun Location.toPacketLocation() = com.github.retrooper.packetevents.protocol.world.Location(x, y, z, yaw, pitch)

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/data/minecraft/living/EquipmentData.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/data/minecraft/living/EquipmentData.kt
@@ -7,7 +7,9 @@ import com.typewritermc.core.extension.annotations.Entry
 import com.typewritermc.core.extension.annotations.Tags
 import com.typewritermc.engine.paper.entry.entries.*
 import com.typewritermc.engine.paper.extensions.packetevents.toPacketItem
+import com.typewritermc.engine.paper.logger
 import com.typewritermc.engine.paper.utils.item.Item
+import me.tofaa.entitylib.wrapper.WrapperEntityEquipment
 import me.tofaa.entitylib.wrapper.WrapperLivingEntity
 import org.bukkit.entity.Player
 import java.util.*
@@ -99,8 +101,19 @@ private class EquipmentCollector(
     }
 }
 
+/**
+ * Dresses the entity, reporting the slots this server version has no place for.
+ *
+ * A slot travels as its ordinal, so one that arrived after the version the server runs leaves the client
+ * reading an id it cannot map back. EntityLib keeps those out of the packet, which is the right thing to
+ * send but a silent one to watch, and a slot chosen in the panel says nothing about the version it lands on.
+ */
 fun applyEquipmentData(entity: WrapperLivingEntity, property: EquipmentProperty) {
     property.data.forEach { (slot, item) ->
+        if (!WrapperEntityEquipment.isSlotSupported(slot)) {
+            logger.warning("The $slot equipment slot does not exist on this server version, so it is left empty.")
+            return@forEach
+        }
         if (item.isEmpty) entity.equipment.setItem(slot, null)
         else entity.equipment.setItem(slot, item)
     }

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/WrapperFakeEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/WrapperFakeEntity.kt
@@ -38,15 +38,24 @@ abstract class WrapperFakeEntity(
     override val state: EntityState
         get() = type.state(properties)
 
+    /**
+     * Notifications are held back for the length of the batch, so the whole of it travels as one packet.
+     *
+     * They are turned back on even when a property throws. Leaving them off outlives the batch, and the
+     * entity then sends no metadata at all for the rest of its life.
+     */
     override fun applyProperties(properties: List<EntityProperty>) {
         entity.entityMeta.setNotifyAboutChanges(false)
-        properties.forEach { property ->
-            when (property) {
-                is PositionProperty -> applyPosition(property)
-                else -> applyProperty(property)
+        try {
+            properties.forEach { property ->
+                when (property) {
+                    is PositionProperty -> applyPosition(property)
+                    else -> applyProperty(property)
+                }
             }
+        } finally {
+            entity.entityMeta.setNotifyAboutChanges(true)
         }
-        entity.entityMeta.setNotifyAboutChanges(true)
     }
 
     protected open fun applyPosition(property: PositionProperty) {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/custom/EntityTypeProperty.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/custom/EntityTypeProperty.kt
@@ -18,7 +18,6 @@ import com.typewritermc.entity.entries.data.minecraft.living.tameable.SittingPro
 import com.typewritermc.entity.entries.data.minecraft.other.MarkerProperty
 import com.typewritermc.entity.entries.data.minecraft.other.SmallProperty
 import me.tofaa.entitylib.meta.mobs.water.PufferFishMeta
-import java.util.*
 import kotlin.reflect.KClass
 import kotlin.reflect.full.safeCast
 
@@ -26,6 +25,14 @@ fun <T : EntityProperty> Map<KClass<*>, EntityProperty>.property(type: KClass<T>
     return type.safeCast(this[type])
 }
 
+/**
+ * Which entities a row of the table below applies to. A field that is left out stands for any value, so
+ * `EntityDataMatcher(EntityTypes.CAT)` covers every cat and `EntityDataMatcher(EntityTypes.CAT, isBaby = true)`
+ * only the kittens.
+ *
+ * The entity being looked up is described the same way, with every field filled in. Which of the two an
+ * instance is decides the side of [matches] it goes on.
+ */
 private class EntityDataMatcher(
     val type: EntityType,
     val isBaby: Boolean? = null,
@@ -35,24 +42,29 @@ private class EntityDataMatcher(
     val marker: Boolean? = null,
     val puffState: PufferFishMeta.State? = null,
 ) {
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
+    /**
+     * How many fields a row pins down, which is how closely it fits the entities it applies to.
+     *
+     * Several rows can apply to one entity at once: a warden roaring is a warden as much as it is a warden
+     * roaring. The one that pins down the most is the one meant for it.
+     */
+    val precision: Int = listOfNotNull(isBaby, pose, size, small, marker, puffState).size
 
-        other as EntityDataMatcher
-
-        if (type != other.type) return false
-        if (other.isBaby != null && isBaby != other.isBaby) return false
-        if (other.pose != null && pose != other.pose) return false
-        if (other.size != null && size != null && size > other.size) return false
-        if (other.small != null && small != other.small) return false
-        if (other.marker != null && marker != other.marker) return false
-        if (other.puffState != null && puffState != other.puffState) return false
+    /** Whether this entity is one [row] applies to. */
+    fun matches(row: EntityDataMatcher): Boolean {
+        if (type != row.type) return false
+        if (row.isBaby != null && isBaby != row.isBaby) return false
+        if (row.pose != null && pose != row.pose) return false
+        if (row.size != null && size != null && size > row.size) return false
+        if (row.small != null && small != row.small) return false
+        if (row.marker != null && marker != row.marker) return false
+        if (row.puffState != null && puffState != row.puffState) return false
 
         return true
     }
 
-    override fun hashCode(): Int = Objects.hash(type, isBaby, pose, size, small, marker, puffState)
+    fun standing(): EntityDataMatcher =
+        EntityDataMatcher(type, isBaby, EntityPose.STANDING, size, small, marker, puffState)
 
     override fun toString(): String {
         return "EntityDataMatcher(type=${type.name}, isBaby=$isBaby, pose=$pose, size=$size, small=$small, marker=$marker, puffState=$puffState)"
@@ -65,7 +77,7 @@ private data class EntityData(
     val eyeHeight: Double = height * 0.85
 )
 
-private val generatedEntityDataMap = mapOf(
+private val generatedEntityData = listOf(
 //<editor-fold desc="Entity Data Map Entries">
     EntityDataMatcher(EntityTypes.ALLAY) to EntityData(width = 0.35, height = 0.6, eyeHeight = 0.36),
     EntityDataMatcher(EntityTypes.AREA_EFFECT_CLOUD) to EntityData(width = 6.0, height = 0.5),
@@ -475,7 +487,7 @@ private val generatedEntityDataMap = mapOf(
 //</editor-fold>
 )
 
-private val manualEntityDataMap = mapOf(
+private val manualEntityData = listOf(
     EntityDataMatcher(EntityTypes.PLAYER, pose = EntityPose.SITTING) to EntityData(
         width = 0.6,
         height = 1.3,
@@ -550,7 +562,14 @@ private val manualEntityDataMap = mapOf(
     EntityDataMatcher(EntityTypes.CAT, isBaby = false) to EntityData(width = 0.6, height = 0.7, eyeHeight = 0.48),
 )
 
-private val entityDataMap = manualEntityDataMap + generatedEntityDataMap
+/**
+ * The table, grouped so that looking an entity up only walks the rows of its own type.
+ *
+ * The manual rows come first, so that they win the ties they exist to win: a manual row and a generated row
+ * that pin down the same fields fit equally closely, and the manual one is the correction.
+ */
+private val entityDataByType: Map<EntityType, List<Pair<EntityDataMatcher, EntityData>>> =
+    (manualEntityData + generatedEntityData).groupBy { (row, _) -> row.type }
 
 private fun pose(properties: Map<KClass<*>, EntityProperty>): EntityPose {
     val isSitting = properties.property(SittingProperty::class)?.sitting
@@ -574,8 +593,35 @@ private fun EntityType.matcher(properties: Map<KClass<*>, EntityProperty>): Enti
     return EntityDataMatcher(this, isBaby, pose(properties), size, small, marker, puffState)
 }
 
+/**
+ * The dimensions of the row that fits this entity closest.
+ *
+ * Closest, rather than first, because the table is written in no particular order and a row that pins down
+ * nothing but the type sits ahead of the pose rows for several of them. Taking the first would have every
+ * warden be the height of one climbing out of the ground.
+ *
+ * Size is a threshold rather than a value, so a row for size four also applies to everything smaller, and the
+ * tightest of the ones that fit is the one meant for it. Rows that fit equally closely are settled by
+ * position, which is what keeps a manual row ahead of the generated one it is there to correct.
+ */
+private fun EntityDataMatcher.findEntityData(): EntityData? =
+    entityDataByType[type]
+        ?.filter { (row, _) -> matches(row) }
+        ?.minWithOrNull(compareByDescending<Pair<EntityDataMatcher, EntityData>> { (row, _) -> row.precision }
+            .thenBy { (row, _) -> row.size ?: Int.MAX_VALUE })
+        ?.second
+
+/**
+ * Dimensions are only recorded for the poses a type strikes in vanilla, while a pose can be put on any
+ * entity. One the type has no dimensions for falls back on its standing ones, which is also what the
+ * client draws when a model has nothing for the pose it is given.
+ */
 private val EntityDataMatcher.entityData: EntityData?
-    get() = entityDataMap.entries.find { (key, _) -> this == key }?.value
+    get() {
+        findEntityData()?.let { return it }
+        if (pose == EntityPose.STANDING) return null
+        return standing().findEntityData()
+    }
 
 private val EntityDataMatcher.width: Double
     get() = entityData?.width

--- a/extensions/EntityExtension/src/test/kotlin/com/typewritermc/entity/entries/entity/custom/EntityDataSpec.kt
+++ b/extensions/EntityExtension/src/test/kotlin/com/typewritermc/entity/entries/entity/custom/EntityDataSpec.kt
@@ -1,0 +1,61 @@
+package com.typewritermc.entity.entries.entity.custom
+
+import com.github.retrooper.packetevents.PacketEvents
+import com.github.retrooper.packetevents.PacketEventsAPI
+import com.github.retrooper.packetevents.settings.PacketEventsSettings
+import com.github.retrooper.packetevents.protocol.entity.pose.EntityPose
+import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes
+import com.typewritermc.engine.paper.entry.entries.EntityProperty
+import com.typewritermc.entity.entries.data.minecraft.PoseProperty
+import com.typewritermc.entity.entries.data.minecraft.living.AgeableProperty
+import com.typewritermc.entity.entries.data.minecraft.living.SizeProperty
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.reflect.KClass
+
+private fun properties(vararg properties: EntityProperty): Map<KClass<*>, EntityProperty> =
+    properties.associateBy<EntityProperty, KClass<*>> { it::class }
+
+/** Naming an [EntityTypes] constant loads the mappings, which are read through the settings and nothing else. */
+private fun loadEntityTypes() {
+    if (PacketEvents.getAPI() != null) return
+    val api = mockk<PacketEventsAPI<Any>>(relaxed = true)
+    every { api.settings } returns PacketEventsSettings()
+    PacketEvents.setAPI(api)
+}
+
+class EntityDataSpec : FunSpec({
+    beforeSpec { loadEntityTypes() }
+
+    test("a row for the pose beats the row for the type on its own") {
+        EntityTypes.WARDEN.state(properties(PoseProperty(EntityPose.ROARING))).height shouldBe 2.9
+        EntityTypes.WARDEN.state(properties(PoseProperty(EntityPose.SNIFFING))).height shouldBe 2.9
+        EntityTypes.WARDEN.state(properties(PoseProperty(EntityPose.DIGGING))).height shouldBe 1.0
+    }
+
+    test("a size row applies to its own size, not to every size below it") {
+        EntityTypes.SLIME.state(properties(SizeProperty(1))).height shouldBe 0.52
+        EntityTypes.SLIME.state(properties(SizeProperty(2))).height shouldBe 1.04
+        EntityTypes.SLIME.state(properties(SizeProperty(4))).height shouldBe 2.08
+    }
+
+    test("a size with no row of its own rounds up to the next one that fits") {
+        EntityTypes.MAGMA_CUBE.state(properties(SizeProperty(3))).height shouldBe 2.08
+    }
+
+    test("a pose the type has no row for falls back on standing") {
+        val standing = EntityTypes.PLAYER.state(properties(PoseProperty(EntityPose.STANDING)))
+        EntityTypes.PLAYER.state(properties(PoseProperty(EntityPose.CROAKING))).height shouldBe standing.height
+    }
+
+    test("a manual row wins over the generated row it corrects") {
+        EntityTypes.CAT.state(properties(AgeableProperty(baby = false))).eyeHeight shouldBe 0.48
+        EntityTypes.CAT.state(properties(AgeableProperty(baby = true))).eyeHeight shouldBe 0.28
+    }
+
+    test("a manual row is found for a pose the generated rows do not cover") {
+        EntityTypes.PLAYER.state(properties(PoseProperty(EntityPose.SITTING))).height shouldBe 1.3
+    }
+})


### PR DESCRIPTION
Stop an entity from breaking on data it cannot take

An entity that was handed a property it could not be given threw in the middle of its metadata batch. Change notifications had already been switched off for the batch, so the entity went silent and never sent another update, and the viewer was left holding a copy that nothing had a reference to any more and that could never be despawned. A property that cannot be written is now reported and skipped, and the batch turns notifications back on whatever happens.

The dimension table is asked for a row per pose and answered with nothing for a pose nobody wrote a row for, which is the same throw again, this time for a pose the entity is perfectly able to hold. Every player row is written per pose with no plain row behind them, so the entries could reach it. It now falls back on the standing row of the same type. 

Reading that lookup turned up two rows that were being answered wrongly. It took the first row in write order that matched rather than the row describing the entity closest, so a warden was given the dimensions it has while it is still coming out of the ground, and every slime the dimensions of the largest one. Sorting by how much of the entity a row describes, then by the closest size, gives each of them the row that was written for it. Both are pinned by tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unsupported entity metadata without interrupting gameplay.
  * Added compatibility for equipment slots across server versions.
  * Ensured entity property updates reliably restore metadata notifications after errors.
  * Improved entity dimension and eye-height selection for different poses, sizes, and states.
  * Added fallback behavior when pose-specific data is unavailable.

* **Tests**
  * Added coverage for entity data selection, size matching, pose fallback, and manual overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->