### PR TITLE
feat(basic-extension): add the quest item audience

### DIFF
--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/InventoryFullStrategy.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/InventoryFullStrategy.kt
@@ -1,0 +1,50 @@
+package com.typewritermc.basic.entries.audience
+
+import org.bukkit.entity.Player
+import org.bukkit.inventory.ItemStack
+
+/** The last slot of the storage rows, the bottom right of the inventory screen. */
+private const val LAST_STORAGE_SLOT = 35
+
+/**
+ * What to do when a player has to be given a quest item and every slot is taken.
+ *
+ * A quest item is free to sit wherever the player puts it, so none of these name a slot to give up. Whichever
+ * one is taken comes from the hotbar or the storage rows, as those are the only slots an item is given into.
+ */
+enum class InventoryFullStrategy {
+    /** Wait for the player to make room themselves, and ask them to in the meantime. */
+    WAIT_FOR_SPACE,
+
+    /** Drop whatever is in the way on the floor. */
+    DROP,
+
+    /** Take whatever is in the way, and give it back as soon as the player has room for it again. */
+    REPLACE;
+
+    /** Frees a slot for the quest item, or null when the player has to make room themselves. */
+    fun makeRoom(player: Player): FreedSlot? {
+        if (this == WAIT_FOR_SPACE) return null
+        val slot = player.slotToGiveUp() ?: return null
+        val occupant = player.inventory.getItem(slot)
+        player.inventory.setItem(slot, null)
+        if (this == REPLACE) return FreedSlot(slot, occupant)
+        occupant?.let { player.world.dropItemNaturally(player.location, it) }
+        return FreedSlot(slot, null)
+    }
+}
+
+/** A slot the quest item may take, and the item that has to go back to the player, if any. */
+class FreedSlot(val slot: Int, val restore: ItemStack?)
+
+/**
+ * The slot to take, counting back from the end of the storage rows so that the hotbar is the last to go.
+ *
+ * Armor and the offhand are not in here, and taking one would be no help if they were: an item is handed out
+ * with [org.bukkit.inventory.Inventory.addItem], which only ever fills the storage rows and the hotbar. It
+ * would take the player's armor off for nothing. Wearing the quest item is a separate matter and is allowed.
+ *
+ * Null when every slot holds a quest item, as taking one of those to make room for another gets nowhere.
+ */
+private fun Player.slotToGiveUp(): Int? =
+    (LAST_STORAGE_SLOT downTo 0).firstOrNull { !inventory.getItem(it).isQuestItem }

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/QuestItemAudienceEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/QuestItemAudienceEntry.kt
@@ -1,0 +1,255 @@
+package com.typewritermc.basic.entries.audience
+
+import com.destroystokyo.paper.event.player.PlayerLaunchProjectileEvent
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.entries.ref
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.core.utils.launch
+import com.typewritermc.engine.paper.entry.entries.*
+import com.typewritermc.engine.paper.utils.Sync
+import com.typewritermc.engine.paper.utils.item.Item
+import io.papermc.paper.event.player.PlayerItemFrameChangeEvent
+import kotlinx.coroutines.Dispatchers
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.block.BlockPlaceEvent
+import org.bukkit.event.entity.EntityPickupItemEvent
+import org.bukkit.event.entity.EntityPlaceEvent
+import org.bukkit.event.entity.PlayerDeathEvent
+import org.bukkit.event.hanging.HangingPlaceEvent
+import org.bukkit.event.inventory.*
+import org.bukkit.event.player.*
+import org.bukkit.inventory.ItemStack
+
+private const val RECONCILE_INTERVAL_TICKS = 10
+
+@Entry("quest_item_audience", "Gives players an item they cannot lose", Colors.GREEN, "mdi:treasure-chest")
+/**
+ * The `Quest Item Audience` entry forces players in the audience to carry an item they cannot lose.
+ * The item can be moved around the inventory, but it cannot be dropped, moved into a container, used up, or
+ * lost on death. Once a player leaves the audience, the item is taken back.
+ *
+ * If the inventory is full, you can choose what happens:
+ *
+ * - **Wait For Space**: Wait until a slot frees up, and ask the player to make room in the meantime.
+ * - **Drop**: Drop whatever is in the way on the floor.
+ * - **Replace**: Take whatever is in the way, and give it back as soon as the player has room for it again.
+ *
+ * If the item belongs in a slot of its own, use the `Item Slot Binder Audience` instead.
+ *
+ * ## How could this be used?
+ * A key that has to stay with the player until they open the door it belongs to.
+ * Or a relic they have to carry back to the temple and cannot stash in a chest along the way.
+ */
+class QuestItemAudienceEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("The item the player has to carry.")
+    val item: Var<Item> = ConstVar(Item.Empty),
+    @Help("What to do when the player's inventory is full.")
+    val inventoryFull: InventoryFullStrategy = InventoryFullStrategy.WAIT_FOR_SPACE,
+) : AudienceEntry {
+    override suspend fun display(): AudienceDisplay = QuestItemAudienceDisplay(ref(), item, inventoryFull)
+}
+
+/**
+ * Refuses every way the item has of leaving the player, and leans on [QuestItemStock] for what they should be
+ * holding in the first place.
+ *
+ * The one rule the refusals are built on is that a quest item may go anywhere in the player's own inventory
+ * and nowhere else. Every container in the game takes items through the inventory click event, so
+ * [onInventoryClick] covers all of them at once. The handlers after it are the ways an item leaves an
+ * inventory without a click.
+ */
+class QuestItemAudienceDisplay(
+    private val ref: Ref<QuestItemAudienceEntry>,
+    item: Var<Item>,
+    inventoryFull: InventoryFullStrategy,
+) : AudienceDisplay(), TickableDisplay {
+    private val stock = QuestItemStock(ref, item, inventoryFull)
+    private var ticks = 0
+
+    override fun onPlayerAdd(player: Player) {
+        Dispatchers.Sync.launch { reconcile(player) }
+    }
+
+    override fun onPlayerRemove(player: Player) {
+        Dispatchers.Sync.launch { stock.takeBack(player) }
+    }
+
+    /** The pass that hands the item out and catches whatever got past the refusals, a /clear or a plugin. */
+    override fun tick() {
+        if (++ticks % RECONCILE_INTERVAL_TICKS != 0) return
+        val audience = players
+        if (audience.isEmpty()) return
+        Dispatchers.Sync.launch { audience.forEach(::reconcile) }
+    }
+
+    /**
+     * Call on the main thread, as the audience tick loop does not run there.
+     *
+     * Whether the player is still in the audience is asked again here rather than taken from whoever queued
+     * this. A tick takes the audience as it is and reaches the main thread a moment later, by which time the
+     * player may have been let go of and had their item taken back, and handing it over again would leave
+     * them with one that nothing is left to take.
+     */
+    private fun reconcile(player: Player) {
+        if (player !in this) return
+        stock.reconcile(player)
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    fun onInventoryClick(event: InventoryClickEvent) {
+        val player = event.whoClicked as? Player ?: return
+        if (event is InventoryCreativeEvent) return guardCreativeWrite(event, player)
+
+        val escapes = clickEscapesInventory(
+            action = event.action,
+            inOwnInventory = event.rawSlot >= event.view.topInventory.size,
+            ownScreen = event.view.topInventory.type == InventoryType.CRAFTING,
+            slotIsQuestItem = event.currentItem.carriesQuestItemOf(ref),
+            cursorIsQuestItem = event.cursor.carriesQuestItemOf(ref),
+            swapInIsQuestItem = event.swappedIn(player).carriesQuestItemOf(ref),
+        )
+        if (escapes) event.isCancelled = true
+    }
+
+    /**
+     * A creative client writes inventory slots itself, so it deletes the item by writing nothing over it and
+     * duplicates it by writing a copy somewhere else. Both are refused and the inventory is sent again.
+     *
+     * Moving the item is those same two writes, so a creative player cannot move it either.
+     */
+    private fun guardCreativeWrite(event: InventoryCreativeEvent, player: Player) {
+        if (!event.currentItem.carriesQuestItemOf(ref) && !event.cursor.carriesQuestItemOf(ref)) return
+        event.isCancelled = true
+        Dispatchers.Sync.launch { player.updateInventory() }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    fun onInventoryDrag(event: InventoryDragEvent) {
+        if (!event.oldCursor.carriesQuestItemOf(ref)) return
+        val topSize = event.view.topInventory.size
+        if (event.rawSlots.none { it < topSize }) return
+        event.isCancelled = true
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    fun onDropItem(event: PlayerDropItemEvent) {
+        if (!event.itemDrop.itemStack.carriesQuestItemOf(ref)) return
+        event.isCancelled = true
+    }
+
+    /**
+     * Whatever is on the cursor is dropped when the window closes, so it goes back into the inventory first.
+     *
+     * It goes back the way it is handed out in the first place, so that a full inventory is met with the same
+     * strategy rather than with the item quietly going nowhere.
+     */
+    @EventHandler(priority = EventPriority.HIGHEST)
+    fun onInventoryClose(event: InventoryCloseEvent) {
+        val player = event.player as? Player ?: return
+        val cursor = player.itemOnCursor
+        if (!cursor.carriesQuestItemOf(ref)) return
+        player.setItemOnCursor(null)
+        stock.handOut(player, cursor)
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    fun onPlayerDeath(event: PlayerDeathEvent) {
+        val drops = event.drops.iterator()
+        while (drops.hasNext()) {
+            val drop = drops.next()
+            if (!drop.carriesQuestItemOf(ref)) continue
+            drops.remove()
+            event.itemsToKeep.add(drop)
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    fun onItemConsume(event: PlayerItemConsumeEvent) {
+        if (event.item.isQuestItemOf(ref)) event.isCancelled = true
+    }
+
+    /** Breaking cannot be cancelled, so the durability is never allowed to drop in the first place. */
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    fun onItemDamage(event: PlayerItemDamageEvent) {
+        if (event.item.isQuestItemOf(ref)) event.isCancelled = true
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    fun onBlockPlace(event: BlockPlaceEvent) {
+        if (event.itemInHand.isQuestItemOf(ref)) event.isCancelled = true
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    fun onEntityPlace(event: EntityPlaceEvent) {
+        val player = event.player ?: return
+        if (player.inventory.getItem(event.hand).isQuestItemOf(ref)) event.isCancelled = true
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    fun onHangingPlace(event: HangingPlaceEvent) {
+        if (event.itemStack.carriesQuestItemOf(ref)) event.isCancelled = true
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    fun onItemFrameChange(event: PlayerItemFrameChangeEvent) {
+        if (event.action != PlayerItemFrameChangeEvent.ItemFrameChangeAction.PLACE) return
+        if (event.itemStack.carriesQuestItemOf(ref)) event.isCancelled = true
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    fun onArmorStandManipulate(event: PlayerArmorStandManipulateEvent) {
+        if (event.playerItem.carriesQuestItemOf(ref)) event.isCancelled = true
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    fun onLaunchProjectile(event: PlayerLaunchProjectileEvent) {
+        if (event.itemStack.isQuestItemOf(ref)) event.isCancelled = true
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    fun onBucketEmpty(event: PlayerBucketEmptyEvent) {
+        if (event.player.inventory.getItem(event.hand).isQuestItemOf(ref)) event.isCancelled = true
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    fun onBucketFill(event: PlayerBucketFillEvent) {
+        if (event.player.inventory.getItem(event.hand).isQuestItemOf(ref)) event.isCancelled = true
+    }
+
+    /**
+     * Signing turns a writable book into a written one, which is a different item.
+     *
+     * A book can be signed from either hand and the event does not say which, so both are matched against the
+     * meta the book had before.
+     */
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    fun onEditBook(event: PlayerEditBookEvent) {
+        if (!event.isSigning) return
+        val inventory = event.player.inventory
+        val hands = sequenceOf(inventory.itemInMainHand, inventory.itemInOffHand)
+        if (hands.none { it.isQuestItemOf(ref) && it.itemMeta == event.previousBookMeta }) return
+        event.isCancelled = true
+    }
+
+    /** A copy that leaked into the world still belongs to the player it was given to. */
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    fun onPickupItem(event: EntityPickupItemEvent) {
+        val carried = event.item.itemStack.carriedQuestItemOf(ref) ?: return
+        val picker = event.entity as? Player
+        if (picker != null && carried.questItemOwner == picker.uniqueId) return
+        event.isCancelled = true
+    }
+}
+
+/** The item a swap brings in: the offhand for an offhand swap, and otherwise the hotbar slot the key names. */
+private fun InventoryClickEvent.swappedIn(player: Player): ItemStack? = when {
+    click == ClickType.SWAP_OFFHAND -> player.inventory.itemInOffHand
+    hotbarButton >= 0 -> player.inventory.getItem(hotbarButton)
+    else -> null
+}

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/QuestItemClickRules.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/QuestItemClickRules.kt
@@ -1,0 +1,39 @@
+package com.typewritermc.basic.entries.audience
+
+import org.bukkit.event.inventory.InventoryAction
+import org.bukkit.event.inventory.InventoryAction.*
+
+/**
+ * Whether a click would take a quest item out of the player's own inventory, and so has to be cancelled.
+ *
+ * A quest item may go anywhere in the player's own inventory and nowhere else. Every container in the game
+ * takes items through this one event, so that single rule covers all of them. Pickups stay allowed, so a copy
+ * that leaked into a container can still be taken back out. A bundle that arrived with a quest item in it
+ * counts as the quest item throughout, or it would carry one into a container on the item's behalf.
+ *
+ * @param inOwnInventory whether the clicked slot is one of the player's own. The armor slots and the offhand
+ * are among those, so a quest item that is armor can be worn and any quest item can be held in the offhand.
+ * @param ownScreen whether the open screen is the player's own, whose top inventory is the 2x2 crafting grid.
+ * Shift clicking moves between the hotbar and the storage rows there, and into the container otherwise.
+ * @param swapInIsQuestItem whether the item a swap brings in is a quest item: the offhand for an offhand
+ * swap, and otherwise the hotbar slot the number key points at.
+ */
+internal fun clickEscapesInventory(
+    action: InventoryAction,
+    inOwnInventory: Boolean,
+    ownScreen: Boolean,
+    slotIsQuestItem: Boolean,
+    cursorIsQuestItem: Boolean,
+    swapInIsQuestItem: Boolean,
+): Boolean = when (action) {
+    DROP_ALL_SLOT, DROP_ONE_SLOT -> slotIsQuestItem
+    DROP_ALL_CURSOR, DROP_ONE_CURSOR -> cursorIsQuestItem
+    PICKUP_ALL_INTO_BUNDLE, PICKUP_SOME_INTO_BUNDLE -> slotIsQuestItem
+    PLACE_ALL_INTO_BUNDLE, PLACE_SOME_INTO_BUNDLE -> cursorIsQuestItem
+    PLACE_FROM_BUNDLE -> cursorIsQuestItem && !inOwnInventory
+    CLONE_STACK -> slotIsQuestItem
+    MOVE_TO_OTHER_INVENTORY -> slotIsQuestItem && inOwnInventory && !ownScreen
+    HOTBAR_SWAP -> swapInIsQuestItem && !inOwnInventory
+    PLACE_ALL, PLACE_SOME, PLACE_ONE, SWAP_WITH_CURSOR -> cursorIsQuestItem && !inOwnInventory
+    else -> false
+}

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/QuestItemStock.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/QuestItemStock.kt
@@ -1,0 +1,278 @@
+package com.typewritermc.basic.entries.audience
+
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.extensions.placeholderapi.parsePlaceholders
+import com.typewritermc.engine.paper.logger
+import com.typewritermc.engine.paper.snippets.snippet
+import com.typewritermc.engine.paper.utils.asMini
+import com.typewritermc.engine.paper.utils.item.Item
+import org.bukkit.entity.Player
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.PlayerInventory
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
+
+private val WARNING_INTERVAL = 10.seconds
+
+private val inventoryFullMessage by snippet(
+    "quest_item.inventory_full",
+    "<gray>Make room in your inventory, you are missing a quest item."
+)
+
+/**
+ * Keeps a player holding what the entry asks for: the right amount of the right item, and no quest items
+ * they have no business with.
+ *
+ * Everything here writes to an inventory, so call it on the main thread.
+ */
+internal class QuestItemStock(
+    private val ref: Ref<QuestItemAudienceEntry>,
+    private val item: Var<Item>,
+    private val inventoryFull: InventoryFullStrategy,
+) {
+    private val replacedItems = ConcurrentHashMap<UUID, MutableList<ItemStack>>()
+    private val nextWarnings = ConcurrentHashMap<UUID, Instant>()
+    private var warnedAboutEmptyItem = false
+
+    /**
+     * Brings the inventory back in line with the entry.
+     *
+     * Handing the item over for the first time is the same work as correcting it later, so both go through
+     * here.
+     */
+    fun reconcile(player: Player) {
+        unbundle(player) { it.isQuestItemOf(ref) || it.isStaleQuestItem(player) }
+        clearStaleQuestItems(player)
+        settle(player, buildItem(player))
+        restoreReplaced(player)
+    }
+
+    /**
+     * Brings what the player carries in line with [required], which is null when the entry asks for nothing.
+     *
+     * An item that turns empty is taken back rather than left behind, as a `Var<Item>` can answer with
+     * nothing for a player it answered with something for a moment ago.
+     */
+    private fun settle(player: Player, required: ItemStack?) {
+        val carried = countCarried(player)
+        if (required == null) {
+            trim(player, carried)
+            return
+        }
+
+        when {
+            carried < required.amount -> handOut(player, required.withAmount(required.amount - carried))
+            carried > required.amount -> trim(player, carried - required.amount)
+            else -> refresh(player, required)
+        }
+    }
+
+    /**
+     * Puts [stack] in the player's inventory, making room for it the way the entry asks for if there is none.
+     *
+     * The stack goes back as it is, so a quest item has to be tagged before it gets here.
+     */
+    fun handOut(player: Player, stack: ItemStack) {
+        val leftOver = player.inventory.addItem(stack).values.firstOrNull() ?: return
+
+        val freed = inventoryFull.makeRoom(player)
+        if (freed == null) {
+            warnInventoryFull(player)
+            return
+        }
+
+        freed.restore?.let { keepUntilThereIsRoom(player, it) }
+        player.inventory.setItem(freed.slot, leftOver)
+    }
+
+    /** Takes the item back, and hands over whatever a replacement was still holding on to. */
+    fun takeBack(player: Player) {
+        unbundle(player) { it.isQuestItemOf(ref) }
+        val inventory = player.inventory
+        for (slot in 0 until inventory.size) {
+            if (inventory.getItem(slot).isQuestItemOf(ref)) inventory.setItem(slot, null)
+        }
+        if (player.itemOnCursor.isQuestItemOf(ref)) player.setItemOnCursor(null)
+
+        nextWarnings.remove(player.uniqueId)
+        val replaced = replacedItems.remove(player.uniqueId) ?: return
+        replaced.forEach { player.giveOrDrop(it) }
+    }
+
+    /** How much of the entry's item the player has, counting what they are holding on the cursor. */
+    private fun countCarried(player: Player): Int {
+        val inventory = player.inventory
+        val inSlots = (0 until inventory.size)
+            .mapNotNull { inventory.getItem(it) }
+            .filter { it.belongsTo(player) }
+            .sumOf { it.amount }
+        val onCursor = if (player.itemOnCursor.belongsTo(player)) player.itemOnCursor.amount else 0
+        return inSlots + onCursor
+    }
+
+    /**
+     * Clears the quest items the player has no business holding: another player's, or one belonging to an
+     * audience that is not around any more to ask for it back.
+     */
+    private fun clearStaleQuestItems(player: Player) {
+        val inventory = player.inventory
+        for (slot in 0 until inventory.size) {
+            val stack = inventory.getItem(slot) ?: continue
+            if (stack.belongsTo(player)) continue
+            if (stack.isStaleQuestItem(player)) inventory.setItem(slot, null)
+        }
+
+        val cursor = player.itemOnCursor
+        if (cursor.belongsTo(player)) return
+        if (cursor.isStaleQuestItem(player)) player.setItemOnCursor(null)
+    }
+
+    /**
+     * Takes the stacks [matches] answers for out of every bundle the player carries.
+     *
+     * A bundle keeps what it holds out of a count of the inventory and takes it along wherever it goes, so a
+     * quest item that turns up in one is taken out of it. Nothing is allowed to put one in, but a bundle can
+     * arrive with one already inside. Ours is handed out again in the open by the rest of the pass this is
+     * part of, and a stale one is gone, which is what would have become of it in a slot of its own.
+     */
+    private fun unbundle(player: Player, matches: (ItemStack) -> Boolean) {
+        val inventory = player.inventory
+        for (slot in 0 until inventory.size) {
+            val stack = inventory.getItem(slot) ?: continue
+            if (stack.removeBundled(matches)) inventory.setItem(slot, stack)
+        }
+
+        val cursor = player.itemOnCursor
+        if (cursor.removeBundled(matches)) player.setItemOnCursor(cursor)
+    }
+
+    /**
+     * Removes the excess, taking the copy the player is least likely to have meant to keep.
+     *
+     * That is the back of the storage rows first and the hotbar after it, then what they wear or hold in the
+     * offhand. A quest item that is armor can be worn, and taking it off their head before a spare copy sat
+     * in the backpack is not what anyone means.
+     */
+    private fun trim(player: Player, excess: Int) {
+        var left = excess
+        val inventory = player.inventory
+
+        for (slot in inventory.trimOrder()) {
+            if (left <= 0) return
+            if (!inventory.getItem(slot).isQuestItemOf(ref)) continue
+            left -= inventory.takeFromSlot(slot, left)
+        }
+
+        trimCursor(player, left)
+    }
+
+    /**
+     * Empties the cursor last of all, as it is not a slot and it is the copy the player is holding.
+     *
+     * It counts towards what they carry, so leaving it out of a trim would have the next pass hand them a
+     * replacement for an item still in their hand.
+     */
+    private fun trimCursor(player: Player, excess: Int) {
+        if (excess <= 0) return
+        val cursor = player.itemOnCursor
+        if (!cursor.isQuestItemOf(ref)) return
+        if (excess >= cursor.amount) player.setItemOnCursor(null)
+        else player.setItemOnCursor(cursor.withAmount(cursor.amount - excess))
+    }
+
+    /** Rewrites the stacks when the item changed, keeping each one in the slot the player left it in. */
+    private fun refresh(player: Player, fresh: ItemStack) {
+        if (item is ConstVar) return
+        val inventory = player.inventory
+        for (slot in 0 until inventory.size) {
+            val stack = inventory.getItem(slot) ?: continue
+            if (!stack.isQuestItemOf(ref)) continue
+            val updated = fresh.withAmount(stack.amount)
+            if (stack == updated) continue
+            inventory.setItem(slot, updated)
+        }
+    }
+
+    private fun keepUntilThereIsRoom(player: Player, item: ItemStack) {
+        replacedItems.getOrPut(player.uniqueId) { mutableListOf() } += item
+    }
+
+    /**
+     * Hands back what a replacement took, as soon as the player has room for it.
+     *
+     * This runs after the quest item is settled, so room that opens up goes to the quest item first and to
+     * what made way for it after. A player who empties the slot the quest item went into gets their own item
+     * straight back into it, rather than having to wait out the audience for it.
+     */
+    private fun restoreReplaced(player: Player) {
+        val replaced = replacedItems[player.uniqueId] ?: return
+        while (replaced.isNotEmpty()) {
+            val leftOver = player.inventory.addItem(replaced.removeAt(0)).values.firstOrNull()
+            if (leftOver != null) {
+                replaced.add(0, leftOver)
+                return
+            }
+        }
+        replacedItems.remove(player.uniqueId)
+    }
+
+    private fun buildItem(player: Player): ItemStack? {
+        val stack = item.get(player).build(player)
+        if (stack.isEmpty) {
+            warnAboutEmptyItem()
+            return null
+        }
+        stack.tagAsQuestItem(ref, player)
+        return stack
+    }
+
+    /** Whether the stack is this entry's item and was given to this player rather than to somebody else. */
+    private fun ItemStack?.belongsTo(player: Player): Boolean =
+        isQuestItemOf(ref) && questItemOwner == player.uniqueId
+
+    private fun warnAboutEmptyItem() {
+        if (warnedAboutEmptyItem) return
+        warnedAboutEmptyItem = true
+        logger.warning("The quest item audience $ref has no item set, so its players are given nothing.")
+    }
+
+    private fun warnInventoryFull(player: Player) {
+        val now = Clock.System.now()
+        val nextWarning = nextWarnings[player.uniqueId]
+        if (nextWarning != null && now < nextWarning) return
+        nextWarnings[player.uniqueId] = now + WARNING_INTERVAL
+        player.sendMessage(inventoryFullMessage.parsePlaceholders(player).asMini())
+    }
+}
+
+private fun ItemStack.withAmount(amount: Int): ItemStack = clone().apply { this.amount = amount }
+
+private fun Player.giveOrDrop(item: ItemStack) {
+    inventory.addItem(item).values.forEach { world.dropItemNaturally(location, it) }
+}
+
+/** Takes up to [wanted] off the stack in [slot], and answers with how much of it it took. */
+private fun PlayerInventory.takeFromSlot(slot: Int, wanted: Int): Int {
+    val stack = getItem(slot) ?: return 0
+    val taken = minOf(wanted, stack.amount)
+    if (taken == stack.amount) setItem(slot, null)
+    else setItem(slot, stack.withAmount(stack.amount - taken))
+    return taken
+}
+
+/**
+ * Every slot, the storage rows and hotbar first and the armor slots and the offhand after them, each counting
+ * back from its own end.
+ *
+ * The two halves come from the inventory itself rather than from written down slot numbers, so between them
+ * they name every slot exactly once whatever the size turns out to be.
+ */
+private fun PlayerInventory.trimOrder(): List<Int> {
+    val stored = storageContents.size
+    return (stored - 1 downTo 0) + (size - 1 downTo stored)
+}

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/QuestItemTag.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/QuestItemTag.kt
@@ -1,0 +1,105 @@
+package com.typewritermc.basic.entries.audience
+
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.engine.paper.entry.inAudience
+import com.typewritermc.engine.paper.plugin
+import org.bukkit.NamespacedKey
+import org.bukkit.entity.Player
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.meta.BundleMeta
+import org.bukkit.persistence.PersistentDataType
+import java.util.*
+
+private val questItemKey = NamespacedKey(plugin, "quest_item")
+private val questItemOwnerKey = NamespacedKey(plugin, "quest_item_owner")
+
+/**
+ * Marks the item as the quest item of [entry], given to [owner].
+ *
+ * Use this on every stack handed to a player. The tag is the only thing that makes an item a quest item. Its
+ * contents cannot stand in for it, as a `Var<Item>` may change them and the player may split or restack them.
+ *
+ * The entry id is stored as a value instead of as part of the key, because entry ids are mixed case and a
+ * [NamespacedKey] path may not be.
+ */
+fun ItemStack.tagAsQuestItem(entry: Ref<QuestItemAudienceEntry>, owner: Player) {
+    editPersistentDataContainer {
+        it[questItemKey, PersistentDataType.STRING] = entry.id
+        it[questItemOwnerKey, PersistentDataType.STRING] = owner.uniqueId.toString()
+    }
+}
+
+/** The entry the item belongs to, or null when it is not a quest item. */
+val ItemStack?.questItemEntry: Ref<QuestItemAudienceEntry>?
+    get() {
+        if (this == null || isEmpty) return null
+        val id = persistentDataContainer.get(questItemKey, PersistentDataType.STRING) ?: return null
+        return Ref(id, QuestItemAudienceEntry::class)
+    }
+
+/** The player the item was given to, or null when it is not a quest item. */
+val ItemStack?.questItemOwner: UUID?
+    get() {
+        if (this == null || isEmpty) return null
+        val raw = persistentDataContainer.get(questItemOwnerKey, PersistentDataType.STRING) ?: return null
+        return runCatching { UUID.fromString(raw) }.getOrNull()
+    }
+
+/** Whether the item is the quest item of any entry. */
+val ItemStack?.isQuestItem: Boolean
+    get() = questItemEntry != null
+
+/** Whether the item is the quest item of [entry], whoever it was given to. */
+fun ItemStack?.isQuestItemOf(entry: Ref<QuestItemAudienceEntry>): Boolean = questItemEntry == entry
+
+/**
+ * The quest item of [entry] this stack is, or the one it carries as a bundle, or null for neither.
+ *
+ * Nothing is allowed to put a quest item into a bundle, but a bundle can turn up with one already in it. A
+ * bundle carrying one has to be stopped everywhere the item itself is, or it walks the item into a container
+ * for the player.
+ */
+fun ItemStack?.carriedQuestItemOf(entry: Ref<QuestItemAudienceEntry>): ItemStack? {
+    if (isQuestItemOf(entry)) return this
+    val bundle = this?.itemMeta as? BundleMeta ?: return null
+    return bundle.items.firstOrNull { it.isQuestItemOf(entry) }
+}
+
+/**
+ * Whether the item is the quest item of [entry], or a bundle with one inside it.
+ *
+ * Use this to ask whether something may leave the player's inventory, and [isQuestItemOf] to ask what an
+ * inventory holds, so that counting the item back up never counts a bundle as the item.
+ */
+fun ItemStack?.carriesQuestItemOf(entry: Ref<QuestItemAudienceEntry>): Boolean =
+    carriedQuestItemOf(entry) != null
+
+/**
+ * Takes the stacks [matches] answers for out of the bundle, and answers with whether it took any.
+ *
+ * Anything that is not a bundle is left alone, as is the rest of what the bundle holds. A bundle a quest item
+ * turned up in is most likely one the player keeps their own things in as well.
+ */
+fun ItemStack.removeBundled(matches: (ItemStack) -> Boolean): Boolean {
+    val meta = itemMeta as? BundleMeta ?: return false
+    val kept = meta.items.filterNot(matches)
+    if (kept.size == meta.items.size) return false
+    meta.setItems(kept)
+    itemMeta = meta
+    return true
+}
+
+/**
+ * Whether the item is tagged for something that no longer applies to [player]: another player, an entry that
+ * no longer exists, or an audience they are not in.
+ *
+ * Use this when cleaning up an inventory. A crash, a deleted entry, or an audience the player left while they
+ * were offline all leave a tagged item behind that no display takes back, so this asks about every entry
+ * rather than one.
+ */
+fun ItemStack?.isStaleQuestItem(player: Player): Boolean {
+    val entry = questItemEntry ?: return false
+    if (questItemOwner != player.uniqueId) return true
+    if (entry.get() == null) return true
+    return !player.inAudience(entry)
+}

--- a/extensions/BasicExtension/src/test/kotlin/com/typewritermc/basic/entries/audience/QuestItemClickRulesTest.kt
+++ b/extensions/BasicExtension/src/test/kotlin/com/typewritermc/basic/entries/audience/QuestItemClickRulesTest.kt
@@ -1,0 +1,80 @@
+package com.typewritermc.basic.entries.audience
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.bukkit.event.inventory.InventoryAction
+import org.bukkit.event.inventory.InventoryAction.*
+
+private fun escapes(
+    action: InventoryAction,
+    inOwnInventory: Boolean = true,
+    ownScreen: Boolean = false,
+    slot: Boolean = false,
+    cursor: Boolean = false,
+    swapIn: Boolean = false,
+) = clickEscapesInventory(action, inOwnInventory, ownScreen, slot, cursor, swapIn)
+
+class QuestItemClickRulesTest : FunSpec({
+    test("the item moves freely inside the player's own inventory, armor slots and offhand included") {
+        escapes(PLACE_ALL, inOwnInventory = true, cursor = true) shouldBe false
+        escapes(SWAP_WITH_CURSOR, inOwnInventory = true, cursor = true) shouldBe false
+        escapes(PICKUP_ALL, inOwnInventory = true, slot = true) shouldBe false
+    }
+
+    test("the item cannot be placed into an open container") {
+        escapes(PLACE_ALL, inOwnInventory = false, cursor = true) shouldBe true
+        escapes(PLACE_ONE, inOwnInventory = false, cursor = true) shouldBe true
+        escapes(SWAP_WITH_CURSOR, inOwnInventory = false, cursor = true) shouldBe true
+    }
+
+    test("shift clicking moves within the player's own screen but not into a container") {
+        escapes(MOVE_TO_OTHER_INVENTORY, inOwnInventory = true, ownScreen = true, slot = true) shouldBe false
+        escapes(MOVE_TO_OTHER_INVENTORY, inOwnInventory = true, ownScreen = false, slot = true) shouldBe true
+    }
+
+    test("number key and offhand swaps cannot push it into a container") {
+        escapes(HOTBAR_SWAP, inOwnInventory = false, swapIn = true) shouldBe true
+        escapes(HOTBAR_SWAP, inOwnInventory = true, swapIn = true) shouldBe false
+    }
+
+    test("it cannot be dropped from the slot or the cursor") {
+        escapes(DROP_ALL_SLOT, slot = true) shouldBe true
+        escapes(DROP_ONE_SLOT, slot = true) shouldBe true
+        escapes(DROP_ALL_CURSOR, cursor = true) shouldBe true
+        escapes(DROP_ONE_CURSOR, cursor = true) shouldBe true
+    }
+
+    test("it cannot be hidden inside a bundle, but may come out of one") {
+        escapes(PLACE_ALL_INTO_BUNDLE, cursor = true) shouldBe true
+        escapes(PICKUP_ALL_INTO_BUNDLE, slot = true) shouldBe true
+        escapes(PLACE_FROM_BUNDLE, slot = true, cursor = true) shouldBe false
+        escapes(PICKUP_FROM_BUNDLE, slot = true, cursor = true) shouldBe false
+    }
+
+    test("it cannot come out of a bundle straight into a container") {
+        escapes(PLACE_FROM_BUNDLE, inOwnInventory = false, cursor = true) shouldBe true
+        escapes(PICKUP_FROM_BUNDLE, inOwnInventory = false, slot = true) shouldBe false
+    }
+
+    test("a bundle carrying the item is stopped everywhere the item is") {
+        escapes(MOVE_TO_OTHER_INVENTORY, inOwnInventory = true, ownScreen = false, slot = true) shouldBe true
+        escapes(PLACE_ALL, inOwnInventory = false, cursor = true) shouldBe true
+        escapes(DROP_ALL_SLOT, slot = true) shouldBe true
+    }
+
+    test("it cannot be cloned in creative") {
+        escapes(CLONE_STACK, slot = true) shouldBe true
+    }
+
+    test("a leaked copy can be taken back out of a container") {
+        escapes(PICKUP_ALL, inOwnInventory = false, slot = true) shouldBe false
+        escapes(MOVE_TO_OTHER_INVENTORY, inOwnInventory = false, slot = true) shouldBe false
+    }
+
+    test("nothing is blocked when no quest item is involved") {
+        InventoryAction.entries.forEach { action ->
+            escapes(action, inOwnInventory = false) shouldBe false
+            escapes(action, inOwnInventory = true) shouldBe false
+        }
+    }
+})


### PR DESCRIPTION
Add the quest item audience

An item that belongs to a quest should be in the player's inventory for exactly as long as the audience holds them, and nowhere else. Getting that right is mostly a question of what to compare an item against and where to intervene.

Its contents are no help: a `Var<Item>` may resolve differently for two players, and a player may split or restack them. So the entry it belongs to and the player it was given to are kept in its persistent data instead, keyed by the entry id, which has to live in the value rather than the key because entry ids are mixed case nanoids and a NamespacedKey path forbids those.

One rule does most of the work. Every container in the game takes items through the inventory click event, so requiring that a tagged item may only land in a slot of the player's own inventory covers all of them at once, without a list of container types to keep up to date. The remaining guards are the ways an item leaves an inventory without a click, and a pass every ten ticks hands the item out and catches whatever got past all of that, such as a /clear or another plugin.

Creative is the one place the item ends up frozen rather than merely unlosable. A creative client writes inventory slots itself instead of asking the server, and a move there arrives as a delete write plus a write of a copy, neither of which can be told apart from destroying or duplicating the item. Every write on a tagged slot is refused, which means in creative the item cannot be moved either.

Three strategies for a full inventory, as an algebraic type, so drop and replace can each take the slot they need.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added quest-item audience support that equips and protects quest items, keeping the required quantity synchronized (including items held on the cursor).
  * Quest items are persistently tagged for reliable detection, ownership enforcement, and automatic cleanup when stale.
  * Inventory full handling is now configurable: wait for space, drop displaced items, or temporarily replace and restore them later.
* **Bug Fixes**
  * Prevents quest items from being consumed, used to place/take actions, duplicated, or lost on death.
* **Tests**
  * Added automated coverage to ensure quest-item interactions can’t escape the intended inventory rules across clicks, swaps, containers, bundles, and creative actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->