### PR TITLE
Upgrade Skir Dart generation dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,7 @@
     "": {
       "name": "typewriter-build-tools",
       "dependencies": {
-        "skir": "1.2.20",
-        "skir-dart-gen": "github:gabber235/skir-dart-gen#78c2d2d",
+        "skir": "1.2.21",
         "skir-kotlin-gen": "1.0.11",
         "skir-rust-gen": "0.1.5",
       },
@@ -243,13 +242,13 @@
 
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
-    "skir": ["skir@1.2.20", "", { "dependencies": { "glob": "^13.0.6", "skir-cc-gen": "^1.0.16", "skir-csharp-gen": "^0.1.1", "skir-dart-gen": "^1.0.8", "skir-gleam-gen": "^0.1.3", "skir-go-gen": "^0.1.7", "skir-internal": "^0.2.21", "skir-java-gen": "^1.0.10", "skir-kotlin-gen": "^1.0.11", "skir-moonbit-gen": "^0.1.0", "skir-python-gen": "^1.0.9", "skir-rust-gen": "^0.1.5", "skir-swift-gen": "^0.1.7", "skir-typescript-gen": "^1.0.11", "skir-zig-gen": "^0.1.8", "watcher": "^2.3.1", "yaml": "^2.7.1", "zod": "^4.3.6" }, "bin": { "skir": "dist/compiler.js" } }, "sha512-GPbFQ73bM1njC9mrtFcgmkrwr+8YcrGmlB1DnfNxruI8k2OL5l5AFsNt97+uwi4zNyDlRJmsiOhdfJ3GqmzJdw=="],
+    "skir": ["skir@1.2.21", "", { "dependencies": { "glob": "^13.0.6", "skir-cc-gen": "^1.0.16", "skir-csharp-gen": "^0.1.1", "skir-dart-gen": "^1.0.9", "skir-gleam-gen": "^0.1.3", "skir-go-gen": "^0.1.7", "skir-internal": "^0.2.21", "skir-java-gen": "^1.0.10", "skir-kotlin-gen": "^1.0.11", "skir-moonbit-gen": "^0.1.0", "skir-python-gen": "^1.0.9", "skir-rust-gen": "^0.1.5", "skir-swift-gen": "^0.1.7", "skir-typescript-gen": "^1.0.11", "skir-zig-gen": "^0.1.8", "watcher": "^2.3.1", "yaml": "^2.7.1", "zod": "^4.3.6" }, "bin": { "skir": "dist/compiler.js" } }, "sha512-hpuTBOloqZ8T3XX1FoSRHMNJp0OGvu/h1esrWbZ1nfyUnP95fREDu88QM4KEmS1vvfQ05p10s/DGYYEdiSMilQ=="],
 
     "skir-cc-gen": ["skir-cc-gen@1.0.16", "", { "dependencies": { "skir-internal": "^0.2.19", "zod": "^4.2.1" } }, "sha512-BpL81tWcOndPtIReX3ek+ZGK6wblCiTUvX2rf0tcc8LuMtVMD1y7iCT4+Mh2aZmnWTxjmJYjqIBiTXooLPyhCg=="],
 
     "skir-csharp-gen": ["skir-csharp-gen@0.1.1", "", { "dependencies": { "skir-internal": "^0.2.21", "zod": "^4.2.1" } }, "sha512-aP594TnW2iSRBnp9H7TeYyXNS9NmmERT3WF80mNhNdanBeShzvnuQu0QgShJMX0k5nQEoK579lZNSwSYNAZBSQ=="],
 
-    "skir-dart-gen": ["skir-dart-gen@github:gabber235/skir-dart-gen#78c2d2d", { "dependencies": { "skir-internal": "^0.1.1", "zod": "^4.2.1" } }, "gabber235-skir-dart-gen-78c2d2d", "sha512-H2ZD3aFtqjD+7J7yS+//iRKcPd//2p2RthVDQWKxY87Hyzvy4Bt81V+Kw+RlMmz6gIaI0uExXpET/iJ+KU2X8Q=="],
+    "skir-dart-gen": ["skir-dart-gen@1.0.9", "", { "dependencies": { "skir-internal": "^0.1.1", "zod": "^4.2.1" } }, "sha512-niB2TE1BOaMdXUDT5SvUQ2RHJqlDUH88OFFm4Ufir0GmqHHo5qIsypR+wWcjB4LUwDH2HVBfztRn4V3MA5OL/A=="],
 
     "skir-gleam-gen": ["skir-gleam-gen@0.1.3", "", { "dependencies": { "skir-internal": "^0.2.19", "zod": "^4.2.1" } }, "sha512-qSCk1Xr0cDaI5yQbZCcST75QloKJL74waO9q2uVW6JlWgAC9YL+ZlDZ5rJbJcJecbZnWuPyFRK6pQfwV7VmU1w=="],
 
@@ -303,8 +302,6 @@
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
-    "skir/skir-dart-gen": ["skir-dart-gen@1.0.8", "", { "dependencies": { "skir-internal": "^0.1.1", "zod": "^4.2.1" } }, "sha512-9IWR7h05aD9/5jCKJyp7lEnigSkJ5Rkj531JzaJDiaWmEu4aAr61pP8n1nlNKnW8ML4LRc2SACuFGycd1DRdcg=="],
-
     "skir-dart-gen/skir-internal": ["skir-internal@0.1.1", "", { "dependencies": { "zod": "^4.2.1" }, "bin": { "skir-internal": "dist/compiler.js" } }, "sha512-lE/ZlQMfmGAZ3gb1gkdCv/PRZOrJmndp0tBWYcQb6Vr+qNjpPhIqw1a5iJ88muFw1AVUAGx97NIP3FI17vqi8A=="],
 
     "skir-go-gen/skir-internal": ["skir-internal@0.1.1", "", { "dependencies": { "zod": "^4.2.1" }, "bin": { "skir-internal": "dist/compiler.js" } }, "sha512-lE/ZlQMfmGAZ3gb1gkdCv/PRZOrJmndp0tBWYcQb6Vr+qNjpPhIqw1a5iJ88muFw1AVUAGx97NIP3FI17vqi8A=="],
@@ -318,7 +315,5 @@
     "skir-swift-gen/skir-internal": ["skir-internal@0.1.1", "", { "dependencies": { "zod": "^4.2.1" }, "bin": { "skir-internal": "dist/compiler.js" } }, "sha512-lE/ZlQMfmGAZ3gb1gkdCv/PRZOrJmndp0tBWYcQb6Vr+qNjpPhIqw1a5iJ88muFw1AVUAGx97NIP3FI17vqi8A=="],
 
     "skir-typescript-gen/skir-internal": ["skir-internal@0.1.1", "", { "dependencies": { "zod": "^4.2.1" }, "bin": { "skir-internal": "dist/compiler.js" } }, "sha512-lE/ZlQMfmGAZ3gb1gkdCv/PRZOrJmndp0tBWYcQb6Vr+qNjpPhIqw1a5iJ88muFw1AVUAGx97NIP3FI17vqi8A=="],
-
-    "skir/skir-dart-gen/skir-internal": ["skir-internal@0.1.1", "", { "dependencies": { "zod": "^4.2.1" }, "bin": { "skir-internal": "dist/compiler.js" } }, "sha512-lE/ZlQMfmGAZ3gb1gkdCv/PRZOrJmndp0tBWYcQb6Vr+qNjpPhIqw1a5iJ88muFw1AVUAGx97NIP3FI17vqi8A=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "lefthook": "2.1.10"
   },
   "dependencies": {
-    "skir": "1.2.20",
-    "skir-dart-gen": "github:gabber235/skir-dart-gen#78c2d2d",
+    "skir": "1.2.21",
     "skir-kotlin-gen": "1.0.11",
     "skir-rust-gen": "0.1.5"
   },

--- a/panel/.zed/debug.json
+++ b/panel/.zed/debug.json
@@ -5,7 +5,7 @@
     "request": "attach",
     "tcp_connection": {
       "host": "127.0.0.1",
-      "port": 61525
+      "port": 50784
     }
   }
 ]

--- a/panel/lib/infrastructure/protocols/skir/skirout/access/v1/permission.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/access/v1/permission.dart
@@ -13,6 +13,7 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "../../kernel/v1/duration.dart" as _lib_kernel_v1_duration;
 import "../../kernel/v1/record_id.dart" as _lib_kernel_v1_record_id;
 

--- a/panel/lib/infrastructure/protocols/skir/skirout/access/v1/sentinel.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/access/v1/sentinel.dart
@@ -13,6 +13,7 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "../../kernel/v1/errors.dart" as _lib_kernel_v1_errors;
 
 // -----------------------------------------------------------------------------

--- a/panel/lib/infrastructure/protocols/skir/skirout/editor/v1/action.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/editor/v1/action.dart
@@ -13,6 +13,7 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "./binding.dart" as _lib_editor_v1_binding;
 import "./diagnostic.dart" as _lib_editor_v1_diagnostic;
 import "./expression.dart" as _lib_editor_v1_expression;

--- a/panel/lib/infrastructure/protocols/skir/skirout/editor/v1/binding.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/editor/v1/binding.dart
@@ -13,6 +13,7 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "./diagnostic.dart" as _lib_editor_v1_diagnostic;
 import "./path.dart" as _lib_editor_v1_path;
 import "./type_catalog.dart" as _lib_editor_v1_type_catalog;

--- a/panel/lib/infrastructure/protocols/skir/skirout/editor/v1/catalog.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/editor/v1/catalog.dart
@@ -13,6 +13,7 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "./conversion.dart" as _lib_editor_v1_conversion;
 import "./diagnostic.dart" as _lib_editor_v1_diagnostic;
 import "./presentation.dart" as _lib_editor_v1_presentation;

--- a/panel/lib/infrastructure/protocols/skir/skirout/editor/v1/conversion.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/editor/v1/conversion.dart
@@ -13,6 +13,7 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "./path.dart" as _lib_editor_v1_path;
 import "./type_catalog.dart" as _lib_editor_v1_type_catalog;
 

--- a/panel/lib/infrastructure/protocols/skir/skirout/editor/v1/diagnostic.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/editor/v1/diagnostic.dart
@@ -13,6 +13,7 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "./path.dart" as _lib_editor_v1_path;
 
 // -----------------------------------------------------------------------------

--- a/panel/lib/infrastructure/protocols/skir/skirout/editor/v1/expression.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/editor/v1/expression.dart
@@ -13,9 +13,10 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "./binding.dart" as _lib_editor_v1_binding;
-import "./path.dart" as _lib_editor_v1_path;
 import "./type_catalog.dart" as _lib_editor_v1_type_catalog;
+import "./path.dart" as _lib_editor_v1_path;
 
 // -----------------------------------------------------------------------------
 // enum ComparisonOperator

--- a/panel/lib/infrastructure/protocols/skir/skirout/editor/v1/path.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/editor/v1/path.dart
@@ -13,6 +13,7 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "./type_catalog.dart" as _lib_editor_v1_type_catalog;
 
 // -----------------------------------------------------------------------------

--- a/panel/lib/infrastructure/protocols/skir/skirout/editor/v1/presentation.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/editor/v1/presentation.dart
@@ -13,6 +13,7 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "./action.dart" as _lib_editor_v1_action;
 import "./binding.dart" as _lib_editor_v1_binding;
 import "./expression.dart" as _lib_editor_v1_expression;

--- a/panel/lib/infrastructure/protocols/skir/skirout/editor/v1/search.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/editor/v1/search.dart
@@ -13,6 +13,7 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "./diagnostic.dart" as _lib_editor_v1_diagnostic;
 import "./type_catalog.dart" as _lib_editor_v1_type_catalog;
 

--- a/panel/lib/infrastructure/protocols/skir/skirout/editor/v1/type_catalog.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/editor/v1/type_catalog.dart
@@ -13,6 +13,7 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "../../kernel/v1/duration.dart" as _lib_kernel_v1_duration;
 
 // -----------------------------------------------------------------------------

--- a/panel/lib/infrastructure/protocols/skir/skirout/editor/v1/typed_value.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/editor/v1/typed_value.dart
@@ -13,6 +13,7 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "./type_catalog.dart" as _lib_editor_v1_type_catalog;
 
 // -----------------------------------------------------------------------------

--- a/panel/lib/infrastructure/protocols/skir/skirout/library/v1/book.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/library/v1/book.dart
@@ -13,6 +13,7 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "../../kernel/v1/color.dart" as _lib_kernel_v1_color;
 import "../../kernel/v1/errors.dart" as _lib_kernel_v1_errors;
 import "../../kernel/v1/record_id.dart" as _lib_kernel_v1_record_id;

--- a/panel/lib/infrastructure/protocols/skir/skirout/library/v1/page.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/library/v1/page.dart
@@ -13,6 +13,7 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "../../kernel/v1/errors.dart" as _lib_kernel_v1_errors;
 import "../../kernel/v1/record_id.dart" as _lib_kernel_v1_record_id;
 

--- a/panel/lib/infrastructure/protocols/skir/skirout/library/v1/tag.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/library/v1/tag.dart
@@ -13,6 +13,7 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "../../kernel/v1/color.dart" as _lib_kernel_v1_color;
 import "../../kernel/v1/errors.dart" as _lib_kernel_v1_errors;
 import "../../kernel/v1/record_id.dart" as _lib_kernel_v1_record_id;

--- a/panel/lib/infrastructure/protocols/skir/skirout/organization/v1/join_codes.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/organization/v1/join_codes.dart
@@ -13,6 +13,7 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "../../kernel/v1/duration.dart" as _lib_kernel_v1_duration;
 import "../../kernel/v1/errors.dart" as _lib_kernel_v1_errors;
 import "../../kernel/v1/record_id.dart" as _lib_kernel_v1_record_id;

--- a/panel/lib/infrastructure/protocols/skir/skirout/organization/v1/join_request.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/organization/v1/join_request.dart
@@ -13,6 +13,7 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "../../kernel/v1/errors.dart" as _lib_kernel_v1_errors;
 import "../../kernel/v1/record_id.dart" as _lib_kernel_v1_record_id;
 import "./member.dart" as _lib_organization_v1_member;

--- a/panel/lib/infrastructure/protocols/skir/skirout/organization/v1/member.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/organization/v1/member.dart
@@ -13,6 +13,7 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "../../kernel/v1/errors.dart" as _lib_kernel_v1_errors;
 import "../../kernel/v1/record_id.dart" as _lib_kernel_v1_record_id;
 import "./role.dart" as _lib_organization_v1_role;

--- a/panel/lib/infrastructure/protocols/skir/skirout/organization/v1/organization.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/organization/v1/organization.dart
@@ -13,6 +13,7 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "../../kernel/v1/errors.dart" as _lib_kernel_v1_errors;
 import "../../kernel/v1/record_id.dart" as _lib_kernel_v1_record_id;
 

--- a/panel/lib/infrastructure/protocols/skir/skirout/organization/v1/role.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/organization/v1/role.dart
@@ -13,6 +13,7 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "../../kernel/v1/color.dart" as _lib_kernel_v1_color;
 import "../../kernel/v1/errors.dart" as _lib_kernel_v1_errors;
 import "../../kernel/v1/record_id.dart" as _lib_kernel_v1_record_id;

--- a/panel/lib/infrastructure/protocols/skir/skirout/organization/v1/user.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/organization/v1/user.dart
@@ -13,6 +13,7 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "../../kernel/v1/errors.dart" as _lib_kernel_v1_errors;
 import "../../kernel/v1/record_id.dart" as _lib_kernel_v1_record_id;
 import "./join_request.dart" as _lib_organization_v1_join_request;

--- a/panel/lib/infrastructure/protocols/skir/skirout/service/v1/identity.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/service/v1/identity.dart
@@ -13,6 +13,7 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "../../kernel/v1/errors.dart" as _lib_kernel_v1_errors;
 import "./service.dart" as _lib_service_v1_service;
 

--- a/panel/lib/infrastructure/protocols/skir/skirout/service/v1/organization.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/service/v1/organization.dart
@@ -13,6 +13,7 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "../../kernel/v1/errors.dart" as _lib_kernel_v1_errors;
 import "../../kernel/v1/record_id.dart" as _lib_kernel_v1_record_id;
 import "./service.dart" as _lib_service_v1_service;

--- a/panel/lib/infrastructure/protocols/skir/skirout/service/v1/registration.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/service/v1/registration.dart
@@ -13,6 +13,7 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "../../kernel/v1/errors.dart" as _lib_kernel_v1_errors;
 import "./service.dart" as _lib_service_v1_service;
 

--- a/panel/lib/infrastructure/protocols/skir/skirout/service/v1/service.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/service/v1/service.dart
@@ -13,6 +13,7 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "../../kernel/v1/record_id.dart" as _lib_kernel_v1_record_id;
 
 // -----------------------------------------------------------------------------

--- a/panel/lib/infrastructure/protocols/skir/skirout/service/v1/status.dart
+++ b/panel/lib/infrastructure/protocols/skir/skirout/service/v1/status.dart
@@ -13,6 +13,7 @@
 
 import "dart:core" as _core;
 import "package:skir_client/skir_client.dart" as _skir;
+
 import "../../kernel/v1/errors.dart" as _lib_kernel_v1_errors;
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Upgrade Skir to 1.2.21
- Replace the pinned Git Dart generator with the published 1.0.9 package
- Regenerate Dart protocol imports with the updated generator

## Testing

Not run (not requested)