### PR TITLE
fix(entity-extension): stop npcs from stacking up in the social interaction panel

### DIFF
--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/custom/Npc.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/custom/Npc.kt
@@ -65,7 +65,8 @@ class NpcEntity(
     private val skin: Var<SkinProperty>,
     definition: Ref<out EntityDefinitionEntry>,
 ) : FakeEntity(player) {
-    private val namePlate = NamedEntity(player, displayName, PlayerEntity(player, displayName), definition)
+    private val namePlate =
+        NamedEntity(player, displayName, PlayerEntity(player, displayName, definition.id), definition)
 
     init {
         consumeProperties(skin.get(player))

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/custom/SelfNpc.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/custom/SelfNpc.kt
@@ -34,13 +34,14 @@ class SelfNpcDefinition(
     override val displayName: Var<String>
         get() = overrideName.orElseGet { ConstVar("%player_name%") }
 
-    override fun create(player: Player): FakeEntity = SelfNpc(player)
+    override fun create(player: Player): FakeEntity = SelfNpc(player, id)
 }
 
 class SelfNpc(
     player: Player,
+    stableId: String? = null,
 ) : FakeEntity(player) {
-    private val playerEntity = PlayerEntity(player, ConstVar(player.name))
+    private val playerEntity = PlayerEntity(player, ConstVar(player.name), stableId)
 
     override val state: EntityState
         get() = playerEntity.state

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/PlayerEntity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/entity/minecraft/PlayerEntity.kt
@@ -4,6 +4,7 @@ import com.github.retrooper.packetevents.protocol.entity.pose.EntityPose
 import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes
 import com.github.retrooper.packetevents.protocol.player.TextureProperty
 import com.github.retrooper.packetevents.protocol.player.UserProfile
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerPlayerInfoRemove
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerTeams
 import com.typewritermc.core.books.pages.Colors
 import com.typewritermc.core.entries.Ref
@@ -33,6 +34,7 @@ import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
 import org.bukkit.entity.Player
 import java.util.*
+import java.util.concurrent.ConcurrentHashMap
 
 @Entry("player_definition", "A player entity", Colors.ORANGE, "material-symbols:account-box")
 @Tags("player_definition")
@@ -51,7 +53,7 @@ class PlayerDefinition(
     @OnlyTags("generic_entity_data", "living_entity_data", "player_data")
     override val data: List<Ref<EntityData<*>>> = emptyList(),
 ) : SimpleEntityDefinition {
-    override fun create(player: Player): FakeEntity = PlayerEntity(player, displayName)
+    override fun create(player: Player): FakeEntity = PlayerEntity(player, displayName, id)
 }
 
 @Entry("player_instance", "An instance of a player entity", Colors.YELLOW, "material-symbols:account-box")
@@ -68,9 +70,18 @@ class PlayerInstance(
     override val activity: Ref<out SharedEntityActivityEntry> = emptyRef(),
 ) : SimpleEntityInstance
 
+/**
+ * A fake player shown to [player].
+ *
+ * [stableId] is whatever names the npc across respawns, so that it is shown under the profile it had before. A
+ * client keeps every profile it has been told about in its social interactions panel, also after that profile is
+ * removed again, so an npc without one leaves an entry there every time the viewer walks back into range. Leave
+ * it out for a fake player that is only ever shown once.
+ */
 class PlayerEntity(
     player: Player,
     displayName: Var<String>,
+    stableId: String? = null,
 ) : FakeEntity(player) {
     private val rideableSitting = RideableSittingSupport(
         player,
@@ -87,7 +98,7 @@ class PlayerEntity(
         get() = entity.entityType.state(properties)
 
     init {
-        val uuid = UUID.randomUUID()
+        val uuid = stableId?.let { claimProfile(player.uniqueId, it) } ?: UUID.randomUUID()
         var entityId: Int
         do {
             entityId = EntityLib.getPlatform().entityIdProvider.provide(uuid, EntityTypes.PLAYER)
@@ -190,5 +201,27 @@ class PlayerEntity(
         rideableSitting.dispose()
         entity.despawn()
         entity.remove()
+        // EntityLib adds the profile to the client's player list on spawn and never takes it back out.
+        WrapperPlayServerPlayerInfoRemove(entity.uuid) sendPacketTo player
+        claimedProfiles -= entity.uuid
+    }
+
+    companion object {
+        private val claimedProfiles = ConcurrentHashMap.newKeySet<UUID>()
+
+        /**
+         * The profile [viewer] is shown an npc named [stableId] under, held until that npc is disposed.
+         *
+         * A fake player exists per viewer, so a profile belongs to the viewer it is shown to as much as to the
+         * npc itself. Two npcs sharing a [stableId] are handed a profile each, so that copies standing next to
+         * each other are not shown as one player.
+         */
+        private fun claimProfile(viewer: UUID, stableId: String): UUID {
+            var index = 0
+            while (true) {
+                val profile = UUID.nameUUIDFromBytes("typewriter:npc:$viewer:$stableId:${index++}".toByteArray())
+                if (claimedProfiles.add(profile)) return profile
+            }
+        }
     }
 }


### PR DESCRIPTION
Stop npcs stacking up in the social interactions panel

EntityLib's despawn only flips the listed flag on a profile, which takes it out of the player list but leaves it in the client's social interactions panel; a client keeps every profile it has ever been told about there. On top of that, every spawn minted a fresh random profile, so the panel collected an entry per spawn rather than per npc.

An npc now takes back the profile it had. Profiles are handed out per definition and only reused once the npc that held one is disposed, so npcs shown next to each other still get one each.

The remove packet stays on dispose rather than being sent straight after spawning. Removing it early would keep npcs out of the panel's online list, but a client resolves a profile lazily and only when the entity is actually rendered, so an npc that spawned out of view would keep a default skin for the rest of its life. Since 1.19.3 the profile also has to exist when the spawn packet arrives or the client drops the entity outright.

The breaking change is avoided by keeping the random uuid if no stable id is provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed spawned player entities remaining visible in the client's player list after being removed.
  * Player entries are now cleared during entity disposal, alongside existing cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->