### PR TITLE
feat(engine-paper): read an entry as it stands in staging, and report whether a field write landed

### DIFF
--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/AudienceManager.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/AudienceManager.kt
@@ -234,3 +234,42 @@ fun <E : AudienceEntry> Ref<out AudienceFilterEntry>.descendants(klass: KClass<E
     val entry = get() ?: return emptyList()
     return entry.children.descendants(klass)
 }
+
+/**
+ * The entries of type [E] found by walking up from these refs, through every filter that
+ * declared them as a child. The reverse of [descendants].
+ *
+ * A ref that is itself an [E] is reported instead of its parents, the same way [descendants]
+ * stops at a match on the way down. The nearest matches come first, and an entry reachable
+ * through more than one parent is reported once, so a filter above a diamond is not counted
+ * twice.
+ *
+ * Which entries are parents of which is only known once the audience tree is loaded, so this
+ * asks the [AudienceManager] rather than reading it off the entries.
+ */
+fun <E : AudienceEntry> List<Ref<out AudienceEntry>>.ascendants(klass: KClass<E>): List<Ref<E>> {
+    val manager = get<AudienceManager>(AudienceManager::class.java)
+    val found = mutableListOf<Ref<E>>()
+    val visited = mutableSetOf<Ref<out AudienceEntry>>()
+    val pending = ArrayDeque(this)
+
+    while (pending.isNotEmpty()) {
+        val ref = pending.removeFirst()
+        if (!visited.add(ref)) continue
+        val entry = ref.get() ?: continue
+        if (klass.isInstance(entry)) {
+            @Suppress("UNCHECKED_CAST")
+            found.add(ref as Ref<E>)
+            continue
+        }
+        pending.addAll(manager.getParents(ref))
+    }
+    return found
+}
+
+fun <E : AudienceEntry> AudienceEntry.ascendants(klass: KClass<E>): List<Ref<E>> = ref().ascendants(klass)
+
+fun <E : AudienceEntry> Ref<out AudienceEntry>.ascendants(klass: KClass<E>): List<Ref<E>> {
+    val manager = get<AudienceManager>(AudienceManager::class.java)
+    return manager.getParents(this).ascendants(klass)
+}

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/StagingManager.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/StagingManager.kt
@@ -400,25 +400,48 @@ enum class StagingState {
 }
 
 inline fun <reified T : Any> Ref<out Entry>.fieldValue(path: String, value: T) = fieldValue(path, value, T::class.java)
+
+/**
+ * Writes [value] into this entry's [path] in staging and tells the panel about it.
+ *
+ * A failed write is logged and otherwise passes unnoticed. Use [writeFieldValue] where the
+ * caller tells a player the write succeeded.
+ */
 fun Ref<out Entry>.fieldValue(path: String, value: Any, type: Type) {
+    writeFieldValue(path, value, type)
+}
+
+inline fun <reified T : Any> Ref<out Entry>.writeFieldValue(path: String, value: T): Result<Unit> =
+    writeFieldValue(path, value, T::class.java)
+
+/**
+ * Writes [value] into this entry's [path] in staging and tells the panel about it, reporting
+ * the outcome.
+ *
+ * An entry moved to another page between resolving the ref and writing resolves its page id
+ * against the published library, and the write then lands nowhere. A caller that reports back
+ * to a player needs to know that, rather than playing the confirmation sound regardless.
+ */
+fun Ref<out Entry>.writeFieldValue(path: String, value: Any, type: Type): Result<Unit> {
     val stagingManager = KoinJavaComponent.get<StagingManager>(StagingManager::class.java)
     val gson = KoinJavaComponent.get<Gson>(Gson::class.java, named("dataSerializer"))
 
     val pageId = pageId
     if (pageId == null) {
         logger.warning("No pageId found for $this. Did you forgot to publish?")
-        return
+        return Result.failure(IllegalStateException("No page found for $this. Publish the page first."))
     }
 
     val json = gson.toJsonTree(value, type)
     val result = stagingManager.updateEntryField(pageId, id, path, json)
     if (result.isFailure) {
         logger.warning("Failed to update field: ${result.exceptionOrNull()}")
-        return
+        return result.map { }
     }
 
     val clientSynchronizer = KoinJavaComponent.get<ClientSynchronizer>(ClientSynchronizer::class.java)
     clientSynchronizer.sendEntryFieldUpdate(pageId, id, path, json)
+    return Result.success(Unit)
 }
 
 /**

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/StagingManager.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/StagingManager.kt
@@ -421,6 +421,25 @@ fun Ref<out Entry>.fieldValue(path: String, value: Any, type: Type) {
     clientSynchronizer.sendEntryFieldUpdate(pageId, id, path, json)
 }
 
+/**
+ * The entry as it exists in staging, including field edits not yet published, or `null` when
+ * the entry is not on a staged page or cannot be parsed. Deserialized fresh from the staging
+ * json, so it reflects writes made through [fieldValue] that [Ref.get] (the published
+ * runtime) does not see until a publish.
+ */
+fun <E : Entry> Ref<E>.stagedEntry(): E? {
+    val published = get() ?: return null
+    val pageId = pageId ?: return null
+    val stagingManager = KoinJavaComponent.get<StagingManager>(StagingManager::class.java)
+    val entries = stagingManager.pages[pageId]?.getAsJsonArray("entries") ?: return null
+    val json = entries
+        .firstOrNull { it.isJsonObject && it.asJsonObject.get("id")?.asString == id }
+        ?.asJsonObject ?: return null
+    val gson = KoinJavaComponent.get<Gson>(Gson::class.java, named("dataSerializer"))
+    // The target type is the published entry's own class, so the parse already yields an E.
+    return runCatching { gson.fromJson(json, published.javaClass) }.getOrNull()
+}
+
 fun List<File>.backupAndMove() {
     if (isEmpty()) {
         // Nothing to back up


### PR DESCRIPTION
Three small engine additions that came out of building the region editor, none of them specific to it.

The first is stagedEntry. Ref.get returns the published entry, so a content mode that writes a field through fieldValue and reads the entry back in the same session watches its own edits disappear until the next publish. Anything that shows a builder what they have changed so far needs the staged state, and this reads it straight from the staging json rather than waiting for a publish.

The second is writeFieldValue, which returns a Result rather than swallowing the outcome. A ref resolves its page id against the published library, so an entry moved to another page between resolving and writing lands its write nowhere at all. Callers that tell a player the value was saved, and play the confirmation sound while they say it, had no way of knowing that. fieldValue keeps its old shape and behaviour for callers that only want the write attempted, so every existing call site is untouched.

The third is ascendants, the reverse of descendants on the audience tree. A display that needs to know which filter it sits under had to start at every root and walk down until it found itself. Which entries are parents is known only to the AudienceManager once the tree is loaded, since an entry declares only its children, so the walk upward goes through the manager instead of the entries. It walks iteratively with a visited set, so a circular reference terminates instead of overflowing the stack the way descendants does, and an entry reachable through two parents is reported once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved audience hierarchy navigation, including support for finding matching parent entries across shared hierarchies.
  * Added access to staged entry data, including unpublished edits.
* **Bug Fixes**
  * Improved field updates by providing clearer success or failure results.
  * Missing pages and staging update errors are now reported reliably instead of being logged silently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->