### PR TITLE
refactor(entity-extension): take the duplicate paths out of the sitting support

### DIFF
--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/RideableSittingSupport.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/RideableSittingSupport.kt
@@ -11,6 +11,13 @@ import me.tofaa.entitylib.meta.other.ArmorStandMeta
 import me.tofaa.entitylib.wrapper.WrapperEntity
 import org.bukkit.entity.Player
 
+/**
+ * Sits an entity down on a seat that only its own viewer can see.
+ *
+ * Everything the entity does has a counterpart here: [applyPose] when it takes a pose, [move] when it
+ * is moved, [onSpawn] and [mountIfNeeded] around its spawn, [contains] when it is asked what it is
+ * made of, and [dispose] when it goes away.
+ */
 class RideableSittingSupport(
     private val player: Player,
     private val passenger: () -> WrapperEntity,
@@ -20,41 +27,60 @@ class RideableSittingSupport(
     private var sitEntity: WrapperEntity? = null
     private val seat: Seat = if (player.isFloodgate) Seat.ARMOR_STAND else Seat.BLOCK_DISPLAY
 
+    /**
+     * Puts a seat under the entity for as long as it holds a sitting pose, and takes it away again
+     * for every other pose.
+     *
+     * [poseLocation] is where the seat goes. Without one it falls back on where the entity is.
+     */
     fun applyPose(pose: EntityPose, poseLocation: PositionProperty?) {
         if (pose == EntityPose.SITTING) sit(poseLocation) else unsit()
     }
 
+    /**
+     * Moves the seat along with the entity.
+     *
+     * A client positions a passenger from the entity it rides as well as from the packets the
+     * passenger itself gets, and lets the two fight whenever they disagree, so the seat has to end up
+     * wherever the entity is asked to go.
+     */
     fun move(property: PositionProperty) {
-        if (sitEntity?.isSpawned == true) {
-            sitEntity?.move(seat.at(property))
-        }
+        sitEntity?.move(seat.at(property))
     }
 
+    /**
+     * Spawns the seat of an entity that was already sitting when it is spawned again, which is what
+     * a respawn is for as long as the pose holds.
+     *
+     * Call it before spawning the entity, so the seat is there to receive it.
+     */
     fun onSpawn(spawnLocation: PositionProperty) {
         val seatEntity = sitEntity ?: return
         seatEntity.spawn(seat.at(spawnLocation).toPacketLocation())
         seatEntity.addViewer(player.uniqueId)
     }
 
+    /**
+     * Call after spawning the entity.
+     *
+     * A client only accepts the two of them being tied together once it knows both, so a mount is
+     * tried from either end and settles on whichever of them arrives last.
+     */
     fun mountIfNeeded() {
         val seatEntity = sitEntity ?: return
-        if (isPassengerSpawned()) {
-            seatEntity.addPassengers(passenger())
-        }
+        if (!isPassengerSpawned()) return
+        if (seatEntity.hasPassenger(passenger())) return
+        seatEntity.addPassengers(passenger())
     }
 
+    /**
+     * Whether the id is the seat's, so that an entity asked what it consists of owns up to the seat
+     * it is sat on as well.
+     */
     fun contains(entityId: Int): Boolean = sitEntity?.entityId == entityId
 
-    fun dispose() {
-        val seatEntity = sitEntity ?: return
-        if (seatEntity.hasPassenger(passenger())) {
-            seatEntity.removePassengers(passenger())
-        }
-        seatEntity.removeViewer(player.uniqueId)
-        seatEntity.despawn()
-        seatEntity.remove()
-        sitEntity = null
-    }
+    /** Call from the entity's own dispose, so that the seat does not outlive it. */
+    fun dispose() = unsit()
 
     private fun sit(poseLocation: PositionProperty?) {
         val loc = poseLocation ?: location() ?: return
@@ -63,9 +89,7 @@ class RideableSittingSupport(
         sitEntity = seatEntity
         seatEntity.spawn(seat.at(loc).toPacketLocation())
         seatEntity.addViewer(player.uniqueId)
-        if (isPassengerSpawned()) {
-            seatEntity.addPassengers(passenger())
-        }
+        mountIfNeeded()
     }
 
     private fun unsit() {
@@ -79,6 +103,14 @@ class RideableSittingSupport(
         sitEntity = null
     }
 
+    /**
+     * @param yOffset how far above the entity its seat is placed for the entity to end up where it
+     * was asked to be. A client draws a passenger on the point its seat hands it, which for a block
+     * display is the display itself, so nothing has to be added on java. Vanilla positioning would
+     * drop a player shaped passenger 0.6 below that point, and a real player mounting a real block
+     * display does land there, but an entity that only ever existed in packets does not, so leave
+     * this at zero. Bedrock goes through geyser and was measured on its own.
+     */
     private enum class Seat(private val yOffset: Double) {
         BLOCK_DISPLAY(0.0),
         ARMOR_STAND(-0.25);


### PR DESCRIPTION
Take the duplicate paths out of the sitting support

This branch started out as a fix for a sitting entity breaking when it respawns, on the belief that handing entitylib the same passenger twice throws. That was true up to 3.2.0 and stopped being true in 3.3.4, which the engine has had pinned since the 26.2 support went in. Looking further, nothing hands it the same passenger twice in the first place: every respawn goes through `DisplayEntity`, which builds a new fake entity and with it a sitting support whose seat starts empty.

The first version of this branch also moved the entity's own position packet into the sitting support and took it out of the nine entities that can sit. That was a breaking change, and it bought nothing, because `rideableSitting.move` followed by `super.applyPosition` already makes the same two calls in the same order as the combined one did. It is gone, and so is the api changes entry it needed.

What is left is a tidy up of the file it all happened in. dispose was a verbatim copy of unsit and delegates to it now, sit no longer repeats the mount that `mountIfNeeded` already does, and a mount is refused when the seat is already carrying the entity, which costs nothing and holds whichever way that library contract goes next. The rest is documentation on a class that had none.

Nothing here changes what any entity does, so there is nothing to watch for on a server beyond a sitting npc still sitting.