### PR TITLE
fix(entity-extension,roadnetwork-extension): keep the route when a navigation is activated where it left off

### DIFF
--- a/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/NavigationActivityTask.kt
+++ b/extensions/EntityExtension/src/main/kotlin/com/typewritermc/entity/entries/activity/NavigationActivityTask.kt
@@ -25,6 +25,8 @@ import org.bukkit.util.BoundingBox
 import kotlin.math.*
 
 
+private const val MAX_RESUME_DISTANCE_SQUARED = 1.0
+
 class NavigationActivity(
     private val gps: GPS,
     startPosition: PositionProperty,
@@ -36,14 +38,31 @@ class NavigationActivity(
         get() = state.position()
 
     override fun activate(context: ActivityContext, position: PositionProperty) {
+        val moved = (currentPosition.distanceSquared(position) ?: Double.MAX_VALUE) > MAX_RESUME_DISTANCE_SQUARED
+
+        // Nothing about the route changed while it was paused, so the state that was travelling it
+        // is kept whole, block path included. Building it again would path from the exact spot the
+        // entity stopped on, and that spot can be one the pathfinder refuses to start from, while
+        // the path it already holds was calculated from a node and is still walkable.
+        if (state.edge != null && path != null && !moved) return
+
         state.dispose()
         path = null
+        gps.clearPreviousPath()
         state = NavigationActivityTaskState.Searching(gps, position)
     }
 
     override fun tick(context: ActivityContext): TickResult {
-        val speed = context.entityState.speed
         state.tick(context)
+
+        // Every edge is walked from where the entity stands, so an edge that cannot be walked from
+        // there says the entity is stuck, not that the edge is bad. Moving on to the next one only
+        // burns the rest of the route against the same spot.
+        if (state.hasFailed) {
+            path = null
+            return TickResult.IGNORED
+        }
+
         if (state.isComplete()) {
             val remaining = path?.drop(1)
                 ?: (state as? NavigationActivityTaskState.Searching)?.path
@@ -52,32 +71,33 @@ class NavigationActivity(
 
             val currentEdge = remaining.firstOrNull() ?: return TickResult.IGNORED
 
-            state = when {
-                currentEdge.isFastTravel -> NavigationActivityTaskState.FastTravel(currentEdge)
-                context.isViewed -> NavigationActivityTaskState.Walking(
-                    gps.roadNetwork,
-                    currentEdge,
-                    currentPosition,
-                    speed = speed
-                )
-
-                else -> NavigationActivityTaskState.FakeNavigation(currentEdge, speed = speed)
-            }
+            state = travelState(context, currentEdge, currentPosition)
         }
 
-        val state = state
         // The fake navigation is used to improve the performance; it however, goes through buildings
-        // So, we switch to walking when the entity is viewed
-        if (state is NavigationActivityTaskState.FakeNavigation && context.isViewed) {
-            this.state = NavigationActivityTaskState.Walking(gps.roadNetwork, state.edge, currentPosition, speed)
-        }
-
-        // And we switch back to fake navigation when the entity is not viewed
-        if (state is NavigationActivityTaskState.Walking && !context.isViewed) {
-            this.state = NavigationActivityTaskState.FakeNavigation(state.edge, currentPosition, speed = speed)
+        // So, we switch to walking when the entity is viewed, and back when it is not
+        val state = state
+        val edge = state.edge
+        val viewChanged = (state is NavigationActivityTaskState.FakeNavigation && context.isViewed)
+                || (state is NavigationActivityTaskState.Walking && !context.isViewed)
+        if (edge != null && viewChanged) {
+            this.state = travelState(context, edge, currentPosition)
         }
 
         return TickResult.CONSUMED
+    }
+
+    private fun travelState(
+        context: ActivityContext,
+        edge: GPSEdge,
+        from: PositionProperty,
+    ): NavigationActivityTaskState {
+        val speed = context.entityState.speed
+        return when {
+            edge.isFastTravel -> NavigationActivityTaskState.FastTravel(edge)
+            context.isViewed -> NavigationActivityTaskState.Walking(gps.roadNetwork, edge, from, speed = speed)
+            else -> NavigationActivityTaskState.FakeNavigation(edge, from, speed = speed)
+        }
     }
 
     override fun deactivate(context: ActivityContext) {
@@ -95,6 +115,14 @@ sealed interface NavigationActivityTaskState {
     fun isComplete(): Boolean
     fun tick(context: ActivityContext) {}
     fun dispose() {}
+
+    /** The edge being travelled, or null when there is nothing to travel yet. */
+    val edge: GPSEdge?
+        get() = null
+
+    /** True when the edge could not be travelled and the route it belongs to has to be given up. */
+    val hasFailed: Boolean
+        get() = false
 
     class Idle(
         private val position: PositionProperty,
@@ -129,7 +157,7 @@ sealed interface NavigationActivityTaskState {
     }
 
     class FakeNavigation(
-        val edge: GPSEdge,
+        override val edge: GPSEdge,
         val startPosition: PositionProperty = edge.start.toProperty(),
         val speed: Float,
     ) : NavigationActivityTaskState {
@@ -157,7 +185,7 @@ sealed interface NavigationActivityTaskState {
     }
 
     class FastTravel(
-        val edge: GPSEdge,
+        override val edge: GPSEdge,
     ) : NavigationActivityTaskState {
         override fun position(): PositionProperty = edge.end.toProperty()
         override fun isComplete(): Boolean = true
@@ -165,7 +193,7 @@ sealed interface NavigationActivityTaskState {
 
     class Walking(
         private val roadNetwork: Ref<RoadNetworkEntry>,
-        val edge: GPSEdge,
+        override val edge: GPSEdge,
         startPosition: PositionProperty,
         val speed: Float,
         private val rotationLookAhead: Int = 3,
@@ -199,6 +227,9 @@ sealed interface NavigationActivityTaskState {
 
         @Volatile
         private var pathCalculationFailed: Boolean = false
+
+        override val hasFailed: Boolean
+            get() = pathCalculationFailed
 
         @Volatile
         private var pathIsFallback: Boolean = false
@@ -249,7 +280,9 @@ sealed interface NavigationActivityTaskState {
         override fun position(): PositionProperty = location
 
         override fun tick(context: ActivityContext) {
-            if (pathCalculationJob == null) {
+            // A pause cancels the calculation but leaves the path it produced, which is still the
+            // path to this edge, so only an edge without one has to calculate.
+            if (pathCalculationJob == null && patheticPath == null) {
                 startPathCalculation()
             }
 

--- a/extensions/EntityExtension/src/test/kotlin/com/typewritermc/entity/entries/activity/NavigationActivitySpec.kt
+++ b/extensions/EntityExtension/src/test/kotlin/com/typewritermc/entity/entries/activity/NavigationActivitySpec.kt
@@ -1,0 +1,126 @@
+package com.typewritermc.entity.entries.activity
+
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.entries.emptyRef
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.World
+import com.typewritermc.engine.paper.entry.entity.ActivityContext
+import com.typewritermc.engine.paper.entry.entity.EntityState
+import com.typewritermc.engine.paper.entry.entity.PositionProperty
+import com.typewritermc.roadnetwork.RoadNetworkEntry
+import com.typewritermc.roadnetwork.gps.GPS
+import com.typewritermc.roadnetwork.gps.GPSEdge
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.delay
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+
+private const val TICK_LIMIT = 2000
+
+private val world = World("navigation-world")
+
+private fun positionAt(x: Double) = Position(world, x, 64.0, 0.0)
+
+private fun propertyAt(x: Double) = PositionProperty(world, x, 64.0, 0.0, 0f, 0f)
+
+private fun edgeBetween(startX: Double, endX: Double): GPSEdge {
+    val length = endX - startX
+    return GPSEdge(positionAt(startX), positionAt(endX), length, length)
+}
+
+private class RecordingGPS(private val route: List<GPSEdge>) : GPS {
+    override val roadNetwork: Ref<RoadNetworkEntry> = emptyRef()
+    var searches = 0
+    var clearedPreviousPath = 0
+
+    override suspend fun findPath(): Result<List<GPSEdge>> {
+        searches++
+        return Result.success(route)
+    }
+
+    override fun clearPreviousPath() {
+        clearedPreviousPath++
+    }
+}
+
+class NavigationActivitySpec : FunSpec({
+    val route = listOf(edgeBetween(0.0, 20.0), edgeBetween(20.0, 40.0))
+
+    beforeTest {
+        startKoin {
+            modules(module { factory<Boolean>(named("isEnabled")) { true } })
+        }
+    }
+
+    afterTest { stopKoin() }
+
+    fun context(): ActivityContext {
+        val context = mockk<ActivityContext>(relaxed = true)
+        every { context.isViewed } returns false
+        every { context.entityState } returns EntityState()
+        return context
+    }
+
+    suspend fun NavigationActivity.tickUntilTravelling(context: ActivityContext) {
+        repeat(TICK_LIMIT) {
+            tick(context)
+            if (currentPosition.x != 0.0 || it > 20) return
+            delay(1)
+        }
+    }
+
+    test("activating for the first time searches for a route") {
+        val gps = RecordingGPS(route)
+        val activity = NavigationActivity(gps, propertyAt(0.0))
+
+        activity.activate(context(), propertyAt(0.0))
+        activity.tickUntilTravelling(context())
+
+        gps.searches shouldBe 1
+    }
+
+    test("activating where it left off keeps travelling the same edge") {
+        val gps = RecordingGPS(route)
+        val context = context()
+        val activity = NavigationActivity(gps, propertyAt(0.0))
+
+        activity.activate(context, propertyAt(0.0))
+        activity.tickUntilTravelling(context)
+
+        activity.deactivate(context)
+        activity.activate(context, activity.currentPosition)
+        repeat(400) {
+            activity.tick(context)
+            delay(1)
+        }
+
+        gps.searches shouldBe 1
+        gps.clearedPreviousPath shouldBe 1
+        activity.currentPosition.x shouldBe route.last().end.x
+    }
+
+    test("activating more than a block away searches again") {
+        val gps = RecordingGPS(route)
+        val context = context()
+        val activity = NavigationActivity(gps, propertyAt(0.0))
+
+        activity.activate(context, propertyAt(0.0))
+        activity.tickUntilTravelling(context)
+
+        activity.deactivate(context)
+        activity.activate(context, propertyAt(activity.currentPosition.x + 5.0))
+        repeat(TICK_LIMIT) {
+            activity.tick(context)
+            if (gps.searches > 1) return@repeat
+            delay(1)
+        }
+
+        gps.searches shouldBe 2
+        gps.clearedPreviousPath shouldBe 2
+    }
+})

--- a/extensions/RoadNetworkExtension/src/main/kotlin/com/typewritermc/roadnetwork/gps/GPS.kt
+++ b/extensions/RoadNetworkExtension/src/main/kotlin/com/typewritermc/roadnetwork/gps/GPS.kt
@@ -32,7 +32,23 @@ import kotlin.math.pow
 
 interface GPS {
     val roadNetwork: Ref<RoadNetworkEntry>
+
+    /**
+     * Searches a route between the start and the end.
+     *
+     * The result is stored for the next search to reuse. Nothing is stored when the search is
+     * cancelled.
+     */
     suspend fun findPath(): Result<List<GPSEdge>>
+
+    /**
+     * Removes the route of the last search, so the next search does not reuse it.
+     *
+     * Reuse is only valid when the next search continues along the route of the last one. A caller
+     * whose next search starts elsewhere has to call this first. A search that is already running
+     * does not store its route.
+     */
+    fun clearPreviousPath() {}
 }
 
 data class GPSEdge(

--- a/extensions/RoadNetworkExtension/src/main/kotlin/com/typewritermc/roadnetwork/gps/PointToPointGPS.kt
+++ b/extensions/RoadNetworkExtension/src/main/kotlin/com/typewritermc/roadnetwork/gps/PointToPointGPS.kt
@@ -14,9 +14,15 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.ensureActive
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.util.*
+import java.util.concurrent.atomic.AtomicReference
+
+// Compared by reference, so a search can see whether the route it read at the start was replaced
+// while it was running.
+private class PreviousPath(val edges: List<RoadEdge>)
 
 class PointToPointGPS(
     override val roadNetwork: Ref<RoadNetworkEntry>,
@@ -26,9 +32,14 @@ class PointToPointGPS(
     private val roadNetworkManager: RoadNetworkManager by inject()
     private var previousStart: Pair<RoadNode, List<RoadEdge>?>? = null
     private var previousEnd: Pair<RoadNode, List<RoadEdge>?>? = null
-    private var previousPath: List<RoadEdge> = emptyList()
+    private val previousPath = AtomicReference(PreviousPath(emptyList()))
+
+    override fun clearPreviousPath() {
+        previousPath.set(PreviousPath(emptyList()))
+    }
 
     override suspend fun findPath(): Result<List<GPSEdge>> = Dispatchers.UntickedAsync.switchContext {
+        val previous = previousPath.get()
         var network = roadNetworkManager.getNetwork(roadNetwork)
 
         val start = startFetcher(network)
@@ -61,13 +72,16 @@ class PointToPointGPS(
             network.nodes.firstOrNull { it.id == id }
                 ?: throw IllegalStateException("Could not find node $id in the network, possible nodes: ${network.nodes.map { it.id }}, edges: ${network.edges}, start: $startPair, end: $endPair")
         }
-        val path = findPath(nodes, network.edges, previousPath, startPair.first, endPair.first)
+        val path = findPath(nodes, network.edges, previous.edges, startPair.first, endPair.first)
         if (path.isFailure) {
             return@switchContext path.exceptionOrNull()?.let { failure(it) }
                 ?: failure("Could not find a path between $start and $end.")
         }
-        previousPath = path.getOrThrow()
-        ok(previousPath.map { edge ->
+        // A cancelled search must not store its route.
+        ensureActive()
+        val edges = path.getOrThrow()
+        previousPath.compareAndSet(previous, PreviousPath(edges))
+        ok(edges.map { edge ->
             GPSEdge(
                 nodes[edge.start]!!.position,
                 nodes[edge.end]!!.position,

--- a/extensions/RoadNetworkExtension/src/test/kotlin/com/typewritermc/roadnetwork/gps/PointToPointGPSSpec.kt
+++ b/extensions/RoadNetworkExtension/src/test/kotlin/com/typewritermc/roadnetwork/gps/PointToPointGPSSpec.kt
@@ -1,0 +1,155 @@
+package com.typewritermc.roadnetwork.gps
+
+import com.typewritermc.core.entries.emptyRef
+import com.typewritermc.core.utils.UntickedAsync
+import com.typewritermc.core.utils.launch
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.World
+import com.typewritermc.roadnetwork.RoadEdge
+import com.typewritermc.roadnetwork.RoadNetwork
+import com.typewritermc.roadnetwork.RoadNetworkManager
+import com.typewritermc.roadnetwork.RoadNode
+import com.typewritermc.roadnetwork.RoadNodeId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.withTimeout
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.math.abs
+import kotlin.time.Duration.Companion.seconds
+
+private const val SEARCH_TIMEOUT_SECONDS = 10L
+
+private val world = World("gps-world")
+
+private fun positionAt(x: Double) = Position(world, x, 64.0, 0.0)
+
+private fun CountDownLatch.awaitSearch() {
+    await(SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS) shouldBe true
+}
+
+private suspend fun Job.joinSearch() {
+    withTimeout(SEARCH_TIMEOUT_SECONDS.seconds) { join() }
+}
+
+private fun edgeBetween(start: RoadNode, end: RoadNode): RoadEdge {
+    val length = abs(start.position.x - end.position.x)
+    return RoadEdge(start.id, end.id, weight = length, length = length)
+}
+
+class PointToPointGPSSpec : FunSpec({
+    val behind = RoadNode(RoadNodeId(1), positionAt(0.0), 1.0)
+    val ahead = RoadNode(RoadNodeId(2), positionAt(40.0), 1.0)
+    val destination = RoadNode(RoadNodeId(3), positionAt(200.0), 1.0)
+    val between = RoadNode(RoadNodeId(4), positionAt(5.0), 1.0)
+
+    val network = RoadNetwork(
+        nodes = listOf(behind, ahead, destination, between),
+        edges = listOf(
+            edgeBetween(behind, ahead), edgeBetween(ahead, behind),
+            edgeBetween(ahead, destination), edgeBetween(destination, ahead),
+            edgeBetween(between, behind), edgeBetween(behind, between),
+            edgeBetween(between, ahead), edgeBetween(ahead, between),
+        ),
+    )
+
+    beforeTest {
+        val manager = mockk<RoadNetworkManager>()
+        coEvery { manager.getNetwork(any()) } returns network
+        startKoin {
+            modules(
+                module {
+                    single<RoadNetworkManager> { manager }
+                    factory<Boolean>(named("isEnabled")) { true }
+                }
+            )
+        }
+    }
+
+    afterTest { stopKoin() }
+
+    test("a search from between two nodes takes the node ahead") {
+        val gps = PointToPointGPS(emptyRef(), { between.position }, { destination.position })
+
+        val route = gps.findPath().getOrThrow()
+
+        route.map { it.end } shouldBe listOf(ahead.position, destination.position)
+    }
+
+    test("a search takes the node ahead once the previous route is cleared") {
+        var start = behind.position
+        val gps = PointToPointGPS(emptyRef(), { start }, { destination.position })
+
+        gps.findPath().getOrThrow()
+        start = between.position
+        gps.clearPreviousPath()
+
+        val route = gps.findPath().getOrThrow()
+
+        route.map { it.end } shouldBe listOf(ahead.position, destination.position)
+    }
+
+    test("a search that finishes after a clear does not store its route") {
+        val startedSearch = CountDownLatch(1)
+        val holdSearch = CountDownLatch(1)
+        var holdNextSearch = false
+        var start = behind.position
+        val gps = PointToPointGPS(emptyRef(), {
+            if (holdNextSearch) {
+                startedSearch.countDown()
+                holdSearch.await()
+            }
+            start
+        }, { destination.position })
+
+        gps.findPath().getOrThrow()
+
+        holdNextSearch = true
+        val job = Dispatchers.UntickedAsync.launch { gps.findPath() }
+        try {
+            startedSearch.awaitSearch()
+            gps.clearPreviousPath()
+        } finally {
+            holdSearch.countDown()
+        }
+        job.joinSearch()
+
+        start = between.position
+        val route = gps.findPath().getOrThrow()
+
+        route.map { it.end } shouldBe listOf(ahead.position, destination.position)
+    }
+
+    test("a cancelled search does not store its route") {
+        val startedSearch = CountDownLatch(1)
+        val holdSearch = CountDownLatch(1)
+        var start = behind.position
+        val gps = PointToPointGPS(emptyRef(), {
+            startedSearch.countDown()
+            holdSearch.await()
+            start
+        }, { destination.position })
+
+        val job = Dispatchers.UntickedAsync.launch { runCatching { gps.findPath() } }
+        try {
+            startedSearch.awaitSearch()
+            job.cancel()
+        } finally {
+            holdSearch.countDown()
+        }
+        job.joinSearch()
+
+        start = between.position
+        val route = gps.findPath().getOrThrow()
+
+        route.map { it.end } shouldBe listOf(ahead.position, destination.position)
+    }
+})

--- a/extensions/RoadNetworkExtension/src/test/kotlin/com/typewritermc/roadnetwork/gps/TemporaryStartNodeGPSSpec.kt
+++ b/extensions/RoadNetworkExtension/src/test/kotlin/com/typewritermc/roadnetwork/gps/TemporaryStartNodeGPSSpec.kt
@@ -1,0 +1,190 @@
+package com.typewritermc.roadnetwork.gps
+
+import com.typewritermc.core.entries.emptyRef
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.World
+import com.typewritermc.core.utils.point.distanceSquared
+import com.typewritermc.engine.paper.snippets.SnippetDatabase
+import com.typewritermc.roadnetwork.RoadEdge
+import com.typewritermc.roadnetwork.RoadNetwork
+import com.typewritermc.roadnetwork.RoadNetworkManager
+import com.typewritermc.roadnetwork.RoadNode
+import com.typewritermc.roadnetwork.RoadNodeId
+import de.bsommerfeld.pathetic.api.pathing.Pathfinder
+import de.bsommerfeld.pathetic.api.pathing.PathfindingSearch
+import de.bsommerfeld.pathetic.api.pathing.context.EnvironmentContext
+import de.bsommerfeld.pathetic.api.pathing.hook.PathfinderHook
+import de.bsommerfeld.pathetic.api.pathing.result.Path
+import de.bsommerfeld.pathetic.api.pathing.result.PathState
+import de.bsommerfeld.pathetic.api.pathing.result.PathfinderResult
+import de.bsommerfeld.pathetic.api.wrapper.PathPosition
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+import org.mockbukkit.mockbukkit.MockBukkit
+import org.mockbukkit.mockbukkit.ServerMock
+import java.util.Optional
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.function.Consumer
+import kotlin.math.ceil
+import kotlin.math.max
+import kotlin.math.sqrt
+import kotlin.reflect.KClass
+
+/**
+ * A block level pathfinder that always succeeds with a straight line, one block per step.
+ * A path therefore holds `ceil(distance) + 1` positions, which is what pathetic reports as its length.
+ */
+private class StraightLinePathfinder(private val calls: AtomicInteger) : Pathfinder {
+    override fun findPath(start: PathPosition, target: PathPosition, context: EnvironmentContext): PathfindingSearch {
+        calls.incrementAndGet()
+        return CompletedSearch(StraightPath(straightLineBetween(start, target)))
+    }
+
+    @Suppress("OVERRIDE_DEPRECATION")
+    override fun registerPathfindingHook(hook: PathfinderHook) {}
+}
+
+private class CompletedSearch(path: Path) : PathfindingSearch {
+    private val result: PathfinderResult = SuccessfulResult(path)
+
+    override fun ifPresent(consumer: Consumer<PathfinderResult>): PathfindingSearch {
+        consumer.accept(result)
+        return this
+    }
+
+    override fun orElse(consumer: Consumer<PathfinderResult>): PathfindingSearch = this
+    override fun exceptionally(consumer: Consumer<Throwable>): PathfindingSearch = this
+    override fun resultBlocking(): PathfinderResult = result
+    override fun result(): Optional<PathfinderResult> = Optional.of(result)
+    override fun done(): Boolean = true
+    override fun abort() {}
+}
+
+private class SuccessfulResult(private val path: Path) : PathfinderResult {
+    override fun successful(): Boolean = true
+    override fun hasFailed(): Boolean = false
+    override fun hasFallenBack(): Boolean = false
+    override fun getPathState(): PathState = PathState.FOUND
+    override fun getPath(): Path = path
+}
+
+private class StraightPath(private val positions: MutableList<PathPosition>) : Path {
+    override fun length(): Int = positions.size
+    override fun getStart(): PathPosition = positions.first()
+    override fun getEnd(): PathPosition = positions.last()
+    override fun collect(): Collection<PathPosition> = positions
+    override fun iterator(): MutableIterator<PathPosition> = positions.iterator()
+}
+
+private fun straightLineBetween(start: PathPosition, end: PathPosition): MutableList<PathPosition> {
+    val dx = end.x - start.x
+    val dy = end.y - start.y
+    val dz = end.z - start.z
+    val steps = max(1, ceil(sqrt(dx * dx + dy * dy + dz * dz)).toInt())
+    return (0..steps).mapTo(mutableListOf()) { step ->
+        val progress = step.toDouble() / steps
+        PathPosition(start.x + dx * progress, start.y + dy * progress, start.z + dz * progress)
+    }
+}
+
+private fun blockPathLength(from: Position, to: Position): Double =
+    (max(1, ceil(sqrt(from.distanceSquared(to)!!)).toInt()) + 1).toDouble()
+
+private class DefaultSnippetDatabase : SnippetDatabase {
+    override fun get(path: String, default: Any, comment: String): Any = default
+    override fun <T : Any> getSnippet(path: String, klass: KClass<T>, default: T, comment: String): T = default
+    override fun registerSnippet(path: String, defaultValue: Any, comment: String) {}
+}
+
+private const val NODE_COUNT = 9
+private const val NODE_SPACING = 25.0
+
+class TemporaryStartNodeGPSSpec : FunSpec() {
+    private lateinit var server: ServerMock
+    private lateinit var world: World
+    private lateinit var network: RoadNetwork
+    private val blockPathfinderCalls = AtomicInteger()
+
+    private fun positionAt(x: Double) = Position(world, x, 64.0, 0.0)
+
+    init {
+        beforeTest {
+            blockPathfinderCalls.set(0)
+            server = MockBukkit.mock()
+            world = World(server.addSimpleWorld("gps-temporary-node-world").uid.toString())
+
+            // A straight road running from x = 0 to x = 200. The spacing is close enough that a start
+            // between the first two nodes reaches both, and the destination is far enough that the
+            // node behind the start still scores lower than the node ahead of it.
+            val nodes = (0 until NODE_COUNT).map { index ->
+                RoadNode(RoadNodeId(index + 1), positionAt(index * NODE_SPACING), 1.0)
+            }
+            val edges = nodes.zipWithNext().flatMap { (first, second) ->
+                val length = blockPathLength(first.position, second.position)
+                listOf(
+                    RoadEdge(first.id, second.id, weight = length, length = length),
+                    RoadEdge(second.id, first.id, weight = length, length = length),
+                )
+            }
+            network = RoadNetwork(nodes = nodes, edges = edges)
+
+            val manager = mockk<RoadNetworkManager>()
+            coEvery { manager.getNetwork(any()) } returns network
+
+            startKoin {
+                modules(
+                    module {
+                        single<RoadNetworkManager> { manager }
+                        factory<Boolean>(named("isEnabled")) { true }
+                        single<SnippetDatabase> { DefaultSnippetDatabase() }
+                        factory<Pathfinder> { StraightLinePathfinder(blockPathfinderCalls) }
+                    }
+                )
+            }
+        }
+
+        afterTest {
+            stopKoin()
+            MockBukkit.unmock()
+        }
+
+        test("a start between two nodes builds a temporary node and heads forward") {
+            val gps = PointToPointGPS(emptyRef(), { positionAt(3.0) }, { positionAt(200.0) })
+
+            val route = gps.findPath().getOrThrow()
+
+            blockPathfinderCalls.get() shouldBeGreaterThan 0
+            route.first().start shouldBe positionAt(3.0)
+            route.first().end shouldBe positionAt(25.0)
+            route.last().end shouldBe positionAt(200.0)
+        }
+
+        test("a search from between two nodes heads forward once the previous route is cleared") {
+            var start = positionAt(-5.0)
+            val gps = PointToPointGPS(emptyRef(), { start }, { positionAt(200.0) })
+
+            val first = gps.findPath().getOrThrow()
+            val callsAfterFirst = blockPathfinderCalls.get()
+
+            start = positionAt(3.0)
+            gps.clearPreviousPath()
+            val second = gps.findPath().getOrThrow()
+
+            callsAfterFirst shouldBeGreaterThan 0
+            blockPathfinderCalls.get() shouldBeGreaterThan callsAfterFirst
+            first.first().start shouldBe positionAt(-5.0)
+            first.first().end shouldBe positionAt(0.0)
+
+            second.first().start shouldBe positionAt(3.0)
+            second.first().end shouldBe positionAt(25.0)
+            second.last().end shouldBe positionAt(200.0)
+        }
+    }
+}


### PR DESCRIPTION
An npc with a target location activity that stops between two nodes walks back to the node behind it once the player leaves the range and comes back, instead of carrying on to the next one.

A search reuses the route of the search before it. It stops at the first node it inspects that the previous route also passed through, and appends the rest of that route from there. That node used to be the one ahead of the entity, because the entity was walking towards it. After a pause the entity stands wherever it stopped, which is usually just past a node, so the first node the search inspects is the one behind it. That node is on the previous route too, and the route that comes back starts with the edge the entity had just walked.

Searching there at all is the mistake. Nothing about the route changes while an activity is paused, so a navigation that is activated where it left off now carries on with the edge it was travelling and does not search. It searches, and drops the route it had, only when it is activated more than a block away, which is the only case where the entity can stand somewhere the old route does not reach.

This also avoids a second effect of researching from a paused position. A start that is not inside a node's radius gets a temporary node, and that node is connected to every node within the maximum distance, measured from where the entity stands. That reaches nodes the surrounding road nodes cannot reach themselves, so the search could pick a long edge to a node far ahead and take the npc off the road. That behaviour predates the lifecycle split and is unchanged here; not searching on resume simply stops it from being reached that way.

Before #493 the target location activity built a new PointToPointGPS on every initialize, so a resumed search never had a previous route to reuse. The GPS survives a pause now, so the reuse has to be dropped explicitly whenever the route is thrown away. A search that was already running kept its route as well, so a navigation that is deactivated and activated again within a few ticks could reuse a route from before the activation. A route is now only stored when the one it was searched against is still the current one, and a cancelled search stores nothing.