### PR TITLE
fix(entity-extension): stop npcs bouncing between target locations

### DIFF
--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/PathActivityEntry.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/PathActivityEntry.kt
@@ -49,9 +49,11 @@ private class PathActivity(
 
     fun refreshActivity(context: ActivityContext, network: RoadNetwork) {
         if (nodes.size <= currentLocationIndex) {
+            val position = currentPosition
             activity.dispose(context)
-            activity = idleActivity.get()?.create(context, currentPosition) ?: IdleActivity(currentPosition)
-            activity.initialize(context, currentPosition)
+            activity = (idleActivity.get()?.create(context, position) ?: IdleActivity(position)).also {
+                it.initialize(context, position)
+            }
             return
         }
 

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/TargetLocationActivity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/TargetLocationActivity.kt
@@ -58,7 +58,8 @@ class TargetLocationActivity(
 
 
     private interface State {
-        val isValid: Boolean
+        /** Whether this state still applies to an entity standing at [position]. */
+        fun isValid(position: PositionProperty): Boolean
         fun nextState(): State
         fun createActivity(
             context: ActivityContext,
@@ -67,12 +68,11 @@ class TargetLocationActivity(
     }
 
     private inner class IdleState : State {
-        override val isValid: Boolean
-            get() {
-                if (once) return true
-                val distance = currentPosition.distanceSquared(targetPosition) ?: return true
-                return distance <= locationActivityRange * locationActivityRange
-            }
+        override fun isValid(position: PositionProperty): Boolean {
+            if (once) return true
+            val distance = position.distanceSquared(targetPosition) ?: return true
+            return distance <= locationActivityRange * locationActivityRange
+        }
 
         private var cachedActivity: EntityActivity<ActivityContext>? = null
 
@@ -89,11 +89,10 @@ class TargetLocationActivity(
     }
 
     private inner class NavigatingState : State {
-        override val isValid: Boolean
-            get() {
-                val distance = currentPosition.distanceSquared(targetPosition) ?: return true
-                return distance > locationActivityRange * locationActivityRange
-            }
+        override fun isValid(position: PositionProperty): Boolean {
+            val distance = position.distanceSquared(targetPosition) ?: return true
+            return distance > locationActivityRange * locationActivityRange
+        }
 
         override fun nextState(): State = states[1]
 
@@ -114,24 +113,33 @@ class TargetLocationActivity(
     }
 
     override fun initialize(context: ActivityContext, position: PositionProperty) {
-        if (!state.isValid) {
+        activateState(context, position)
+    }
+
+    override fun tick(context: ActivityContext): TickResult {
+        val position = currentPosition
+        if (!state.isValid(position)) {
+            currentActivity.dispose(context)
+            activateState(context, position)
+        }
+
+        return currentActivity.tick(context)
+    }
+
+    /**
+     * Advances to the next state when the current one no longer applies at [position], and starts its activity there.
+     *
+     * The activity of a state can be reused across activations, so [position] has to be threaded through explicitly:
+     * a reused activity still reports the position it was left at, which is not where the entity stands now.
+     */
+    private fun activateState(context: ActivityContext, position: PositionProperty) {
+        if (!state.isValid(position)) {
             state = state.nextState()
         }
 
         currentActivity = state.createActivity(context, position).also {
             it.initialize(context, position)
         }
-    }
-
-    override fun tick(context: ActivityContext): TickResult {
-        if (!state.isValid) {
-            currentActivity.dispose(context)
-            state = state.nextState()
-            currentActivity = state.createActivity(context, currentPosition)
-            currentActivity.initialize(context, currentPosition)
-        }
-
-        return currentActivity.tick(context)
     }
 
     override fun dispose(context: ActivityContext) {


### PR DESCRIPTION
An individual advanced entity instance whose audience activity switches between two target location activities would walk to the spawn target, snap back to the other target, and repeat forever. It only showed up when the spawn target's idle activity was one that writes its own position on initialize, such as look close or random look.

Since 94c9d740dd activities are created once per npc and reused across activations, so an activity that is not currently running still reports the position it was left at. Two places in TargetLocationActivity read that leftover position as if it were where the entity stands:

- initialize validated the current state against `currentPosition`, the position frozen by the previous dispose, instead of the position it was handed. Coming back to the spawn target from somewhere else, the idle state still saw the old spawn position, decided the entity had already arrived, and handed the far away position to its cached idle activity, which stored it as its own.
- tick reassigned `currentActivity` and only then read `currentPosition` for the initialize call, so the incoming activity was initialized with its own stale position rather than the handover position. That made the stored position permanent: every arrival at the target restored the idle activity to the other target's location.

State.isValid now takes the position to validate, and both call sites thread it through explicitly via activateState.

PathActivity had the same assign-then-read pattern in its final node branch. It was harmless there because the idle activity is created fresh each time, but it breaks the moment that activity gets cached, so it now captures the position first.

The remaining activities are unaffected: PatrolActivity, RandomPatrolActivity and PathActivity's navigation branch build the activity with `X.also { it.initialize(...) }`, where the right hand side is fully evaluated before the assignment, so they still read the old activity's position.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved entity activity transitions after completing a movement path.
  * Improved target-location activity state handling during initialization and updates.
  * Ensured previous activities are properly disposed of when transitioning between states.
  * Improved consistency when creating fallback and replacement activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->