### PR TITLE
refactor(engine-paper,entity-extension)!: split pausing an activity from disposing it

### DIFF
--- a/documentation/docs/develop/02-extensions/09-api-changes/0.9.mdx
+++ b/documentation/docs/develop/02-extensions/09-api-changes/0.9.mdx
@@ -235,11 +235,14 @@ interface EntityActivity<Context : ActivityContext> {
     fun dispose() {}
 
     val currentPosition: PositionProperty
+    val currentProperties: List<EntityProperty> get() = listOf(currentPosition)
 }
 ```
 
-- `activate` starts the activity, at `position`. It runs for the first activation **and** for every
-  resume, and the activity must adopt `position`, which may differ from wherever it left off.
+- `activate` starts the activity, at `position`. It runs for the first activation, for every
+  resume, and again while the activity is already running when whatever owns it is itself
+  activated. The activity must adopt `position` every time and restart its work from there, since
+  it may differ from wherever the activity left off.
 - `deactivate` pauses the activity. Cancel jobs, release listeners, drop temporary resources, keep
   progress. The activity may be activated again afterwards.
 - `dispose` is final teardown. It takes no context, because `deactivate` always runs first, so
@@ -250,7 +253,8 @@ Typewriter guarantees:
 1. `activate` always runs before any `tick`.
 2. `deactivate` only ever follows an `activate`, and never twice in a row.
 3. `dispose` runs at most once, after `deactivate`, and nothing follows it.
-4. `activate` may run many times, each with a possibly different position.
+4. `activate` may run many times, each with a possibly different position, including twice with no
+   `deactivate` between them. Make it safe to call on an activity that is already running.
 
 ### Migrating
 
@@ -269,6 +273,7 @@ override fun dispose(context: ActivityContext) {
 // highlight-green-start
 override fun activate(context: ActivityContext, position: PositionProperty) {
     currentPosition = position
+    searchJob?.cancel()
     searchJob = startSearching()
 }
 
@@ -280,6 +285,10 @@ override fun deactivate(context: ActivityContext) {
 
 In almost every case `initialize` becomes `activate` and the body of the old `dispose` becomes
 `deactivate`. Leave `dispose` empty unless the activity holds child activities of its own.
+
+Note the extra `cancel` in `activate`. Because `activate` can run on an activity that is already
+running, anything it starts has to replace what the previous activation started rather than run
+alongside it.
 
 ### Holding child activities
 
@@ -296,7 +305,7 @@ class MyActivity(
     private val children = entryActivityHolder<ActivityContext>(startPosition)
 
     override fun activate(context: ActivityContext, position: PositionProperty) {
-        children.switchTo(child, context, position)
+        children.activate(child, context, position)
     }
 
     override fun tick(context: ActivityContext): TickResult = children.tick(context)

--- a/documentation/docs/develop/02-extensions/09-api-changes/0.9.mdx
+++ b/documentation/docs/develop/02-extensions/09-api-changes/0.9.mdx
@@ -210,8 +210,8 @@ The listener now receives a context with `player`, `ref`, `oldValue`, and `newVa
 ## Entity Activity Lifecycle Changes
 
 Entity activities are no longer recreated every time they become active.
-Each activity instance is created once per NPC and reused for the lifetime of that entity display.
-This allows activities to hold runtime state and resume where they left off when interrupted.
+Each activity instance is created once per NPC and reused for the lifetime of that entity display,
+so an activity can hold runtime state and resume where it left off after an interruption.
 
 A common example is pathing: an NPC walking a predefined path can be interrupted by an
 `InDialogueActivity`. When the dialogue ends, the path activity resumes from the next node
@@ -223,73 +223,114 @@ instead of restarting from the beginning.
 class, not on the entry.
 :::
 
-### `initialize` Signature
+### The lifecycle
 
-The `initialize` method now receives the entity's current position as a second parameter.
+`EntityActivity` has four methods instead of three.
 
 ```kotlin showLineNumbers
-// highlight-red
-override fun initialize(context: ActivityContext) {
-// highlight-green
-override fun initialize(context: ActivityContext, position: PositionProperty) {
+interface EntityActivity<Context : ActivityContext> {
+    fun activate(context: Context, position: PositionProperty)
+    fun tick(context: Context): TickResult
+    fun deactivate(context: Context) {}
+    fun dispose() {}
+
+    val currentPosition: PositionProperty
+}
 ```
 
-This applies to all `EntityActivity` implementations, including `GenericEntityActivity`,
-`SharedEntityActivity`, and `IndividualEntityActivity`.
+- `activate` starts the activity, at `position`. It runs for the first activation **and** for every
+  resume, and the activity must adopt `position`, which may differ from wherever it left off.
+- `deactivate` pauses the activity. Cancel jobs, release listeners, drop temporary resources, keep
+  progress. The activity may be activated again afterwards.
+- `dispose` is final teardown. It takes no context, because `deactivate` always runs first, so
+  anything that touches viewers belongs there.
 
-### Designing Stateful Activities
+Typewriter guarantees:
 
-Because activity instances are reused, `initialize` may be called multiple times during an
-NPC's lifetime, for example when switching between child activities in a
-`SingleChildActivity`. Follow these guidelines when implementing custom activities:
+1. `activate` always runs before any `tick`.
+2. `deactivate` only ever follows an `activate`, and never twice in a row.
+3. `dispose` runs at most once, after `deactivate`, and nothing follows it.
+4. `activate` may run many times, each with a possibly different position.
 
-1. **Do not reset progress in `initialize`.** Use `initialize` to sync the current position
-   or start child activities. Preserve fields like path indices, timers, or navigation state
-   across calls.
-2. **Do not reset persistent state in `dispose`.** `dispose` is called whenever an activity is
-   deactivated, including when `SingleChildActivity` switches between children (e.g. when
-   dialogue interrupts pathing). Activity instances are cached and reused, so fields like path
-   indices or navigation progress must survive `dispose`. Use `dispose` only to cancel jobs,
-   release listeners, or clean up other temporary resources.
-3. **Lazy-create child activities.** Create child activity instances once and reuse them.
-   Check whether a child already exists before calling `create()`:
+### Migrating
 
 ```kotlin showLineNumbers
 // highlight-red-start
-override fun initialize(context: ActivityContext) {
-    childActivity = child.get()?.create(context, currentPosition) ?: IdleActivity(currentPosition)
-    childActivity.initialize(context)
+override fun initialize(context: ActivityContext, position: PositionProperty) {
+    currentPosition = position
+    searchJob = startSearching()
+}
+
+override fun dispose(context: ActivityContext) {
+    searchJob?.cancel()
 }
 // highlight-red-end
 
 // highlight-green-start
-override fun initialize(context: ActivityContext, position: PositionProperty) {
-    if (childActivity is IdleActivity) {
-        childActivity = child.get()?.create(context, position) ?: IdleActivity(position)
-    }
-    childActivity.initialize(context, position)
+override fun activate(context: ActivityContext, position: PositionProperty) {
+    currentPosition = position
+    searchJob = startSearching()
+}
+
+override fun deactivate(context: ActivityContext) {
+    searchJob?.cancel()
 }
 // highlight-green-end
 ```
 
-### `SingleChildActivity` Caching
+In almost every case `initialize` becomes `activate` and the body of the old `dispose` becomes
+`deactivate`. Leave `dispose` empty unless the activity holds child activities of its own.
 
-`SingleChildActivity` now caches child activity instances per child entry reference.
-When switching between children (e.g. between a talking and idle activity in
-`InDialogueActivity`), the current child is disposed and the cached instance is reactivated
-with `initialize` instead of calling `create()` again.
+### Holding child activities
 
-The `refreshActivity` method signature has also changed:
+An activity that switches between children should not cache them itself. Use
+`ChildActivityHolder`, which creates each child once, activates the incoming one at the position it
+is handed, deactivates the outgoing one, and on `dispose` tears down every child it created rather
+than only the one showing.
 
 ```kotlin showLineNumbers
-// highlight-red
-fun refreshActivity(context: Context)
-// highlight-green
-fun refreshActivity(context: Context, position: PositionProperty)
+class MyActivity(
+    private val child: Ref<out EntityActivityEntry>,
+    startPosition: PositionProperty,
+) : GenericEntityActivity {
+    private val children = entryActivityHolder<ActivityContext>(startPosition)
+
+    override fun activate(context: ActivityContext, position: PositionProperty) {
+        children.switchTo(child, context, position)
+    }
+
+    override fun tick(context: ActivityContext): TickResult = children.tick(context)
+
+    override fun deactivate(context: ActivityContext) = children.deactivate(context)
+
+    override fun dispose() = children.dispose()
+
+    override val currentPosition: PositionProperty
+        get() = children.currentPosition
+}
 ```
 
-If you extend `SingleChildActivity`, override `currentChild` to select the active child.
-The base class handles caching and reuse automatically.
+`SingleChildActivity` is built on the same holder, so subclasses keep overriding `currentChild` and
+nothing else. Its `refreshActivity` method has been removed; switching now happens automatically
+whenever `currentChild` returns a different reference.
+
+`entryActivityHolder` is the entry reference flavour of `ChildActivityHolder`, which is keyed by
+anything you like. When an activity already knows its children rather than reading them from a
+configured reference, key the holder on your own type and build them yourself:
+
+```kotlin showLineNumbers
+private enum class Mode { NAVIGATING, IDLE }
+
+private val children = ChildActivityHolder<Mode, ActivityContext>(startPosition) { mode, context, position ->
+    when (mode) {
+        Mode.NAVIGATING -> NavigationActivity(gps, position)
+        Mode.IDLE -> idleActivity.get()?.create(context, position) ?: IdleActivity(position)
+    }
+}
+```
+
+Each key gets its child built once and kept, so switching back to a mode resumes it rather than
+starting it over.
 
 ## Nested Classes Are Written The Way The JVM Names Them
 

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/entity/ActivityManager.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/entity/ActivityManager.kt
@@ -6,6 +6,7 @@ import org.bukkit.entity.Player
 
 class ActivityManager<Context : ActivityContext>(
     private val activity: EntityActivity<in Context>,
+    private val reportViolation: (String) -> Unit = { logger.severe(it) },
 ) {
     private enum class State { CREATED, ACTIVE, DISPOSED }
 
@@ -28,7 +29,7 @@ class ActivityManager<Context : ActivityContext>(
         if (state != State.ACTIVE) {
             if (reportedTickViolation) return
             reportedTickViolation = true
-            logger.severe("Ticked an activity manager that is $state. This is a Typewriter bug, please report it.")
+            reportViolation("Ticked an activity manager that is $state. This is a Typewriter bug, please report it.")
             return
         }
         activity.tick(context)

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/entity/ActivityManager.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/entity/ActivityManager.kt
@@ -1,11 +1,17 @@
 package com.typewritermc.engine.paper.entry.entity
 
 import com.typewritermc.engine.paper.entry.entries.EntityProperty
+import com.typewritermc.engine.paper.logger
 import org.bukkit.entity.Player
 
 class ActivityManager<Context : ActivityContext>(
     private val activity: EntityActivity<in Context>,
 ) {
+    private enum class State { CREATED, ACTIVE, DISPOSED }
+
+    private var state = State.CREATED
+    private var reportedTickViolation = false
+
     val position: PositionProperty
         get() = activity.currentPosition
 
@@ -13,10 +19,18 @@ class ActivityManager<Context : ActivityContext>(
         get() = activity.currentProperties
 
     fun initialize(context: Context) {
-        activity.initialize(context, position)
+        check(state == State.CREATED) { "An activity manager can only be initialized once, this one is $state" }
+        activity.activate(context, position)
+        state = State.ACTIVE
     }
 
     fun tick(context: Context) {
+        if (state != State.ACTIVE) {
+            if (reportedTickViolation) return
+            reportedTickViolation = true
+            logger.severe("Ticked an activity manager that is $state. This is a Typewriter bug, please report it.")
+            return
+        }
         activity.tick(context)
     }
 
@@ -33,6 +47,9 @@ class ActivityManager<Context : ActivityContext>(
     }
 
     fun dispose(context: Context) {
-        activity.dispose(context)
+        if (state == State.DISPOSED) return
+        if (state == State.ACTIVE) activity.deactivate(context)
+        activity.dispose()
+        state = State.DISPOSED
     }
 }

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/entity/ChildActivityHolder.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/entity/ChildActivityHolder.kt
@@ -1,0 +1,90 @@
+package com.typewritermc.engine.paper.entry.entity
+
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.engine.paper.entry.entries.EntityActivityEntry
+import com.typewritermc.engine.paper.entry.entries.EntityProperty
+
+/**
+ * Owns the child activities an activity switches between, one per [Key].
+ *
+ * Each child is built once by [create] and kept for the lifetime of the holder, so it resumes where
+ * it left off. Switching deactivates the outgoing child and activates the incoming one at the
+ * position it is handed. Disposing tears down every child that was ever built, not only the one
+ * showing.
+ *
+ * [create] returns null when the child cannot be built yet, for instance because the entry it comes
+ * from is not loaded. The entity then stands still and the next activation tries again, so a child
+ * that becomes available later still runs.
+ *
+ * Use [entryActivityHolder] when the children come from entry references. Use this directly when
+ * the owner already knows its children, with an enum for the key.
+ */
+class ChildActivityHolder<Key : Any, Context : ActivityContext>(
+    startPosition: PositionProperty,
+    private val create: (key: Key, context: Context, position: PositionProperty) -> EntityActivity<in Context>?,
+) {
+    private val children = mutableMapOf<Key, EntityActivity<in Context>>()
+    private var active: EntityActivity<in Context> = IdleActivity(startPosition)
+    private var activeKey: Key? = null
+
+    val currentKey: Key?
+        get() = activeKey
+
+    val currentPosition: PositionProperty
+        get() = active.currentPosition
+
+    val currentProperties: List<EntityProperty>
+        get() = active.currentProperties
+
+    /**
+     * Activate the child for [key] at [position], even when it is already the active one.
+     *
+     * Use this when the owner itself is being activated, so a child that was never paused still
+     * adopts the position the owner was handed.
+     */
+    fun activate(key: Key, context: Context, position: PositionProperty) {
+        if (activeKey != null && activeKey != key) active.deactivate(context)
+
+        val child: EntityActivity<in Context> = children[key]
+            ?: create(key, context, position)?.also { children[key] = it }
+            ?: IdleActivity(position)
+
+        activeKey = key
+        active = child
+        active.activate(context, position)
+    }
+
+    /** Activate the child for [key] only when it is not already the active one. */
+    fun switchTo(key: Key, context: Context, position: PositionProperty) {
+        if (activeKey == key) return
+        activate(key, context, position)
+    }
+
+    fun tick(context: Context): TickResult = active.tick(context)
+
+    fun deactivate(context: Context) {
+        if (activeKey == null) return
+        active.deactivate(context)
+        activeKey = null
+    }
+
+    fun dispose() {
+        children.values.forEach { it.dispose() }
+        children.clear()
+        activeKey = null
+    }
+}
+
+typealias EntryActivityHolder<Context> = ChildActivityHolder<Ref<out EntityActivityEntry>, Context>
+
+/**
+ * A [ChildActivityHolder] whose children come from entry references.
+ *
+ * A reference that is unset, or that does not resolve, leaves the entity standing still until it
+ * does.
+ */
+fun <Context : ActivityContext> entryActivityHolder(
+    startPosition: PositionProperty,
+): EntryActivityHolder<Context> = ChildActivityHolder(startPosition) { ref, context, position ->
+    ref.get()?.create(context, position)
+}

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/entity/EntityActivity.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/entity/EntityActivity.kt
@@ -15,8 +15,10 @@ interface EntityActivity<Context : ActivityContext> {
     /**
      * Start running at [position].
      *
-     * Called for the first activation and for every resume after a [deactivate]. The activity must
-     * adopt [position]; it may differ from wherever the activity left off.
+     * Called for the first activation, for every resume after a [deactivate], and again while the
+     * activity is already running when whatever owns it is itself activated. The activity must
+     * adopt [position] every time and restart its work from there; it may differ from wherever the
+     * activity left off.
      */
     fun activate(context: Context, position: PositionProperty)
 

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/entity/EntityActivity.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/entity/EntityActivity.kt
@@ -42,7 +42,9 @@ interface IndividualEntityActivity : EntityActivity<IndividualActivityContext>
 interface GenericEntityActivity : EntityActivity<ActivityContext>
 
 class IdleActivity(override var currentPosition: PositionProperty) : GenericEntityActivity {
-    override fun initialize(context: ActivityContext, position: PositionProperty) {}
+    override fun initialize(context: ActivityContext, position: PositionProperty) {
+        currentPosition = position
+    }
 
     override fun tick(context: ActivityContext): TickResult = TickResult.IGNORED
 

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/entity/EntityActivity.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/entity/EntityActivity.kt
@@ -12,9 +12,30 @@ interface ActivityCreator {
 }
 
 interface EntityActivity<Context : ActivityContext> {
-    fun initialize(context: Context, position: PositionProperty)
+    /**
+     * Start running at [position].
+     *
+     * Called for the first activation and for every resume after a [deactivate]. The activity must
+     * adopt [position]; it may differ from wherever the activity left off.
+     */
+    fun activate(context: Context, position: PositionProperty)
+
     fun tick(context: Context): TickResult
-    fun dispose(context: Context)
+
+    /**
+     * Stop running but keep progress. Cancel jobs, release listeners, drop temporary resources.
+     *
+     * The activity may be activated again afterwards.
+     */
+    fun deactivate(context: Context) {}
+
+    /**
+     * Final teardown. Never activated again.
+     *
+     * Takes no context because [deactivate] always runs first, so anything that touches viewers
+     * belongs there.
+     */
+    fun dispose() {}
 
     val currentPosition: PositionProperty
     val currentProperties: List<EntityProperty> get() = listOf(currentPosition)
@@ -42,13 +63,11 @@ interface IndividualEntityActivity : EntityActivity<IndividualActivityContext>
 interface GenericEntityActivity : EntityActivity<ActivityContext>
 
 class IdleActivity(override var currentPosition: PositionProperty) : GenericEntityActivity {
-    override fun initialize(context: ActivityContext, position: PositionProperty) {
+    override fun activate(context: ActivityContext, position: PositionProperty) {
         currentPosition = position
     }
 
     override fun tick(context: ActivityContext): TickResult = TickResult.IGNORED
-
-    override fun dispose(context: ActivityContext) {}
 
     companion object : ActivityCreator {
         override fun create(
@@ -59,47 +78,31 @@ class IdleActivity(override var currentPosition: PositionProperty) : GenericEnti
 }
 
 abstract class SingleChildActivity<Context : ActivityContext>(
-    startLocation: PositionProperty,
+    startPosition: PositionProperty,
 ) : EntityActivity<Context> {
-    protected var child: Ref<out EntityActivityEntry> = emptyRef()
-        private set
-    private var currentActivity: EntityActivity<in Context> = IdleActivity(startLocation)
+    private val children = entryActivityHolder<Context>(startPosition)
 
-    private val activityCache = mutableMapOf<Ref<out EntityActivityEntry>, EntityActivity<in Context>>()
+    protected val child: Ref<out EntityActivityEntry>?
+        get() = children.currentKey
 
-    override fun initialize(context: Context, position: PositionProperty) {
-        child = currentChild(context)
-        refreshActivity(context, position)
+    override fun activate(context: Context, position: PositionProperty) {
+        children.activate(currentChild(context), context, position)
     }
-
-    fun refreshActivity(context: Context, position: PositionProperty) {
-        currentActivity.dispose(context)
-        currentActivity = activityCache.getOrPut(child) {
-            child.get()?.create(context, position) ?: IdleActivity(position)
-        }
-        currentActivity.initialize(context, position)
-    }
-
 
     override fun tick(context: Context): TickResult {
-        val correctChild = currentChild(context)
-        if (child != correctChild) {
-            child = correctChild
-            refreshActivity(context, currentPosition)
-        }
-        return currentActivity.tick(context)
+        children.switchTo(currentChild(context), context, children.currentPosition)
+        return children.tick(context)
     }
 
-    override fun dispose(context: Context) {
-        currentActivity.dispose(context)
-        child = emptyRef()
-    }
+    override fun deactivate(context: Context) = children.deactivate(context)
+
+    override fun dispose() = children.dispose()
 
     override val currentPosition: PositionProperty
-        get() = currentActivity.currentPosition
+        get() = children.currentPosition
 
     override val currentProperties: List<EntityProperty>
-        get() = currentActivity.currentProperties
+        get() = children.currentProperties
 
     abstract fun currentChild(context: Context): Ref<out EntityActivityEntry>
 }

--- a/engine/engine-paper/src/test/kotlin/com/typewritermc/entity/ActivityManagerSpec.kt
+++ b/engine/engine-paper/src/test/kotlin/com/typewritermc/entity/ActivityManagerSpec.kt
@@ -89,8 +89,7 @@ class ActivityManagerSpec : FunSpec({
 
     test("ticking before initialize never reaches the activity") {
         val activity = CountingActivity(spawn)
-        val reported = mutableListOf<String>()
-        val manager = ActivityManager(activity) { reported += it }
+        val manager = ActivityManager(activity) { }
 
         manager.tick(ManagerContext())
 
@@ -99,8 +98,7 @@ class ActivityManagerSpec : FunSpec({
 
     test("ticking after dispose never reaches the activity") {
         val activity = CountingActivity(spawn)
-        val reported = mutableListOf<String>()
-        val manager = ActivityManager(activity) { reported += it }
+        val manager = ActivityManager(activity) { }
         manager.initialize(ManagerContext())
 
         manager.tick(ManagerContext())

--- a/engine/engine-paper/src/test/kotlin/com/typewritermc/entity/ActivityManagerSpec.kt
+++ b/engine/engine-paper/src/test/kotlin/com/typewritermc/entity/ActivityManagerSpec.kt
@@ -23,13 +23,17 @@ private class CountingActivity(override var currentPosition: PositionProperty) :
     var activations = 0
     var deactivations = 0
     var disposals = 0
+    var ticks = 0
 
     override fun activate(context: ActivityContext, position: PositionProperty) {
         currentPosition = position
         activations++
     }
 
-    override fun tick(context: ActivityContext): TickResult = TickResult.CONSUMED
+    override fun tick(context: ActivityContext): TickResult {
+        ticks++
+        return TickResult.CONSUMED
+    }
 
     override fun deactivate(context: ActivityContext) {
         deactivations++
@@ -81,5 +85,42 @@ class ActivityManagerSpec : FunSpec({
 
         activity.deactivations shouldBe 1
         activity.disposals shouldBe 1
+    }
+
+    test("ticking before initialize never reaches the activity") {
+        val activity = CountingActivity(spawn)
+        val reported = mutableListOf<String>()
+        val manager = ActivityManager(activity) { reported += it }
+
+        manager.tick(ManagerContext())
+
+        activity.ticks shouldBe 0
+    }
+
+    test("ticking after dispose never reaches the activity") {
+        val activity = CountingActivity(spawn)
+        val reported = mutableListOf<String>()
+        val manager = ActivityManager(activity) { reported += it }
+        manager.initialize(ManagerContext())
+
+        manager.tick(ManagerContext())
+        activity.ticks shouldBe 1
+
+        manager.dispose(ManagerContext())
+        manager.tick(ManagerContext())
+
+        activity.ticks shouldBe 1
+    }
+
+    test("a refused tick is reported once, not every tick") {
+        val activity = CountingActivity(spawn)
+        val reported = mutableListOf<String>()
+        val manager = ActivityManager(activity) { reported += it }
+
+        manager.tick(ManagerContext())
+        manager.tick(ManagerContext())
+        manager.tick(ManagerContext())
+
+        reported.size shouldBe 1
     }
 })

--- a/engine/engine-paper/src/test/kotlin/com/typewritermc/entity/ActivityManagerSpec.kt
+++ b/engine/engine-paper/src/test/kotlin/com/typewritermc/entity/ActivityManagerSpec.kt
@@ -1,0 +1,85 @@
+package com.typewritermc.entity
+
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.entries.emptyRef
+import com.typewritermc.core.utils.point.World
+import com.typewritermc.engine.paper.entry.entity.*
+import com.typewritermc.engine.paper.entry.entries.EntityInstanceEntry
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.bukkit.entity.Player
+
+private val managerWorld = World("manager-world")
+
+private class ManagerContext : ActivityContext {
+    override val instanceRef: Ref<out EntityInstanceEntry> = emptyRef()
+    override val isViewed: Boolean = false
+    override val viewers: List<Player> = emptyList()
+    override val entityState: EntityState = EntityState()
+}
+
+private class CountingActivity(override var currentPosition: PositionProperty) : GenericEntityActivity {
+    var activations = 0
+    var deactivations = 0
+    var disposals = 0
+
+    override fun activate(context: ActivityContext, position: PositionProperty) {
+        currentPosition = position
+        activations++
+    }
+
+    override fun tick(context: ActivityContext): TickResult = TickResult.CONSUMED
+
+    override fun deactivate(context: ActivityContext) {
+        deactivations++
+    }
+
+    override fun dispose() {
+        disposals++
+    }
+}
+
+class ActivityManagerSpec : FunSpec({
+    val spawn = PositionProperty(managerWorld, 0.0, 64.0, 0.0, 0f, 0f)
+
+    test("initializing activates the activity where it already stands") {
+        val activity = CountingActivity(spawn)
+        val manager = ActivityManager(activity)
+
+        manager.initialize(ManagerContext())
+
+        activity.activations shouldBe 1
+        activity.currentPosition shouldBe spawn
+    }
+
+    test("initializing twice is refused") {
+        val manager = ActivityManager(CountingActivity(spawn))
+        manager.initialize(ManagerContext())
+
+        shouldThrow<IllegalStateException> { manager.initialize(ManagerContext()) }
+    }
+
+    test("disposing deactivates before it disposes") {
+        val activity = CountingActivity(spawn)
+        val manager = ActivityManager(activity)
+        manager.initialize(ManagerContext())
+
+        manager.dispose(ManagerContext())
+
+        activity.deactivations shouldBe 1
+        activity.disposals shouldBe 1
+    }
+
+    test("disposing twice only tears down once") {
+        val activity = CountingActivity(spawn)
+        val manager = ActivityManager(activity)
+        manager.initialize(ManagerContext())
+
+        manager.dispose(ManagerContext())
+        manager.dispose(ManagerContext())
+
+        activity.deactivations shouldBe 1
+        activity.disposals shouldBe 1
+    }
+})

--- a/engine/engine-paper/src/test/kotlin/com/typewritermc/entity/ChildActivityHolderSpec.kt
+++ b/engine/engine-paper/src/test/kotlin/com/typewritermc/entity/ChildActivityHolderSpec.kt
@@ -1,0 +1,182 @@
+package com.typewritermc.entity
+
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.entries.emptyRef
+import com.typewritermc.core.utils.point.World
+import com.typewritermc.engine.paper.entry.entity.*
+import com.typewritermc.engine.paper.entry.entries.EntityActivityEntry
+import com.typewritermc.engine.paper.entry.entries.EntityInstanceEntry
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.bukkit.entity.Player
+
+private val world = World("holder-world")
+
+private fun positionAt(x: Double, y: Double, z: Double) = PositionProperty(world, x, y, z, 0f, 0f)
+
+private class HolderContext : ActivityContext {
+    override val instanceRef: Ref<out EntityInstanceEntry> = emptyRef()
+    override val isViewed: Boolean = false
+    override val viewers: List<Player> = emptyList()
+    override val entityState: EntityState = EntityState()
+}
+
+private class RecordingActivity(override var currentPosition: PositionProperty) : GenericEntityActivity {
+    var activations = 0
+    var deactivations = 0
+    var disposals = 0
+
+    override fun activate(context: ActivityContext, position: PositionProperty) {
+        currentPosition = position
+        activations++
+    }
+
+    override fun tick(context: ActivityContext): TickResult = TickResult.CONSUMED
+
+    override fun deactivate(context: ActivityContext) {
+        deactivations++
+    }
+
+    override fun dispose() {
+        disposals++
+    }
+}
+
+private class RecordingEntry(
+    override val id: String,
+    override val name: String,
+    private val activity: RecordingActivity,
+) : EntityActivityEntry {
+    override fun create(context: ActivityContext, currentLocation: PositionProperty): EntityActivity<ActivityContext> =
+        activity
+}
+
+private fun refTo(id: String, activity: RecordingActivity) =
+    Ref(id, EntityActivityEntry::class, RecordingEntry(id, id, activity))
+
+class ChildActivityHolderSpec : FunSpec({
+    val spawn = positionAt(0.0, 64.0, 0.0)
+    val target = positionAt(20.0, 64.0, 20.0)
+
+    test("switching activates the incoming child at the given position") {
+        val context = HolderContext()
+        val walking = RecordingActivity(spawn)
+        val holder = entryActivityHolder<ActivityContext>(spawn)
+
+        holder.switchTo(refTo("walking", walking), context, target)
+
+        walking.activations shouldBe 1
+        holder.currentPosition shouldBe target
+    }
+
+    test("switching deactivates the outgoing child exactly once") {
+        val context = HolderContext()
+        val first = RecordingActivity(spawn)
+        val second = RecordingActivity(spawn)
+        val holder = entryActivityHolder<ActivityContext>(spawn)
+
+        holder.switchTo(refTo("first", first), context, spawn)
+        holder.switchTo(refTo("second", second), context, target)
+
+        first.deactivations shouldBe 1
+        second.activations shouldBe 1
+    }
+
+    test("a child that is used again is activated at the position it is given") {
+        val context = HolderContext()
+        val idle = RecordingActivity(spawn)
+        val walking = RecordingActivity(spawn)
+        val idleRef = refTo("idle", idle)
+
+        val holder = entryActivityHolder<ActivityContext>(spawn)
+        holder.switchTo(idleRef, context, spawn)
+        holder.switchTo(refTo("walking", walking), context, spawn)
+        holder.switchTo(idleRef, context, target)
+
+        idle.activations shouldBe 2
+        holder.currentPosition shouldBe target
+    }
+
+    test("activating the same child again moves it to the new position") {
+        val context = HolderContext()
+        val child = RecordingActivity(spawn)
+        val ref = refTo("child", child)
+        val holder = entryActivityHolder<ActivityContext>(spawn)
+
+        holder.activate(ref, context, spawn)
+        holder.activate(ref, context, target)
+
+        child.activations shouldBe 2
+        child.deactivations shouldBe 0
+        holder.currentPosition shouldBe target
+    }
+
+    test("deactivating twice in a row only reaches the child once") {
+        val context = HolderContext()
+        val child = RecordingActivity(spawn)
+        val holder = entryActivityHolder<ActivityContext>(spawn)
+
+        holder.switchTo(refTo("child", child), context, spawn)
+        holder.deactivate(context)
+        holder.deactivate(context)
+
+        child.deactivations shouldBe 1
+    }
+
+    test("a deactivated holder keeps reporting where the child stopped") {
+        val context = HolderContext()
+        val child = RecordingActivity(spawn)
+        val holder = entryActivityHolder<ActivityContext>(spawn)
+
+        holder.switchTo(refTo("child", child), context, target)
+        holder.deactivate(context)
+
+        holder.currentPosition shouldBe target
+    }
+
+    test("disposing tears down children that are no longer showing") {
+        val context = HolderContext()
+        val idle = RecordingActivity(spawn)
+        val walking = RecordingActivity(spawn)
+        val holder = entryActivityHolder<ActivityContext>(spawn)
+
+        holder.switchTo(refTo("idle", idle), context, spawn)
+        holder.switchTo(refTo("walking", walking), context, target)
+        holder.dispose()
+
+        idle.disposals shouldBe 1
+        walking.disposals shouldBe 1
+    }
+
+    test("an unset ref falls back to an idle child that still adopts the position") {
+        val context = HolderContext()
+        val holder = entryActivityHolder<ActivityContext>(spawn)
+        val idleRef = emptyRef<EntityActivityEntry>()
+        val walking = RecordingActivity(spawn)
+
+        holder.switchTo(idleRef, context, spawn)
+        holder.switchTo(refTo("walking", walking), context, spawn)
+        holder.switchTo(idleRef, context, target)
+
+        holder.currentPosition shouldBe target
+    }
+
+    test("a holder keyed by something other than a ref builds one child per key") {
+        val context = HolderContext()
+        val built = mutableListOf<Mode>()
+        val holder = ChildActivityHolder<Mode, ActivityContext>(spawn) { mode, _, position ->
+            built += mode
+            RecordingActivity(position)
+        }
+
+        holder.activate(Mode.NAVIGATING, context, spawn)
+        holder.switchTo(Mode.IDLE, context, target)
+        holder.switchTo(Mode.NAVIGATING, context, spawn)
+
+        built shouldBe listOf(Mode.NAVIGATING, Mode.IDLE)
+        holder.currentKey shouldBe Mode.NAVIGATING
+        holder.currentPosition shouldBe spawn
+    }
+})
+
+private enum class Mode { NAVIGATING, IDLE }

--- a/engine/engine-paper/src/test/kotlin/com/typewritermc/entity/ChildActivityHolderSpec.kt
+++ b/engine/engine-paper/src/test/kotlin/com/typewritermc/entity/ChildActivityHolderSpec.kt
@@ -142,6 +142,7 @@ class ChildActivityHolderSpec : FunSpec({
 
         holder.switchTo(refTo("idle", idle), context, spawn)
         holder.switchTo(refTo("walking", walking), context, target)
+        holder.deactivate(context)
         holder.dispose()
 
         idle.disposals shouldBe 1
@@ -158,6 +159,25 @@ class ChildActivityHolderSpec : FunSpec({
         holder.switchTo(refTo("walking", walking), context, spawn)
         holder.switchTo(idleRef, context, target)
 
+        holder.currentPosition shouldBe target
+    }
+
+    test("a child that could not be built yet is tried again on the next activation") {
+        val context = HolderContext()
+        val walking = RecordingActivity(spawn)
+        var resolves = false
+        val holder = ChildActivityHolder<Mode, ActivityContext>(spawn) { _, _, _ ->
+            if (resolves) walking else null
+        }
+
+        holder.activate(Mode.NAVIGATING, context, spawn)
+        walking.activations shouldBe 0
+        holder.currentPosition shouldBe spawn
+
+        resolves = true
+        holder.activate(Mode.NAVIGATING, context, target)
+
+        walking.activations shouldBe 1
         holder.currentPosition shouldBe target
     }
 

--- a/engine/engine-paper/src/test/kotlin/com/typewritermc/entity/ReusedActivityPositionSpec.kt
+++ b/engine/engine-paper/src/test/kotlin/com/typewritermc/entity/ReusedActivityPositionSpec.kt
@@ -24,7 +24,7 @@ private class StubContext : ActivityContext {
 private class TeleportingActivity(private val destination: PositionProperty) : GenericEntityActivity {
     override var currentPosition: PositionProperty = destination
 
-    override fun initialize(context: ActivityContext, position: PositionProperty) {
+    override fun activate(context: ActivityContext, position: PositionProperty) {
         currentPosition = position
     }
 
@@ -32,8 +32,6 @@ private class TeleportingActivity(private val destination: PositionProperty) : G
         currentPosition = destination
         return TickResult.CONSUMED
     }
-
-    override fun dispose(context: ActivityContext) {}
 }
 
 private class TeleportingActivityEntry(
@@ -60,10 +58,10 @@ class ReusedActivityPositionSpec : FunSpec({
     val spawn = positionAt(0.0, 64.0, 0.0)
     val destination = positionAt(20.0, 64.0, 20.0)
 
-    test("an idle activity moves to the position it is initialized with") {
+    test("an idle activity moves to the position it is activated with") {
         val activity = IdleActivity(spawn)
 
-        activity.initialize(StubContext(), destination)
+        activity.activate(StubContext(), destination)
 
         activity.currentPosition shouldBe destination
     }
@@ -78,7 +76,7 @@ class ReusedActivityPositionSpec : FunSpec({
         )
 
         val activity = TogglingActivity(spawn, idleRef)
-        activity.initialize(context, spawn)
+        activity.activate(context, spawn)
         activity.currentPosition shouldBe spawn
 
         activity.switchTo(travelRef)

--- a/engine/engine-paper/src/test/kotlin/com/typewritermc/entity/ReusedActivityPositionSpec.kt
+++ b/engine/engine-paper/src/test/kotlin/com/typewritermc/entity/ReusedActivityPositionSpec.kt
@@ -1,0 +1,93 @@
+package com.typewritermc.entity
+
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.entries.emptyRef
+import com.typewritermc.core.utils.point.World
+import com.typewritermc.engine.paper.entry.entity.*
+import com.typewritermc.engine.paper.entry.entries.EntityActivityEntry
+import com.typewritermc.engine.paper.entry.entries.EntityInstanceEntry
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.bukkit.entity.Player
+
+private val world = World("reused-activity-world")
+
+private fun positionAt(x: Double, y: Double, z: Double) = PositionProperty(world, x, y, z, 0f, 0f)
+
+private class StubContext : ActivityContext {
+    override val instanceRef: Ref<out EntityInstanceEntry> = emptyRef()
+    override val isViewed: Boolean = false
+    override val viewers: List<Player> = emptyList()
+    override val entityState: EntityState = EntityState()
+}
+
+private class TeleportingActivity(private val destination: PositionProperty) : GenericEntityActivity {
+    override var currentPosition: PositionProperty = destination
+
+    override fun initialize(context: ActivityContext, position: PositionProperty) {
+        currentPosition = position
+    }
+
+    override fun tick(context: ActivityContext): TickResult {
+        currentPosition = destination
+        return TickResult.CONSUMED
+    }
+
+    override fun dispose(context: ActivityContext) {}
+}
+
+private class TeleportingActivityEntry(
+    override val id: String,
+    override val name: String,
+    private val destination: PositionProperty,
+) : EntityActivityEntry {
+    override fun create(context: ActivityContext, currentLocation: PositionProperty): EntityActivity<ActivityContext> =
+        TeleportingActivity(destination)
+}
+
+private class TogglingActivity(
+    startLocation: PositionProperty,
+    private var childRef: Ref<out EntityActivityEntry>,
+) : SingleChildActivity<ActivityContext>(startLocation) {
+    override fun currentChild(context: ActivityContext): Ref<out EntityActivityEntry> = childRef
+
+    fun switchTo(ref: Ref<out EntityActivityEntry>) {
+        childRef = ref
+    }
+}
+
+class ReusedActivityPositionSpec : FunSpec({
+    val spawn = positionAt(0.0, 64.0, 0.0)
+    val destination = positionAt(20.0, 64.0, 20.0)
+
+    test("an idle activity moves to the position it is initialized with") {
+        val activity = IdleActivity(spawn)
+
+        activity.initialize(StubContext(), destination)
+
+        activity.currentPosition shouldBe destination
+    }
+
+    test("a child activity that is used again reports where the entity is now") {
+        val context = StubContext()
+        val idleRef = emptyRef<EntityActivityEntry>()
+        val travelRef = Ref(
+            "travel",
+            EntityActivityEntry::class,
+            TeleportingActivityEntry("travel", "travel", destination),
+        )
+
+        val activity = TogglingActivity(spawn, idleRef)
+        activity.initialize(context, spawn)
+        activity.currentPosition shouldBe spawn
+
+        activity.switchTo(travelRef)
+        activity.tick(context)
+        activity.currentPosition shouldBe destination
+
+        activity.switchTo(idleRef)
+        activity.tick(context)
+
+        activity.currentPosition shouldBe destination
+    }
+})

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/BobbingActivity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/BobbingActivity.kt
@@ -62,7 +62,8 @@ class BobbingActivity(
 
     override fun activate(context: ActivityContext, position: PositionProperty) {
         startTime = System.currentTimeMillis()
-        childActivity.activate(context, position)
+        childActivity.activate(context, position.withY { it - lastOffset })
+        lastOffset = 0.0f
     }
 
     override fun tick(context: ActivityContext): TickResult {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/BobbingActivity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/BobbingActivity.kt
@@ -60,9 +60,9 @@ class BobbingActivity(
     private var startTime: Long = System.currentTimeMillis()
     private var lastOffset: Float = 0.0f
 
-    override fun initialize(context: ActivityContext, position: PositionProperty) {
+    override fun activate(context: ActivityContext, position: PositionProperty) {
         startTime = System.currentTimeMillis()
-        childActivity.initialize(context, position)
+        childActivity.activate(context, position)
     }
 
     override fun tick(context: ActivityContext): TickResult {
@@ -80,8 +80,12 @@ class BobbingActivity(
         return childActivity.tick(context)
     }
 
-    override fun dispose(context: ActivityContext) {
-        childActivity.dispose(context)
+    override fun deactivate(context: ActivityContext) {
+        childActivity.deactivate(context)
+    }
+
+    override fun dispose() {
+        childActivity.dispose()
     }
 
     override val currentPosition: PositionProperty

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/EyeHeightDebugActivity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/EyeHeightDebugActivity.kt
@@ -52,7 +52,7 @@ class EyeHeightDebugActivity(
     val showHitbox: Boolean,
 ) : GenericEntityActivity {
 
-    override fun initialize(context: ActivityContext, position: PositionProperty) {
+    override fun activate(context: ActivityContext, position: PositionProperty) {
         currentPosition = position
     }
 
@@ -93,8 +93,6 @@ class EyeHeightDebugActivity(
 
         return TickResult.CONSUMED
     }
-
-    override fun dispose(context: ActivityContext) {}
 }
 
 private fun sendDustParticle(viewers: List<Player>, position: Vector3d, color: Color) {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/InDialogueActivity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/InDialogueActivity.kt
@@ -171,8 +171,8 @@ class InDialogueActivity(
     override val currentProperties: List<EntityProperty>
         get() = super.currentProperties.filter { it !is PositionProperty } + currentPosition
 
-    override fun dispose(context: ActivityContext) {
-        super.dispose(context)
+    override fun deactivate(context: ActivityContext) {
+        super.deactivate(context)
         yawAdditiveVelocity.value = 0f
         pitchAdditiveVelocity.value = 0f
     }

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/LookAtBlockActivity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/LookAtBlockActivity.kt
@@ -48,9 +48,9 @@ class LookAtBlockActivity(
     private val pitchVelocity = Velocity(0f)
     private var currentDirection: LookDirection = LookDirection(startLocation.yaw, startLocation.pitch)
 
-    override fun initialize(context: ActivityContext, position: PositionProperty) {
+    override fun activate(context: ActivityContext, position: PositionProperty) {
         currentDirection = LookDirection(position.yaw, position.pitch)
-        childActivity.initialize(context, position)
+        childActivity.activate(context, position)
     }
 
     override fun tick(context: ActivityContext): TickResult {
@@ -73,10 +73,14 @@ class LookAtBlockActivity(
         return childActivity.tick(context)
     }
 
-    override fun dispose(context: ActivityContext) {
+    override fun deactivate(context: ActivityContext) {
         yawVelocity.value = 0f
         pitchVelocity.value = 0f
-        childActivity.dispose(context)
+        childActivity.deactivate(context)
+    }
+
+    override fun dispose() {
+        childActivity.dispose()
     }
 
     override val currentPosition: PositionProperty

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/LookAtPitchYawActivity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/LookAtPitchYawActivity.kt
@@ -45,9 +45,9 @@ class LookAtPitchYawActivity(
     private val pitchVelocity = Velocity(0f)
     private var currentDirection: LookDirection = LookDirection(startLocation.yaw, startLocation.pitch)
 
-    override fun initialize(context: ActivityContext, position: PositionProperty) {
+    override fun activate(context: ActivityContext, position: PositionProperty) {
         currentDirection = LookDirection(position.yaw, position.pitch)
-        childActivity.initialize(context, position)
+        childActivity.activate(context, position)
     }
 
     override fun tick(context: ActivityContext): TickResult {
@@ -64,11 +64,15 @@ class LookAtPitchYawActivity(
         return childActivity.tick(context)
     }
 
-    override fun dispose(context: ActivityContext) {
+    override fun deactivate(context: ActivityContext) {
         yawVelocity.value = 0f
         pitchVelocity.value = 0f
 
-        childActivity.dispose(context)
+        childActivity.deactivate(context)
+    }
+
+    override fun dispose() {
+        childActivity.dispose()
     }
 
     override val currentPosition: PositionProperty

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/LookCloseActivity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/LookCloseActivity.kt
@@ -47,7 +47,7 @@ class LookCloseActivity(
 
     override var currentPosition: PositionProperty = startPosition
 
-    override fun initialize(context: ActivityContext, position: PositionProperty) {
+    override fun activate(context: ActivityContext, position: PositionProperty) {
         currentPosition = position
         yawVelocity.value = 0f
         pitchVelocity.value = 0f
@@ -125,7 +125,7 @@ class LookCloseActivity(
         return TickResult.CONSUMED
     }
 
-    override fun dispose(context: ActivityContext) {
+    override fun deactivate(context: ActivityContext) {
         target = null
         yawVelocity.value = 0f
         pitchVelocity.value = 0f

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/NavigationActivityTask.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/NavigationActivityTask.kt
@@ -35,7 +35,8 @@ class NavigationActivity(
     override val currentPosition: PositionProperty
         get() = state.position()
 
-    override fun initialize(context: ActivityContext, position: PositionProperty) {
+    override fun activate(context: ActivityContext, position: PositionProperty) {
+        path = null
         state = NavigationActivityTaskState.Searching(gps, position)
     }
 
@@ -43,14 +44,12 @@ class NavigationActivity(
         val speed = context.entityState.speed
         state.tick(context)
         if (state.isComplete()) {
-            if (path?.isEmpty() == true) {
-                return TickResult.IGNORED
-            }
-            path = path?.subList(1, path?.size ?: 0) ?: (state as NavigationActivityTaskState.Searching).let {
-                it.path ?: return TickResult.CONSUMED
-            }
+            val remaining = path?.drop(1)
+                ?: (state as? NavigationActivityTaskState.Searching)?.path
+                ?: return TickResult.CONSUMED
+            path = remaining
 
-            val currentEdge = path?.firstOrNull() ?: return TickResult.IGNORED
+            val currentEdge = remaining.firstOrNull() ?: return TickResult.IGNORED
 
             state = when {
                 currentEdge.isFastTravel -> NavigationActivityTaskState.FastTravel(currentEdge)
@@ -80,7 +79,7 @@ class NavigationActivity(
         return TickResult.CONSUMED
     }
 
-    override fun dispose(context: ActivityContext) {
+    override fun deactivate(context: ActivityContext) {
         state.dispose()
     }
 }

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/NavigationActivityTask.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/NavigationActivityTask.kt
@@ -36,6 +36,7 @@ class NavigationActivity(
         get() = state.position()
 
     override fun activate(context: ActivityContext, position: PositionProperty) {
+        state.dispose()
         path = null
         state = NavigationActivityTaskState.Searching(gps, position)
     }
@@ -80,6 +81,10 @@ class NavigationActivity(
     }
 
     override fun deactivate(context: ActivityContext) {
+        state.dispose()
+    }
+
+    override fun dispose() {
         state.dispose()
     }
 }

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/OffsetActivityEntry.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/OffsetActivityEntry.kt
@@ -48,8 +48,8 @@ class OffsetActivity(
     private val childActivity: EntityActivity<ActivityContext>
 ) : EntityActivity<ActivityContext> {
     private var lastOffset: Vector = Vector.ZERO
-    override fun initialize(context: ActivityContext, position: PositionProperty) {
-        childActivity.initialize(context, position)
+    override fun activate(context: ActivityContext, position: PositionProperty) {
+        childActivity.activate(context, position)
         lastOffset = offset.get(context.randomViewer) ?: Vector.ZERO
     }
 
@@ -60,8 +60,12 @@ class OffsetActivity(
         return childActivity.tick(context)
     }
 
-    override fun dispose(context: ActivityContext) {
-        childActivity.dispose(context)
+    override fun deactivate(context: ActivityContext) {
+        childActivity.deactivate(context)
+    }
+
+    override fun dispose() {
+        childActivity.dispose()
     }
 
     override val currentPosition: PositionProperty

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/OffsetActivityEntry.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/OffsetActivityEntry.kt
@@ -49,7 +49,7 @@ class OffsetActivity(
 ) : EntityActivity<ActivityContext> {
     private var lastOffset: Vector = Vector.ZERO
     override fun activate(context: ActivityContext, position: PositionProperty) {
-        childActivity.activate(context, position)
+        childActivity.activate(context, position.add(-lastOffset.x, -lastOffset.y, -lastOffset.z))
         lastOffset = offset.get(context.randomViewer) ?: Vector.ZERO
     }
 

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/PathActivityEntry.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/PathActivityEntry.kt
@@ -49,9 +49,10 @@ private class PathActivity(
 
     fun refreshActivity(context: ActivityContext, network: RoadNetwork) {
         if (nodes.size <= currentLocationIndex) {
-            activity.dispose(context)
+            activity.deactivate(context)
+            activity.dispose()
             activity = idleActivity.get()?.create(context, currentPosition) ?: IdleActivity(currentPosition)
-            activity.initialize(context, currentPosition)
+            activity.activate(context, currentPosition)
             return
         }
 
@@ -60,7 +61,8 @@ private class PathActivity(
         val targetNode = network.nodes.find { it.id == targetNodeId }
             ?: return
 
-        activity.dispose(context)
+        activity.deactivate(context)
+        activity.dispose()
         activity = NavigationActivity(
             PointToPointGPS(
                 roadNetwork,
@@ -72,11 +74,11 @@ private class PathActivity(
             },
             currentPosition
         ).also {
-            it.initialize(context, currentPosition)
+            it.activate(context, currentPosition)
         }
     }
 
-    override fun initialize(context: ActivityContext, position: PositionProperty) {
+    override fun activate(context: ActivityContext, position: PositionProperty) {
         activity = IdleActivity(position)
         setup(context)
     }
@@ -101,7 +103,7 @@ private class PathActivity(
             currentLocationIndex = (currentLocationIndex + 1)
             refreshActivity(context, network!!)
             // If we refreshed to nothing, we are done.
-            if (activity is IdleActivity) {
+            if (nodes.size <= currentLocationIndex && !idleActivity.isSet) {
                 return TickResult.IGNORED
             }
         }
@@ -109,10 +111,14 @@ private class PathActivity(
         return TickResult.CONSUMED
     }
 
-    override fun dispose(context: ActivityContext) {
+    override fun deactivate(context: ActivityContext) {
         val oldPosition = currentPosition
-        activity.dispose(context)
+        activity.deactivate(context)
         activity = IdleActivity(oldPosition)
+    }
+
+    override fun dispose() {
+        activity.dispose()
     }
 
     override val currentPosition: PositionProperty

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/PathActivityEntry.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/PathActivityEntry.kt
@@ -79,6 +79,7 @@ private class PathActivity(
     }
 
     override fun activate(context: ActivityContext, position: PositionProperty) {
+        activity.dispose()
         activity = IdleActivity(position)
         setup(context)
     }
@@ -112,9 +113,7 @@ private class PathActivity(
     }
 
     override fun deactivate(context: ActivityContext) {
-        val oldPosition = currentPosition
         activity.deactivate(context)
-        activity = IdleActivity(oldPosition)
     }
 
     override fun dispose() {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/PathActivityEntry.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/PathActivityEntry.kt
@@ -103,7 +103,7 @@ private class PathActivity(
             currentLocationIndex = (currentLocationIndex + 1)
             refreshActivity(context, network!!)
             // If we refreshed to nothing, we are done.
-            if (nodes.size <= currentLocationIndex && !idleActivity.isSet) {
+            if (activity is IdleActivity) {
                 return TickResult.IGNORED
             }
         }

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/PatrolActivity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/PatrolActivity.kt
@@ -74,6 +74,7 @@ class PatrolActivity(
     }
 
     override fun activate(context: ActivityContext, position: PositionProperty) {
+        activity.dispose()
         activity = IdleActivity(position)
         setup(context)
     }
@@ -103,9 +104,7 @@ class PatrolActivity(
     }
 
     override fun deactivate(context: ActivityContext) {
-        val oldPosition = currentPosition
         activity.deactivate(context)
-        activity = IdleActivity(oldPosition)
     }
 
     override fun dispose() {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/PatrolActivity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/PatrolActivity.kt
@@ -56,7 +56,8 @@ class PatrolActivity(
         val targetNode = network.nodes.find { it.id == targetNodeId }
             ?: return
 
-        activity.dispose(context)
+        activity.deactivate(context)
+        activity.dispose()
         activity = NavigationActivity(
             PointToPointGPS(
                 roadNetwork,
@@ -68,11 +69,11 @@ class PatrolActivity(
             },
             currentPosition
         ).also {
-            it.initialize(context, currentPosition)
+            it.activate(context, currentPosition)
         }
     }
 
-    override fun initialize(context: ActivityContext, position: PositionProperty) {
+    override fun activate(context: ActivityContext, position: PositionProperty) {
         activity = IdleActivity(position)
         setup(context)
     }
@@ -101,10 +102,14 @@ class PatrolActivity(
         return TickResult.CONSUMED
     }
 
-    override fun dispose(context: ActivityContext) {
+    override fun deactivate(context: ActivityContext) {
         val oldPosition = currentPosition
-        activity.dispose(context)
+        activity.deactivate(context)
         activity = IdleActivity(oldPosition)
+    }
+
+    override fun dispose() {
+        activity.dispose()
     }
 
     override val currentPosition: PositionProperty

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/PlayerWorldActivityEntry.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/PlayerWorldActivityEntry.kt
@@ -42,35 +42,33 @@ class PlayerWorldActivity(
     private val child: Ref<out EntityActivityEntry>,
     startPosition: PositionProperty,
 ) : IndividualEntityActivity {
-    private var childActivity: EntityActivity<in IndividualActivityContext> = IdleActivity(startPosition)
+    private val children = entryActivityHolder<IndividualActivityContext>(startPosition)
     private var world: World = startPosition.world
 
-    override fun initialize(context: IndividualActivityContext, position: PositionProperty) {
+    override fun activate(context: IndividualActivityContext, position: PositionProperty) {
         world = context.viewer.position.world
-        if (childActivity is IdleActivity) {
-            childActivity = child.get()?.create(context, position) ?: IdleActivity(position)
-        }
-        childActivity.initialize(context, position)
+        children.switchTo(child, context, position)
     }
 
     override fun tick(context: IndividualActivityContext): TickResult {
         val playerWorld = context.viewer.position.world
         if (playerWorld != world) {
-            childActivity.dispose(context)
+            val position = currentPosition
+            children.deactivate(context)
             world = playerWorld
-            childActivity.initialize(context, currentPosition)
+            children.switchTo(child, context, position.withWorld(playerWorld))
         }
 
-        return childActivity.tick(context)
+        return children.tick(context)
     }
 
-    override fun dispose(context: IndividualActivityContext) {
-        childActivity.dispose(context)
-    }
+    override fun deactivate(context: IndividualActivityContext) = children.deactivate(context)
+
+    override fun dispose() = children.dispose()
 
     override val currentPosition: PositionProperty
-        get() = childActivity.currentPosition.withWorld(world)
+        get() = children.currentPosition.withWorld(world)
 
     override val currentProperties: List<EntityProperty>
-        get() = childActivity.currentProperties.filter { it !is PositionProperty } + currentPosition
+        get() = children.currentProperties.filter { it !is PositionProperty } + currentPosition
 }

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/PlayerWorldActivityEntry.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/PlayerWorldActivityEntry.kt
@@ -47,7 +47,7 @@ class PlayerWorldActivity(
 
     override fun activate(context: IndividualActivityContext, position: PositionProperty) {
         world = context.viewer.position.world
-        children.switchTo(child, context, position)
+        children.activate(child, context, position.withWorld(world))
     }
 
     override fun tick(context: IndividualActivityContext): TickResult {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/RandomLookActivityEntry.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/RandomLookActivityEntry.kt
@@ -48,7 +48,7 @@ class RandomLookActivity(
     private var nextChangeTime = Instant.now()
 
 
-    override fun initialize(context: ActivityContext, position: PositionProperty) {
+    override fun activate(context: ActivityContext, position: PositionProperty) {
         currentPosition = position
         pitchVelocity.value = 0f
         yawVelocity.value = 0f
@@ -78,8 +78,6 @@ class RandomLookActivity(
 
         return TickResult.CONSUMED
     }
-
-    override fun dispose(context: ActivityContext) {}
 }
 
 fun ClosedRange<Float>.random(): Float {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/RandomPatrolActivity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/RandomPatrolActivity.kt
@@ -113,6 +113,9 @@ class RandomPatrolActivity(
     }
 
     override fun activate(context: ActivityContext, position: PositionProperty) {
+        searchJob?.cancel()
+        searchJob = null
+        activity.dispose()
         activity = IdleActivity(position)
         setup(context)
     }
@@ -158,9 +161,7 @@ class RandomPatrolActivity(
     override fun deactivate(context: ActivityContext) {
         searchJob?.cancel()
         searchJob = null
-        val oldPosition = currentPosition
         activity.deactivate(context)
-        activity = IdleActivity(oldPosition)
     }
 
     override fun dispose() {

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/RandomPatrolActivity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/RandomPatrolActivity.kt
@@ -112,7 +112,7 @@ class RandomPatrolActivity(
         return TickResult.CONSUMED
     }
 
-    override fun initialize(context: ActivityContext, position: PositionProperty) {
+    override fun activate(context: ActivityContext, position: PositionProperty) {
         activity = IdleActivity(position)
         setup(context)
     }
@@ -155,12 +155,16 @@ class RandomPatrolActivity(
         return distance > MIN_MOVED_DISTANCE_SQUARED
     }
 
-    override fun dispose(context: ActivityContext) {
+    override fun deactivate(context: ActivityContext) {
         searchJob?.cancel()
         searchJob = null
         val oldPosition = currentPosition
-        activity.dispose(context)
+        activity.deactivate(context)
         activity = IdleActivity(oldPosition)
+    }
+
+    override fun dispose() {
+        activity.dispose()
     }
 
     override val currentPosition: PositionProperty
@@ -215,8 +219,9 @@ class RandomPatrolActivity(
     }
 
     private fun setNavigationActivity(context: ActivityContext, gps: PointToPointGPS) {
-        activity.dispose(context)
-        activity = NavigationActivity(gps, currentPosition).also { it.initialize(context, currentPosition) }
+        activity.deactivate(context)
+        activity.dispose()
+        activity = NavigationActivity(gps, currentPosition).also { it.activate(context, currentPosition) }
     }
 
     private fun setIdleFallbackActivity(
@@ -229,10 +234,11 @@ class RandomPatrolActivity(
             .randomOrNull()
             .logErrorIfNull("No reachable nodes found")
 
-        activity.dispose(context)
+        activity.deactivate(context)
+        activity.dispose()
         val newPosition = teleportNode?.position?.toProperty() ?: currentPosition
         activity = IdleActivity(newPosition).also {
-            it.initialize(context, newPosition)
+            it.activate(context, newPosition)
         }
     }
 }

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/SpinActivity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/SpinActivity.kt
@@ -51,9 +51,9 @@ class SpinActivity(
     private val direction = if (clockwise) -1 else 1
     private var currentRotation = 0f
 
-    override fun initialize(context: ActivityContext, position: PositionProperty) {
+    override fun activate(context: ActivityContext, position: PositionProperty) {
         startTime = Instant.now()
-        childActivity.initialize(context, position)
+        childActivity.activate(context, position)
         startRotation = when (axis) {
             SpinAxis.YAW -> childActivity.currentPosition.yaw
             SpinAxis.PITCH -> childActivity.currentPosition.pitch
@@ -83,8 +83,12 @@ class SpinActivity(
         return childActivity.tick(context)
     }
 
-    override fun dispose(context: ActivityContext) {
-        childActivity.dispose(context)
+    override fun deactivate(context: ActivityContext) {
+        childActivity.deactivate(context)
+    }
+
+    override fun dispose() {
+        childActivity.dispose()
     }
 
     override val currentPosition: PositionProperty

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/TargetLocationActivity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/TargetLocationActivity.kt
@@ -49,100 +49,65 @@ class TargetLocationActivity(
     private val network: Ref<RoadNetworkEntry>,
     private val targetPosition: Position,
     private val idleActivity: Ref<out EntityActivityEntry>,
-    val once: Boolean,
+    private val once: Boolean,
     startPosition: PositionProperty,
 ) : GenericEntityActivity {
-    private val states = listOf(NavigatingState(), IdleState())
-    private var state: State = states.first()
-    private var currentActivity: EntityActivity<ActivityContext> = IdleActivity(startPosition)
+    private enum class Mode { NAVIGATING, IDLE }
 
+    private var searchStart: PositionProperty = startPosition
+    private var reachedTarget = false
 
-    private interface State {
-        fun isValid(position: PositionProperty): Boolean
-        fun nextState(): State
-        fun createActivity(
-            context: ActivityContext,
-            position: PositionProperty
-        ): EntityActivity<ActivityContext>
-    }
-
-    private inner class IdleState : State {
-        override fun isValid(position: PositionProperty): Boolean {
-            if (once) return true
-            val distance = position.distanceSquared(targetPosition) ?: return true
-            return distance <= locationActivityRange * locationActivityRange
-        }
-
-        private var cachedActivity: EntityActivity<ActivityContext>? = null
-
-        override fun nextState(): State = states[0]
-
-        override fun createActivity(
-            context: ActivityContext,
-            position: PositionProperty
-        ): EntityActivity<ActivityContext> {
-            if (cachedActivity != null) return cachedActivity!!
-            cachedActivity = (idleActivity.get() ?: IdleActivity).create(context, position)
-            return cachedActivity!!
-        }
-    }
-
-    private inner class NavigatingState : State {
-        override fun isValid(position: PositionProperty): Boolean {
-            val distance = position.distanceSquared(targetPosition) ?: return true
-            return distance > locationActivityRange * locationActivityRange
-        }
-
-        override fun nextState(): State = states[1]
-
-        override fun createActivity(
-            context: ActivityContext,
-            position: PositionProperty
-        ): EntityActivity<ActivityContext> {
-            return NavigationActivity(
+    private val children = ChildActivityHolder<Mode, ActivityContext>(startPosition) { mode, context, position ->
+        when (mode) {
+            Mode.NAVIGATING -> NavigationActivity(
                 PointToPointGPS(
                     network,
                     {
-                        val start = position.toPosition()
+                        val start = searchStart.toPosition()
                         start.firstWalkableLocationBelow() ?: start
                     },
-                    { targetPosition }
-                ), position)
+                    { targetPosition },
+                ),
+                position,
+            )
+
+            Mode.IDLE -> idleActivity.get()?.create(context, position)
         }
     }
 
-    override fun initialize(context: ActivityContext, position: PositionProperty) {
-        if (!state.isValid(position)) {
-            state = state.nextState()
-        }
-
-        currentActivity = state.createActivity(context, position).also {
-            it.initialize(context, position)
-        }
+    override fun activate(context: ActivityContext, position: PositionProperty) {
+        enter(modeFor(position), context, position)
     }
 
     override fun tick(context: ActivityContext): TickResult {
         val position = currentPosition
-        if (!state.isValid(position)) {
-            currentActivity.dispose(context)
-            state = state.nextState()
-            currentActivity = state.createActivity(context, position).also {
-                it.initialize(context, position)
-            }
-        }
+        val mode = modeFor(position)
+        if (mode != children.currentKey) enter(mode, context, position)
 
-        return currentActivity.tick(context)
+        return children.tick(context)
     }
 
-    override fun dispose(context: ActivityContext) {
-        val oldPosition = currentPosition
-        currentActivity.dispose(context)
-        currentActivity = IdleActivity(oldPosition)
-    }
+    override fun deactivate(context: ActivityContext) = children.deactivate(context)
+
+    override fun dispose() = children.dispose()
 
     override val currentPosition: PositionProperty
-        get() = currentActivity.currentPosition
+        get() = children.currentPosition
 
     override val currentProperties: List<EntityProperty>
-        get() = currentActivity.currentProperties
+        get() = children.currentProperties
+
+    private fun modeFor(position: PositionProperty): Mode {
+        if (once && reachedTarget) return Mode.IDLE
+        // Another world gives no distance, so keep doing whatever we were already doing.
+        val distance = position.distanceSquared(targetPosition) ?: return children.currentKey ?: Mode.NAVIGATING
+        if (distance <= locationActivityRange * locationActivityRange) return Mode.IDLE
+        return Mode.NAVIGATING
+    }
+
+    private fun enter(mode: Mode, context: ActivityContext, position: PositionProperty) {
+        if (mode == Mode.IDLE) reachedTarget = true
+        searchStart = position
+        children.activate(mode, context, position)
+    }
 }

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/TargetLocationActivity.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/TargetLocationActivity.kt
@@ -58,21 +58,20 @@ class TargetLocationActivity(
 
 
     private interface State {
-        val isValid: Boolean
+        fun isValid(position: PositionProperty): Boolean
         fun nextState(): State
         fun createActivity(
             context: ActivityContext,
-            currentPosition: PositionProperty
+            position: PositionProperty
         ): EntityActivity<ActivityContext>
     }
 
     private inner class IdleState : State {
-        override val isValid: Boolean
-            get() {
-                if (once) return true
-                val distance = currentPosition.distanceSquared(targetPosition) ?: return true
-                return distance <= locationActivityRange * locationActivityRange
-            }
+        override fun isValid(position: PositionProperty): Boolean {
+            if (once) return true
+            val distance = position.distanceSquared(targetPosition) ?: return true
+            return distance <= locationActivityRange * locationActivityRange
+        }
 
         private var cachedActivity: EntityActivity<ActivityContext>? = null
 
@@ -80,41 +79,40 @@ class TargetLocationActivity(
 
         override fun createActivity(
             context: ActivityContext,
-            currentPosition: PositionProperty
+            position: PositionProperty
         ): EntityActivity<ActivityContext> {
             if (cachedActivity != null) return cachedActivity!!
-            cachedActivity = (idleActivity.get() ?: IdleActivity).create(context, currentPosition)
+            cachedActivity = (idleActivity.get() ?: IdleActivity).create(context, position)
             return cachedActivity!!
         }
     }
 
     private inner class NavigatingState : State {
-        override val isValid: Boolean
-            get() {
-                val distance = currentPosition.distanceSquared(targetPosition) ?: return true
-                return distance > locationActivityRange * locationActivityRange
-            }
+        override fun isValid(position: PositionProperty): Boolean {
+            val distance = position.distanceSquared(targetPosition) ?: return true
+            return distance > locationActivityRange * locationActivityRange
+        }
 
         override fun nextState(): State = states[1]
 
         override fun createActivity(
             context: ActivityContext,
-            currentPosition: PositionProperty
+            position: PositionProperty
         ): EntityActivity<ActivityContext> {
             return NavigationActivity(
                 PointToPointGPS(
                     network,
                     {
-                        val position = currentPosition.toPosition()
-                        position.firstWalkableLocationBelow() ?: position
+                        val start = position.toPosition()
+                        start.firstWalkableLocationBelow() ?: start
                     },
                     { targetPosition }
-                ), currentPosition)
+                ), position)
         }
     }
 
     override fun initialize(context: ActivityContext, position: PositionProperty) {
-        if (!state.isValid) {
+        if (!state.isValid(position)) {
             state = state.nextState()
         }
 
@@ -124,11 +122,13 @@ class TargetLocationActivity(
     }
 
     override fun tick(context: ActivityContext): TickResult {
-        if (!state.isValid) {
+        val position = currentPosition
+        if (!state.isValid(position)) {
             currentActivity.dispose(context)
             state = state.nextState()
-            currentActivity = state.createActivity(context, currentPosition)
-            currentActivity.initialize(context, currentPosition)
+            currentActivity = state.createActivity(context, position).also {
+                it.initialize(context, position)
+            }
         }
 
         return currentActivity.tick(context)

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/TriggerActivityEntry.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/TriggerActivityEntry.kt
@@ -48,32 +48,29 @@ private class TriggerActivity(
     private val onStart: Ref<TriggerableEntry>,
     private val onStop: Ref<TriggerableEntry>,
 ) : GenericEntityActivity {
-    private var activity: EntityActivity<in ActivityContext> = IdleActivity(startPosition)
+    private val children = entryActivityHolder<ActivityContext>(startPosition)
 
-    override fun initialize(context: ActivityContext, position: PositionProperty) {
-        if (activity is IdleActivity) {
-            activity = ref.get()?.create(context, position) ?: IdleActivity(position)
-        }
-        activity.initialize(context, position)
+    override fun activate(context: ActivityContext, position: PositionProperty) {
+        children.switchTo(ref, context, position)
         context.viewers.forEach {
             onStart.triggerFor(it, context())
         }
     }
 
-    override fun tick(context: ActivityContext): TickResult {
-        return activity.tick(context)
-    }
+    override fun tick(context: ActivityContext): TickResult = children.tick(context)
 
-    override fun dispose(context: ActivityContext) {
+    override fun deactivate(context: ActivityContext) {
         context.viewers.forEach {
             onStop.triggerFor(it, context())
         }
-        activity.dispose(context)
+        children.deactivate(context)
     }
 
+    override fun dispose() = children.dispose()
+
     override val currentPosition: PositionProperty
-        get() = activity.currentPosition
+        get() = children.currentPosition
 
     override val currentProperties: List<EntityProperty>
-        get() = activity.currentProperties
+        get() = children.currentProperties
 }

--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/TriggerActivityEntry.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/TriggerActivityEntry.kt
@@ -51,7 +51,7 @@ private class TriggerActivity(
     private val children = entryActivityHolder<ActivityContext>(startPosition)
 
     override fun activate(context: ActivityContext, position: PositionProperty) {
-        children.switchTo(ref, context, position)
+        children.activate(ref, context, position)
         context.viewers.forEach {
             onStart.triggerFor(it, context())
         }

--- a/extensions/EntityExtension/src/test/kotlin/com/typewritermc/entity/entries/activity/OffsetActivitySpec.kt
+++ b/extensions/EntityExtension/src/test/kotlin/com/typewritermc/entity/entries/activity/OffsetActivitySpec.kt
@@ -1,0 +1,42 @@
+package com.typewritermc.entity.entries.activity
+
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.entries.emptyRef
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.core.utils.point.World
+import com.typewritermc.engine.paper.entry.entity.*
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.EntityInstanceEntry
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.bukkit.entity.Player
+
+private class StubActivityContext : ActivityContext {
+    override val instanceRef: Ref<out EntityInstanceEntry> = emptyRef()
+    override val isViewed: Boolean = false
+    override val viewers: List<Player> = emptyList()
+    override val entityState: EntityState = EntityState()
+}
+
+class OffsetActivitySpec : FunSpec({
+    val world = World("decorator-world")
+
+    fun positionAt(x: Double, y: Double, z: Double) = PositionProperty(world, x, y, z, 0f, 0f)
+
+    test("re-activating with the position it last reported does not compound the offset") {
+        val context = StubActivityContext()
+        val base = positionAt(0.0, 64.0, 0.0)
+        val offsetActivity = OffsetActivity(
+            offset = ConstVar(Vector(0.0, 2.0, 0.0)),
+            childActivity = IdleActivity(base)
+        )
+
+        offsetActivity.activate(context, base)
+        val decorated = offsetActivity.currentPosition
+        decorated shouldBe base.add(0.0, 2.0, 0.0)
+
+        offsetActivity.activate(context, decorated)
+
+        offsetActivity.currentPosition shouldBe decorated
+    }
+})


### PR DESCRIPTION
An entity that reached its target snapped back to where it had been built and set off again, forever, whenever the once flag was off. Activities became reusable in 94c9d740dd and `IdleActivity.initialize` ignored the position it was handed, so the idle child `TargetLocationActivity` caches kept reporting the spot it was first created at instead of the target it had just walked to. That spot is outside `locationActivityRange`, so the state machine flipped straight back to navigating. once hid it, since `IdleState.isValid` returned true unconditionally and the entity never left idle to begin with.

The names were the real problem. initialize meant start and resume, dispose meant pause and tear down, and neither signature said which, so each implementation picked a reading and they drifted apart. activate now takes the position the activity has to be at and runs for the first start and every resume, deactivate pauses and keeps progress, dispose is final. dispose takes no context: deactivate always runs first so anything touching viewers belongs there, and dropping the parameter is what makes every old override fail to compile rather than quietly keep a cancelled job alive through every pause.

`SingleChildActivity`, the idle child in `TargetLocationActivity`, and the `if (activity is IdleActivity)` sentinel in `TriggerActivity` and `PlayerWorldActivity` were four caches with four different bugs. They share `ChildActivityHolder` now, which also disposes the children it built but is no longer showing, so a cached child's coroutines stop outliving the npc.

Three more things came out of walking the tree. `TriggerActivity` fired `onStop` twice for every interruption against a single `onStart`, because `SingleChildActivity` tore the child down on the pause and again on the activation after it. `NavigationActivity` carried the previous journey's remaining edges across a reuse, and an exhausted path is an empty list, so a reused instance read that as nothing left to walk and stood still; the state as Searching cast beside it would have thrown as soon as path and state disagreed. `OffsetActivity` and `BobbingActivity` pass their child the position they were handed while exposing child position plus their own decoration, so a parent that reads the decorated position and hands it back compounds it, and an offset of 0,2,0 under a `TimedActivity` climbs two blocks a cycle.

The 0.9 api changes page is rewritten. Its rules about preserving state across dispose and not resetting progress in initialize are deleted rather than reworded, since they only existed to paper over the ambiguity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a clearer activity lifecycle with activation, pausing, resuming, and final disposal.
  * Added reusable child-activity management that preserves state and position when switching activities.
  * Improved activity transitions, navigation, world changes, and target tracking.
  * Added safeguards for invalid lifecycle operations and repeated disposal.

* **Documentation**
  * Added migration guidance for the updated activity lifecycle and child-activity behavior.

* **Tests**
  * Expanded coverage for lifecycle ordering, activity switching, position retention, disposal, and offset handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->