### PR TITLE
feat(engine): add debug command

### DIFF
--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/command/DebugCommand.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/command/DebugCommand.kt
@@ -11,23 +11,23 @@ import com.typewritermc.engine.paper.command.dsl.withPermission
 import com.typewritermc.engine.paper.plugin
 import com.typewritermc.engine.paper.ui.CommunicationHandler
 import com.typewritermc.engine.paper.ui.PanelHost
-import com.typewritermc.engine.paper.utils.sendMini
+import com.typewritermc.engine.paper.utils.sendMiniWithResolvers
 import com.typewritermc.engine.paper.utils.server
 import com.typewritermc.loader.ExtensionLoader
-import net.kyori.adventure.text.minimessage.MiniMessage
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
 import org.koin.java.KoinJavaComponent.get
 import java.lang.management.ManagementFactory
-
-private val miniMessage = MiniMessage.miniMessage()
 
 internal fun CommandTree.debugCommand() = literal("debug") {
     withPermission("typewriter.debug")
     executes {
-        sender.sendMini(createDebugMessage())
+        val message = createDebugMessage()
+        sender.sendMiniWithResolvers(message.text, *message.resolvers)
     }
 }
 
-private fun createDebugMessage(): String {
+private fun createDebugMessage(): DebugMessage {
     val runtime = Runtime.getRuntime()
     val extensionLoader = get<ExtensionLoader>(ExtensionLoader::class.java)
     val communicationHandler = get<CommunicationHandler>(CommunicationHandler::class.java)
@@ -37,14 +37,17 @@ private fun createDebugMessage(): String {
     val entries = Query.find<Entry>().count()
     val usedMemory = (runtime.totalMemory() - runtime.freeMemory()).toMebibytes()
     val maxMemory = runtime.maxMemory().toMebibytes()
+    val resolvers = mutableListOf<TagResolver>()
 
-    return buildString {
+    val text = buildString {
         append(createSection("Debug Information"))
-        append("<#5ba3d0>Version:</#5ba3d0> ${plugin.pluginMeta.version.escapeMiniMessageTags()}\n")
-        append(
-            "<#5ba3d0>Server:</#5ba3d0> ${server.name.escapeMiniMessageTags()} " +
-                    "(${server.minecraftVersion.escapeMiniMessageTags()})\n"
-        )
+        append("<#5ba3d0>Version:</#5ba3d0> ")
+        appendUnparsed(plugin.pluginMeta.version, resolvers)
+        append("\n<#5ba3d0>Server:</#5ba3d0> ")
+        appendUnparsed(server.name, resolvers)
+        append(" (")
+        appendUnparsed(server.minecraftVersion, resolvers)
+        append(")\n")
         append("<#5ba3d0>Uptime:</#5ba3d0> ${formatDuration(ManagementFactory.getRuntimeMXBean().uptime)}\n")
         append("<#5ba3d0>Memory:</#5ba3d0> $usedMemory / $maxMemory MiB\n")
         append("<#5ba3d0>Players:</#5ba3d0> ${server.onlinePlayers.size} / ${server.maxPlayers}\n")
@@ -59,17 +62,25 @@ private fun createDebugMessage(): String {
         }
 
         extensionLoader.loadedExtensions.sortedBy { it.info.name }.forEach {
-            append("  <#7ed957>✓</#7ed957> <white>${it.info.name.escapeMiniMessageTags()}Extension</white>")
-            append(" <gray>${it.info.version.escapeMiniMessageTags()}</gray>\n")
+            append("  <#7ed957>✓</#7ed957> <white>")
+            appendUnparsed("${it.info.name}Extension", resolvers)
+            append("</white> <gray>")
+            appendUnparsed(it.info.version, resolvers)
+            append("</gray>\n")
         }
         extensionLoader.failedExtensions.sortedBy { it.info?.name ?: it.jarName }.forEach {
             val name = it.info?.name?.let { name -> "${name}Extension" } ?: it.jarName
-            append("  <red>✕ ${name.escapeMiniMessageTags()}</red>")
-            append(" <#ff8888>(${it.reason.message.escapeMiniMessageTags()})</#ff8888>\n")
+            append("  <red>✕ ")
+            appendUnparsed(name, resolvers)
+            append("</red> <#ff8888>(")
+            appendUnparsed(it.reason.message, resolvers)
+            append(")</#ff8888>\n")
         }
 
         append(createFooter())
     }
+
+    return DebugMessage(text, resolvers.toTypedArray())
 }
 
 private fun startedState(started: Boolean): String =
@@ -95,4 +106,13 @@ internal fun formatDuration(milliseconds: Long): String {
 
 private fun Long.toMebibytes(): Long = this / (1024 * 1024)
 
-internal fun String.escapeMiniMessageTags(): String = miniMessage.escapeTags(this)
+private data class DebugMessage(
+    val text: String,
+    val resolvers: Array<TagResolver>,
+)
+
+internal fun StringBuilder.appendUnparsed(value: String, resolvers: MutableList<TagResolver>) {
+    val name = "debug_value_${resolvers.size}"
+    append("<$name>")
+    resolvers += Placeholder.unparsed(name, value)
+}

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/command/DebugCommand.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/command/DebugCommand.kt
@@ -14,8 +14,11 @@ import com.typewritermc.engine.paper.ui.PanelHost
 import com.typewritermc.engine.paper.utils.sendMini
 import com.typewritermc.engine.paper.utils.server
 import com.typewritermc.loader.ExtensionLoader
+import net.kyori.adventure.text.minimessage.MiniMessage
 import org.koin.java.KoinJavaComponent.get
 import java.lang.management.ManagementFactory
+
+private val miniMessage = MiniMessage.miniMessage()
 
 internal fun CommandTree.debugCommand() = literal("debug") {
     withPermission("typewriter.debug")
@@ -37,8 +40,11 @@ private fun createDebugMessage(): String {
 
     return buildString {
         append(createSection("Debug Information"))
-        append("<#5ba3d0>Version:</#5ba3d0> ${plugin.pluginMeta.version}\n")
-        append("<#5ba3d0>Server:</#5ba3d0> ${server.name} (${server.minecraftVersion})\n")
+        append("<#5ba3d0>Version:</#5ba3d0> ${plugin.pluginMeta.version.escapeMiniMessageTags()}\n")
+        append(
+            "<#5ba3d0>Server:</#5ba3d0> ${server.name.escapeMiniMessageTags()} " +
+                    "(${server.minecraftVersion.escapeMiniMessageTags()})\n"
+        )
         append("<#5ba3d0>Uptime:</#5ba3d0> ${formatDuration(ManagementFactory.getRuntimeMXBean().uptime)}\n")
         append("<#5ba3d0>Memory:</#5ba3d0> $usedMemory / $maxMemory MiB\n")
         append("<#5ba3d0>Players:</#5ba3d0> ${server.onlinePlayers.size} / ${server.maxPlayers}\n")
@@ -53,12 +59,13 @@ private fun createDebugMessage(): String {
         }
 
         extensionLoader.loadedExtensions.sortedBy { it.info.name }.forEach {
-            append("  <#7ed957>✓</#7ed957> <white>${it.info.name}Extension</white>")
-            append(" <gray>${it.info.version}</gray>\n")
+            append("  <#7ed957>✓</#7ed957> <white>${it.info.name.escapeMiniMessageTags()}Extension</white>")
+            append(" <gray>${it.info.version.escapeMiniMessageTags()}</gray>\n")
         }
         extensionLoader.failedExtensions.sortedBy { it.info?.name ?: it.jarName }.forEach {
             val name = it.info?.name?.let { name -> "${name}Extension" } ?: it.jarName
-            append("  <red>✕ $name</red> <#ff8888>(${it.reason.message})</#ff8888>\n")
+            append("  <red>✕ ${name.escapeMiniMessageTags()}</red>")
+            append(" <#ff8888>(${it.reason.message.escapeMiniMessageTags()})</#ff8888>\n")
         }
 
         append(createFooter())
@@ -87,3 +94,5 @@ internal fun formatDuration(milliseconds: Long): String {
 }
 
 private fun Long.toMebibytes(): Long = this / (1024 * 1024)
+
+internal fun String.escapeMiniMessageTags(): String = miniMessage.escapeTags(this)

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/command/DebugCommand.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/command/DebugCommand.kt
@@ -63,13 +63,13 @@ private fun createDebugMessage(): DebugMessage {
 
         extensionLoader.loadedExtensions.sortedBy { it.info.name }.forEach {
             append("  <#7ed957>✓</#7ed957> <white>")
-            appendUnparsed("${it.info.name}Extension", resolvers)
+            appendUnparsed("${it.info.name} Extension", resolvers)
             append("</white> <gray>")
             appendUnparsed(it.info.version, resolvers)
             append("</gray>\n")
         }
         extensionLoader.failedExtensions.sortedBy { it.info?.name ?: it.jarName }.forEach {
-            val name = it.info?.name?.let { name -> "${name}Extension" } ?: it.jarName
+            val name = it.info?.name?.let { name -> "$name Extension" } ?: it.jarName
             append("  <red>✕ ")
             appendUnparsed(name, resolvers)
             append("</red> <#ff8888>(")

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/command/DebugCommand.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/command/DebugCommand.kt
@@ -1,0 +1,89 @@
+@file:Suppress("UnstableApiUsage")
+
+package com.typewritermc.engine.paper.command
+
+import com.typewritermc.core.books.pages.PageType
+import com.typewritermc.core.entries.Entry
+import com.typewritermc.core.entries.Query
+import com.typewritermc.engine.paper.command.dsl.CommandTree
+import com.typewritermc.engine.paper.command.dsl.sender
+import com.typewritermc.engine.paper.command.dsl.withPermission
+import com.typewritermc.engine.paper.plugin
+import com.typewritermc.engine.paper.ui.CommunicationHandler
+import com.typewritermc.engine.paper.ui.PanelHost
+import com.typewritermc.engine.paper.utils.sendMini
+import com.typewritermc.engine.paper.utils.server
+import com.typewritermc.loader.ExtensionLoader
+import org.koin.java.KoinJavaComponent.get
+import java.lang.management.ManagementFactory
+
+internal fun CommandTree.debugCommand() = literal("debug") {
+    withPermission("typewriter.debug")
+    executes {
+        sender.sendMini(createDebugMessage())
+    }
+}
+
+private fun createDebugMessage(): String {
+    val runtime = Runtime.getRuntime()
+    val extensionLoader = get<ExtensionLoader>(ExtensionLoader::class.java)
+    val communicationHandler = get<CommunicationHandler>(CommunicationHandler::class.java)
+    val panelHost = get<PanelHost>(PanelHost::class.java)
+    val socketServer = communicationHandler.server
+    val pages = PageType.entries.sumOf { Query.findPagesOfType(it).count() }
+    val entries = Query.find<Entry>().count()
+    val usedMemory = (runtime.totalMemory() - runtime.freeMemory()).toMebibytes()
+    val maxMemory = runtime.maxMemory().toMebibytes()
+
+    return buildString {
+        append(createSection("Debug Information"))
+        append("<#5ba3d0>Version:</#5ba3d0> ${plugin.pluginMeta.version}\n")
+        append("<#5ba3d0>Server:</#5ba3d0> ${server.name} (${server.minecraftVersion})\n")
+        append("<#5ba3d0>Uptime:</#5ba3d0> ${formatDuration(ManagementFactory.getRuntimeMXBean().uptime)}\n")
+        append("<#5ba3d0>Memory:</#5ba3d0> $usedMemory / $maxMemory MiB\n")
+        append("<#5ba3d0>Players:</#5ba3d0> ${server.onlinePlayers.size} / ${server.maxPlayers}\n")
+        append("<#5ba3d0>Story content:</#5ba3d0> ${pages.withLabel("page")}, ${entries.withLabel("entry")}\n")
+        append("<#5ba3d0>Web panel:</#5ba3d0> ${startedState(panelHost.isStarted)}\n")
+        append("<#5ba3d0>Panel connection:</#5ba3d0> ${startedState(socketServer != null)}")
+        append(" <gray>·</gray> ${(socketServer?.allClients?.size ?: 0).withLabel("user")} connected\n")
+
+        append("\n<gradient:#ff69b4:#ff1493><bold>Extensions:</bold></gradient>\n")
+        if (extensionLoader.extensions.isEmpty()) {
+            append("  <gray>No extensions found.</gray>\n")
+        }
+
+        extensionLoader.loadedExtensions.sortedBy { it.info.name }.forEach {
+            append("  <#7ed957>✓</#7ed957> <white>${it.info.name}Extension</white>")
+            append(" <gray>${it.info.version}</gray>\n")
+        }
+        extensionLoader.failedExtensions.sortedBy { it.info?.name ?: it.jarName }.forEach {
+            val name = it.info?.name?.let { name -> "${name}Extension" } ?: it.jarName
+            append("  <red>✕ $name</red> <#ff8888>(${it.reason.message})</#ff8888>\n")
+        }
+
+        append(createFooter())
+    }
+}
+
+private fun startedState(started: Boolean): String =
+    if (started) "<green>Started</green>" else "<gray>Not started</gray>"
+
+private fun Int.withLabel(singular: String): String =
+    "$this ${if (this == 1) singular else "${singular}s"}"
+
+internal fun formatDuration(milliseconds: Long): String {
+    val totalSeconds = milliseconds.coerceAtLeast(0) / 1_000
+    val days = totalSeconds / 86_400
+    val hours = totalSeconds % 86_400 / 3_600
+    val minutes = totalSeconds % 3_600 / 60
+    val seconds = totalSeconds % 60
+
+    return buildList {
+        if (days > 0) add("${days}d")
+        if (hours > 0 || days > 0) add("${hours}h")
+        if (minutes > 0 || hours > 0 || days > 0) add("${minutes}m")
+        add("${seconds}s")
+    }.joinToString(" ")
+}
+
+private fun Long.toMebibytes(): Long = this / (1024 * 1024)

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/command/TypewriterCommand.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/command/TypewriterCommand.kt
@@ -38,6 +38,7 @@ import java.time.format.DateTimeFormatter
 
 fun typewriterCommand() = command("typewriter", "tw") {
     versionCommand()
+    debugCommand()
     reloadCommand()
     extensionsCommand()
     factsCommand()
@@ -232,12 +233,12 @@ private fun CommandSender.displayFailedExtension(failure: Extension.FailedExtens
     sendMini(message)
 }
 
-private fun createSection(title: String): String {
+internal fun createSection(title: String): String {
     val (leftPadding, rightPadding) = calculatePadding(title)
     return "\n<gradient:#00d4ff:#0099ff><b><st>$leftPadding</st> $title <st>$rightPadding</st></b></gradient>\n\n"
 }
 
-private fun createFooter(): String =
+internal fun createFooter(): String =
     "\n<gradient:#00d4ff:#0099ff><b><st>${" ".repeat(53)}</st></b></gradient>\n"
 
 private fun calculatePadding(title: String): Pair<String, String> {

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/ui/PanelHost.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/ui/PanelHost.kt
@@ -15,6 +15,10 @@ class PanelHost : KoinComponent {
     private val port: Int by config("panel.port", 8080)
 
     private var server: ApplicationEngine? = null
+
+    internal val isStarted: Boolean
+        get() = server != null
+
     fun initialize() {
         if (!enabled) {
             // If we are developing the ui we don't want to start the server
@@ -46,5 +50,6 @@ class PanelHost : KoinComponent {
 
     fun dispose() {
         server?.stop()
+        server = null
     }
 }

--- a/engine/engine-paper/src/test/kotlin/com/typewritermc/utils/DebugCommandTest.kt
+++ b/engine/engine-paper/src/test/kotlin/com/typewritermc/utils/DebugCommandTest.kt
@@ -1,13 +1,23 @@
 package com.typewritermc.utils
 
+import com.typewritermc.engine.paper.command.escapeMiniMessageTags
 import com.typewritermc.engine.paper.command.formatDuration
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import net.kyori.adventure.text.minimessage.MiniMessage
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
 
 class DebugCommandTest : FunSpec({
     test("uptime omits unused leading units") {
         formatDuration(42_000) shouldBe "42s"
         formatDuration(3_661_000) shouldBe "1h 1m 1s"
         formatDuration(90_061_000) shouldBe "1d 1h 1m 1s"
+    }
+
+    test("debug values cannot inject MiniMessage formatting") {
+        val value = "<red>BrokenExtension</red>"
+        val component = MiniMessage.miniMessage().deserialize(value.escapeMiniMessageTags())
+
+        PlainTextComponentSerializer.plainText().serialize(component) shouldBe value
     }
 })

--- a/engine/engine-paper/src/test/kotlin/com/typewritermc/utils/DebugCommandTest.kt
+++ b/engine/engine-paper/src/test/kotlin/com/typewritermc/utils/DebugCommandTest.kt
@@ -1,0 +1,13 @@
+package com.typewritermc.utils
+
+import com.typewritermc.engine.paper.command.formatDuration
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class DebugCommandTest : FunSpec({
+    test("uptime omits unused leading units") {
+        formatDuration(42_000) shouldBe "42s"
+        formatDuration(3_661_000) shouldBe "1h 1m 1s"
+        formatDuration(90_061_000) shouldBe "1d 1h 1m 1s"
+    }
+})

--- a/engine/engine-paper/src/test/kotlin/com/typewritermc/utils/DebugCommandTest.kt
+++ b/engine/engine-paper/src/test/kotlin/com/typewritermc/utils/DebugCommandTest.kt
@@ -1,10 +1,12 @@
 package com.typewritermc.utils
 
-import com.typewritermc.engine.paper.command.escapeMiniMessageTags
+import com.typewritermc.engine.paper.command.appendUnparsed
 import com.typewritermc.engine.paper.command.formatDuration
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import net.kyori.adventure.text.minimessage.MiniMessage
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
 
 class DebugCommandTest : FunSpec({
@@ -14,9 +16,16 @@ class DebugCommandTest : FunSpec({
         formatDuration(90_061_000) shouldBe "1d 1h 1m 1s"
     }
 
-    test("debug values cannot inject MiniMessage formatting") {
-        val value = "<red>BrokenExtension</red>"
-        val component = MiniMessage.miniMessage().deserialize(value.escapeMiniMessageTags())
+    test("debug values cannot inject custom MiniMessage tags") {
+        val value = "<line><confirmation_key>"
+        val resolvers = mutableListOf<TagResolver>()
+        val message = buildString { appendUnparsed(value, resolvers) }
+        val customTags = TagResolver.builder()
+            .resolver(Placeholder.parsed("line", "changed"))
+            .resolver(Placeholder.parsed("confirmation_key", "changed"))
+            .build()
+        val miniMessage = MiniMessage.builder().tags(customTags).build()
+        val component = miniMessage.deserialize(message, *resolvers.toTypedArray())
 
         PlainTextComponentSerializer.plainText().serialize(component) shouldBe value
     }


### PR DESCRIPTION
- Added '/tw debug'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an authorized `/typewriter debug` command.
  - Displays plugin, server, uptime, memory, player, story content, web panel, connection, and extension status.
  - Reports loaded and failed extensions with clearer formatting.

- **Bug Fixes**
  - Prevented diagnostic information from interpreting embedded formatting tags.
  - Improved panel lifecycle tracking so its running state is accurately cleared after shutdown.

- **Tests**
  - Added coverage confirming diagnostic values remain safely formatted as plain text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->