### PR TITLE
fix(engine-loader,engine-paper): resolve nested class names

### DIFF
--- a/documentation/docs/develop/02-extensions/09-api-changes/0.9.mdx
+++ b/documentation/docs/develop/02-extensions/09-api-changes/0.9.mdx
@@ -4,12 +4,12 @@ title: 0.9.X API changes
 
 # 0.9.X API changes
 :::danger[Kotlin Upgrade Required]
-Typewriter v0.9 requires the Kotlin JVM plugin version 2.2.10 and the Typewriter module plugin version 2.1.0. Update your Gradle configuration:
+Typewriter v0.9 requires the Kotlin JVM plugin version 2.2.10 and the Typewriter module plugin version 2.2.0. Update your Gradle configuration:
 
 ```kotlin showLineNumbers
 plugins {
     kotlin("jvm") version "2.2.10"
-    id("com.typewritermc.module-plugin") version "2.1.0"
+    id("com.typewritermc.module-plugin") version "2.2.0"
 }
 ```
 
@@ -290,6 +290,21 @@ fun refreshActivity(context: Context, position: PositionProperty)
 
 If you extend `SingleChildActivity`, override `currentChild` to select the active child.
 The base class handles caching and reuse automatically.
+
+## Nested Classes Are Written The Way The JVM Names Them
+
+Anything the module plugin writes down for the engine to load later, an `@Entry`, a `@Singleton`, a
+`@Factory`, an `@EntryListener`, a context key, or a `@ContentEditor`, is now named the way the JVM names
+it. A class nested inside another is written `com.example.MyEntry$Mode` rather than
+`com.example.MyEntry.Mode`.
+
+Nothing changes in your source. A nested class simply used to be written down under a name no class loader
+could resolve, which made it fail to load at all.
+
+:::warning[Rebuild against module plugin 2.2.0]
+The engine loads these classes by the name it is given and nothing else. An extension built with an older
+module plugin still writes the old name, so its nested classes will not be found.
+:::
 
 ## Questing Extension Changes
 The Questing extension has undergone several changes in its API and structure. Below are the key updates:

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/EntryListeners.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/EntryListeners.kt
@@ -47,11 +47,9 @@ class EntryListeners : KoinComponent, Reloadable {
     override suspend fun load() {
         val entryListeners = extensionLoader.loadedExtensions.flatMap { it.entryListeners }
 
-        val activeEventEntries = Query.find<EventEntry>().map { it::class }.distinct()
+        val activeEventEntries = Query.find<EventEntry>().mapTo(mutableSetOf()) { it::class.java.name }
 
-        val activeEntryListeners = entryListeners.filter {
-            activeEventEntries.any { activeEventEntry -> it.entryClassName == activeEventEntry.qualifiedName }
-        }
+        val activeEntryListeners = entryListeners.filter { it.entryClassName in activeEventEntries }
         activeEntryListeners.forEach {
             val method = it.method
             val eventClass =

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/loader/serializers/EntryInteractionContextKeySerializer.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/loader/serializers/EntryInteractionContextKeySerializer.kt
@@ -53,7 +53,7 @@ class EntryInteractionContextKeySerializer : DataSerializer<EntryInteractionCont
         val obj = JsonObject()
         obj.add("ref", context.serialize(src.ref))
         obj.add("key", context.serialize(src.key))
-        obj.addProperty("keyClass", src.key::class.qualifiedName)
+        obj.addProperty("keyClass", src.key::class.java.name)
         return obj
     }
 }

--- a/module-plugin/build.gradle.kts
+++ b/module-plugin/build.gradle.kts
@@ -33,7 +33,7 @@ val typewriterJavaVersion = providers.gradleProperty("typewriter.java")
     .getOrElse(configuredTypewriterJavaVersion)
 
 group = "com.typewritermc.module-plugin"
-version = "2.1.0"
+version = "2.2.0"
 
 val engineVersion = typewriterVersion.substringBefore("-beta")
 

--- a/module-plugin/extension-processor/src/main/kotlin/com/typewritermc/processors/DependencyInjectionProcessor.kt
+++ b/module-plugin/extension-processor/src/main/kotlin/com/typewritermc/processors/DependencyInjectionProcessor.kt
@@ -51,7 +51,7 @@ class DependencyInjectionProcessor(
     private fun generateBlueprint(clazz: KSClassDeclaration, type: SerializableType): JsonElement {
         logger.info("Generating $type blueprint for ${clazz.simpleName.asString()}")
 
-        val className = clazz.qualifiedName?.asString() ?: throw IllegalClassTypeException(clazz.simpleName.asString())
+        val className = clazz.binaryNameOrNull ?: throw IllegalClassTypeException(clazz.simpleName.asString())
         val name = clazz.getAnnotationsByType(Named::class).firstOrNull()?.value
 
         val blueprint = DependencyInjectionClassInfo(

--- a/module-plugin/extension-processor/src/main/kotlin/com/typewritermc/processors/EntryListenerProcessor.kt
+++ b/module-plugin/extension-processor/src/main/kotlin/com/typewritermc/processors/EntryListenerProcessor.kt
@@ -51,12 +51,12 @@ class EntryListenerProcessor(
 
         val blueprint = EntryListenerBlueprint(
             entryBlueprintId = entryAnnotation.name,
-            entryClassName = entry.fullName,
+            entryClassName = entry.binaryName,
             className = parent.className,
             methodName = function.simpleName.asString(),
             priority = listener.priority,
             ignoreCancelled = listener.ignoreCancelled,
-            arguments = function.parameters.map { it.type.resolve().fullName },
+            arguments = function.parameters.map { it.type.resolve().binaryName },
         )
 
         return blueprintJson.encodeToJsonElement(blueprint)

--- a/module-plugin/extension-processor/src/main/kotlin/com/typewritermc/processors/GlobalContextKeysProcessor.kt
+++ b/module-plugin/extension-processor/src/main/kotlin/com/typewritermc/processors/GlobalContextKeysProcessor.kt
@@ -48,7 +48,7 @@ class GlobalContextKeysProcessor(
         val annotation = clazz.getAnnotationsByType(GlobalKey::class).first()
         val name = clazz.simpleName.asString()
         val targetClass = annotation.annotationClassValue { klass }
-        val klassName = clazz.fullName
+        val klassName = clazz.binaryName
 
         val blueprint = GlobalKeyBlueprint(
             name = name,

--- a/module-plugin/extension-processor/src/main/kotlin/com/typewritermc/processors/entry/EntryProcessor.kt
+++ b/module-plugin/extension-processor/src/main/kotlin/com/typewritermc/processors/entry/EntryProcessor.kt
@@ -49,7 +49,7 @@ class EntryProcessor(
                 description = annotation.description,
                 color = annotation.color,
                 icon = annotation.icon,
-                className = clazz.qualifiedName?.asString()
+                className = clazz.binaryNameOrNull
                     ?: throw IllegalClassTypeException(clazz.simpleName.asString()),
                 extension = configuration.name,
                 tags = clazz.tags,
@@ -149,7 +149,7 @@ class EntryProcessor(
                     val type = annotation.annotationClassValue { type }
                     ContextKey(
                         it.serializedName,
-                        declaration.fullName,
+                        declaration.binaryName,
                         DataBlueprint.blueprint(type) ?: throw FailedToGenerateBlueprintException(
                             this@contextKeys,
                             CouldNotBuildBlueprintException(type.fullName)

--- a/module-plugin/processor/src/main/kotlin/com/typewritermc/processors/KSPExtensions.kt
+++ b/module-plugin/processor/src/main/kotlin/com/typewritermc/processors/KSPExtensions.kt
@@ -19,6 +19,25 @@ val KSType.fullName: String
 val KSDeclaration.fullName: String
     get() = qualifiedName?.asString() ?: simpleName.asString()
 
+/**
+ * The name the JVM knows this declaration by, separating nested classes with `$` instead of a dot.
+ * Every name that gets loaded reflectively at runtime has to use this rather than [fullName].
+ *
+ * Null for local and anonymous declarations, which cannot be loaded by name at all.
+ */
+val KSDeclaration.binaryNameOrNull: String?
+    get() {
+        val qualified = qualifiedName?.asString() ?: return null
+        val outer = parentDeclaration as? KSClassDeclaration ?: return qualified
+        return outer.binaryNameOrNull?.let { "$it$${simpleName.asString()}" }
+    }
+
+val KSDeclaration.binaryName: String
+    get() = binaryNameOrNull ?: simpleName.asString()
+
+val KSType.binaryName: String
+    get() = declaration.binaryName
+
 val Location.format: String
     get() {
         return when (this) {

--- a/module-plugin/processor/src/main/kotlin/com/typewritermc/processors/entry/modifiers/ContentEditorModifierComputer.kt
+++ b/module-plugin/processor/src/main/kotlin/com/typewritermc/processors/entry/modifiers/ContentEditorModifierComputer.kt
@@ -6,6 +6,7 @@ import com.typewritermc.core.extension.annotations.ContentEditor
 import com.typewritermc.core.utils.failure
 import com.typewritermc.core.utils.ok
 import com.typewritermc.processors.annotationClassValue
+import com.typewritermc.processors.binaryNameOrNull
 import com.typewritermc.processors.entry.DataBlueprint
 import com.typewritermc.processors.entry.DataModifier
 import com.typewritermc.processors.entry.DataModifierComputer
@@ -18,7 +19,7 @@ object ContentEditorModifierComputer : DataModifierComputer<ContentEditor> {
     context(logger: KSPLogger, resolver: Resolver)
     override fun compute(blueprint: DataBlueprint, annotation: ContentEditor): Result<DataModifier> {
         val contentMode = annotation.annotationClassValue { capturer }
-        val className = contentMode.declaration.qualifiedName?.asString()
+        val className = contentMode.declaration.binaryNameOrNull
             ?: return failure("ContentEditor ${contentMode.fullName} does not have a qualified name! It must be a non-local non-anonymous class.")
 
         return ok(DataModifier.Modifier("contentMode", className))


### PR DESCRIPTION
Load nested classes by the name the jvm knows them by

Blueprints stored the Kotlin qualified name of everything that gets loaded reflectively, which spells a nested class `Outer.Inner` where the class file is `Outer$Inner`. Nothing nested could be loaded, which covered entry classes, listener parameters, dependency injections, content editors and context keys alike.

The processor writes binary names now. Extensions built before it did still ask for the old spelling, so the loader turns the dots back into `$` from the right until something resolves. The listeners of such an entry are picked out by name too, so that match goes through the loader as well rather than comparing two spellings of the same class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with nested classes by using JVM-standard class names.
  * Fixed discovery and loading of nested event listeners, context keys, and content modes.
  * Updated serialized class identifiers for more reliable runtime resolution.

* **Documentation**
  * Updated Typewriter v0.9 Gradle requirements to module plugin 2.2.0.
  * Added migration guidance requiring projects to rebuild with module plugin 2.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->