### PR TITLE
Move #playStepSound() into the Main Thread

### DIFF
--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/cinematic/EntityCinematicEntry.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/cinematic/EntityCinematicEntry.kt
@@ -30,6 +30,7 @@ import com.typewritermc.engine.paper.extensions.packetevents.ArmSwing
 import com.typewritermc.engine.paper.extensions.packetevents.toPacketItem
 import com.typewritermc.engine.paper.interaction.InterceptionBundle
 import com.typewritermc.engine.paper.interaction.interceptPackets
+import com.typewritermc.engine.paper.plugin
 import com.typewritermc.engine.paper.utils.toBukkitLocation
 import com.typewritermc.engine.paper.utils.toCoordinate
 import com.typewritermc.engine.paper.utils.toWorld
@@ -230,9 +231,11 @@ class EntityCinematicAction(
     }
 
     private fun playStepSound() {
-        val location = entity?.property<PositionProperty>() ?: return
-        val sound = location.toBukkitLocation().block.blockData.soundGroup.stepSound
-        player.playSound(location.toBukkitLocation(), sound, SoundCategory.NEUTRAL, 0.4f, 1.0f)
+        player.server.scheduler.runTask(plugin) { task ->
+            val location = entity?.property<PositionProperty>() ?: return@runTask
+            val sound = location.toBukkitLocation().block.blockData.soundGroup.stepSound
+            player.playSound(location.toBukkitLocation(), sound, SoundCategory.NEUTRAL, 0.4f, 1.0f)
+        }
     }
 
 


### PR DESCRIPTION
This fixes the console spam [found in this thread](https://discord.com/channels/1054708062520360960/1532191019381162226), by altering the playStepSound() method to run on the main thread instead of async

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cinematic entity step sounds by playing them in the correct server execution context.
  * Step sounds now use the entity’s latest position and the block data at that location for more accurate audio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->