### PR TITLE
Add criteria to custom commands

### DIFF
--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/TypewriterPaperPlugin.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/TypewriterPaperPlugin.kt
@@ -145,6 +145,7 @@ class TypewriterPaperPlugin : KotlinPlugin(), KoinComponent {
         get<FactDatabase>().initialize()
         get<AssetManager>().initialize()
         get<PlayerSessionManager>().initialize()
+        get<TypewriterCommandManager>().initialize()
         get<ChatHistoryHandler>().initialize()
         get<ActionBarBlockerHandler>().initialize()
         get<PacketInterceptor>().initialize()

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/command/TypewriterCommandManager.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/command/TypewriterCommandManager.kt
@@ -4,23 +4,45 @@ import com.mojang.brigadier.CommandDispatcher
 import com.mojang.brigadier.builder.LiteralArgumentBuilder
 import com.mojang.brigadier.tree.CommandNode
 import com.mojang.brigadier.tree.LiteralCommandNode
+import com.typewritermc.core.entries.Ref
 import com.typewritermc.core.entries.Query
+import com.typewritermc.core.utils.launch
 import com.typewritermc.engine.paper.command.dsl.DslCommand
+import com.typewritermc.engine.paper.entry.matches
 import com.typewritermc.engine.paper.entry.entries.CustomCommandEntry
+import com.typewritermc.engine.paper.entry.entries.ReadableFactEntry
+import com.typewritermc.engine.paper.facts.FactListenerSubscription
+import com.typewritermc.engine.paper.facts.listenForFacts
 import com.typewritermc.engine.paper.plugin
+import com.typewritermc.engine.paper.utils.Sync
 import com.typewritermc.engine.paper.utils.server
 import io.papermc.paper.command.brigadier.CommandSourceStack
+import kotlinx.coroutines.Dispatchers
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerJoinEvent
+import org.bukkit.event.player.PlayerQuitEvent
 import java.lang.invoke.MethodHandles
 import java.lang.invoke.MethodType
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 
 
 @Suppress("UnstableApiUsage")
-class TypewriterCommandManager {
+class TypewriterCommandManager : Listener {
     private var dispatcher: CommandDispatcher<CommandSourceStack>? = null
     private var commandsLabels = emptyList<String>()
+    private var criteriaFacts = emptyList<Ref<ReadableFactEntry>>()
+    private val criteriaSubscriptions = ConcurrentHashMap<UUID, FactListenerSubscription>()
 
     val labels: List<String>
         get() = commandsLabels
+
+    fun initialize() {
+        plugin.server.pluginManager.registerEvents(this, plugin)
+    }
 
     fun registerDispatcher(dispatcher: CommandDispatcher<CommandSourceStack>) {
         this.dispatcher = dispatcher
@@ -32,16 +54,26 @@ class TypewriterCommandManager {
             throw IllegalStateException("TypewriterCommandManager has not been initialized with a dispatcher")
         }
 
+        val customCommands = Query.find<CustomCommandEntry>().toList()
+        criteriaFacts = customCommands.flatMap { entry -> entry.criteria.map { it.fact } }.distinct()
+
         val commands = listOf(
             typewriterCommand(),
-        ) + Query.find<CustomCommandEntry>().map { it.command() }
+        )
 
         commandsLabels = commands.flatMap {
             dispatcher.register(it, plugin.name.lowercase())
+        } + customCommands.flatMap { entry ->
+            dispatcher.register(entry.command(), plugin.name.lowercase()) { source ->
+                val player = (source.executor as? Player) ?: (source.sender as? Player)
+                entry.criteria.isEmpty() || (player != null && entry.criteria.matches(player))
+            }
         }
 
-        server.onlinePlayers.forEach {
-            it.updateCommands()
+        resetCriteriaSubscriptions()
+        server.onlinePlayers.forEach { player ->
+            player.watchCommandCriteria()
+            player.updateCommands()
         }
     }
 
@@ -55,6 +87,36 @@ class TypewriterCommandManager {
         commandsLabels.forEach {
             dispatcher.unregister(it)
         }
+
+        criteriaFacts = emptyList()
+        resetCriteriaSubscriptions()
+    }
+
+    private fun Player.watchCommandCriteria() {
+        if (criteriaFacts.isEmpty()) return
+
+        criteriaSubscriptions[uniqueId] = listenForFacts(criteriaFacts) {
+            Dispatchers.Sync.launch {
+                player.updateCommands()
+            }
+        }
+    }
+
+    private fun resetCriteriaSubscriptions() {
+        criteriaSubscriptions.forEach { (playerId, subscription) ->
+            server.getPlayer(playerId)?.let(subscription::cancel)
+        }
+        criteriaSubscriptions.clear()
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    private fun onPlayerJoin(event: PlayerJoinEvent) {
+        event.player.watchCommandCriteria()
+    }
+
+    @EventHandler
+    private fun onPlayerQuit(event: PlayerQuitEvent) {
+        criteriaSubscriptions.remove(event.player.uniqueId)?.cancel(event.player)
     }
 }
 
@@ -75,10 +137,18 @@ fun <S> CommandDispatcher<S>.unregister(literal: String) {
 }
 
 fun <S> CommandDispatcher<S>.register(command: DslCommand<S>, identifier: String): List<String> {
+    return register(command, identifier) { true }
+}
+
+fun <S> CommandDispatcher<S>.register(
+    command: DslCommand<S>,
+    identifier: String,
+    additionalRequirement: (S) -> Boolean,
+): List<String> {
     val commandsLabels = mutableListOf<String>()
     val sourceCommand = LiteralArgumentBuilder.literal<S>("$identifier:${command.literal}")
         .executes(command.node.command)
-        .requires(command.node.requirement)
+        .requires { source -> command.node.requirement.test(source) && additionalRequirement(source) }
         .build()
         .apply {
             command.node.children.forEach(this::addChild)

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/command/TypewriterCommandManager.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/command/TypewriterCommandManager.kt
@@ -40,6 +40,7 @@ class TypewriterCommandManager : Listener {
     val labels: List<String>
         get() = commandsLabels
 
+    /** Call once during plugin startup, after player sessions initialize and before custom commands register. */
     fun initialize() {
         plugin.server.pluginManager.registerEvents(this, plugin)
     }

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/entries/EventEntry.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/entries/EventEntry.kt
@@ -7,6 +7,7 @@ import com.typewritermc.core.extension.annotations.Help
 import com.typewritermc.core.extension.annotations.Tags
 import com.typewritermc.core.interaction.InteractionContext
 import com.typewritermc.engine.paper.command.dsl.DslCommand
+import com.typewritermc.engine.paper.entry.Criteria
 import com.typewritermc.engine.paper.entry.TriggerEntry
 import com.typewritermc.engine.paper.entry.TriggerableEntry
 import com.typewritermc.engine.paper.entry.matches
@@ -38,6 +39,10 @@ fun List<CancelableEventEntry>.shouldCancel(
 
 
 interface CustomCommandEntry : Entry {
+    @Help("The criteria that must be met for this command to be available")
+    val criteria: List<Criteria>
+        get() = emptyList()
+
     @Suppress("UnstableApiUsage")
     fun command(): DslCommand<CommandSourceStack>
 }

--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/entries/EventEntry.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/entries/EventEntry.kt
@@ -39,6 +39,7 @@ fun List<CancelableEventEntry>.shouldCancel(
 
 
 interface CustomCommandEntry : Entry {
+    /** Use these criteria to limit command discovery and execution to matching players. */
     @Help("The criteria that must be met for this command to be available")
     val criteria: List<Criteria>
         get() = emptyList()

--- a/engine/engine-paper/src/test/kotlin/com/typewritermc/utils/CommandTest.kt
+++ b/engine/engine-paper/src/test/kotlin/com/typewritermc/utils/CommandTest.kt
@@ -5,6 +5,8 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException
 import com.typewritermc.engine.paper.command.dsl.*
 import com.typewritermc.engine.paper.command.register
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.property.Arb
@@ -43,6 +45,31 @@ class CommandTest : FunSpec({
             dispatcher.execute("test:test2", sender)
 
             verify(exactly = 4) { sender.run() }
+        }
+
+        test("Additional requirements apply to commands and aliases") {
+            val allowed = mockk<Sender>()
+            val commandDenied = mockk<Sender>()
+            val additionalDenied = mockk<Sender>()
+            every { allowed.run(*anyVararg()) } just Runs
+
+            dispatcher.register(command("test", "alias") {
+                requires { it !== commandDenied }
+                testExecutes()
+            }, "namespace") { it !== additionalDenied }
+
+            listOf("test", "alias", "namespace:test", "namespace:alias").forEach { label ->
+                dispatcher.root.getChild(label).canUse(allowed).shouldBeTrue()
+                listOf(commandDenied, additionalDenied).forEach { denied ->
+                    dispatcher.root.getChild(label).canUse(denied).shouldBeFalse()
+                    shouldThrow<CommandSyntaxException> {
+                        dispatcher.execute(label, denied)
+                    }
+                }
+            }
+
+            dispatcher.execute("test", allowed)
+            verify(exactly = 1) { allowed.run() }
         }
     }
 

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/command/CustomCommandEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/command/CustomCommandEntry.kt
@@ -8,6 +8,7 @@ import com.typewritermc.core.extension.annotations.Help
 import com.typewritermc.core.extension.annotations.Tags
 import com.typewritermc.core.interaction.InteractionContextBuilder
 import com.typewritermc.engine.paper.command.dsl.*
+import com.typewritermc.engine.paper.entry.Criteria
 import com.typewritermc.engine.paper.entry.ManifestEntry
 import com.typewritermc.engine.paper.entry.TriggerableEntry
 import com.typewritermc.engine.paper.entry.entries.CustomCommandEntry
@@ -34,6 +35,7 @@ import kotlin.reflect.KClass
 class CustomCommandEntry(
     override val id: String = "",
     override val name: String = "",
+    override val criteria: List<Criteria> = emptyList(),
     @Help("The command to register. Do not include the leading slash.")
     val command: String = "",
     val aliases: List<String> = emptyList(),

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/event/RunCommandEventEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/event/RunCommandEventEntry.kt
@@ -8,6 +8,7 @@ import com.typewritermc.core.interaction.context
 import com.typewritermc.engine.paper.command.dsl.playersResolver
 import com.typewritermc.engine.paper.command.dsl.sender
 import com.typewritermc.engine.paper.command.dsl.withPermission
+import com.typewritermc.engine.paper.entry.Criteria
 import com.typewritermc.engine.paper.entry.TriggerableEntry
 import com.typewritermc.engine.paper.entry.entries.CustomCommandEntry
 import com.typewritermc.engine.paper.entry.entries.EventEntry
@@ -30,6 +31,7 @@ import org.bukkit.entity.Player
 class RunCommandEventEntry(
     override val id: String = "",
     override val name: String = "",
+    override val criteria: List<Criteria> = emptyList(),
     override val triggers: List<Ref<TriggerableEntry>> = emptyList(),
     @Help("The command to register. Do not include the leading slash.")
     val command: String = "",
@@ -60,4 +62,3 @@ class RunCommandEventEntry(
         }
     }
 }
-


### PR DESCRIPTION
- Custom Command Criteria

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom commands can now be restricted using configurable availability criteria.
  * Command access updates automatically when players join, leave, or when criteria change.
  * Command requirements apply consistently to names, aliases, and namespaced aliases.
  * Event-triggered command execution supports configurable criteria.

* **Bug Fixes**
  * Improved command registration and authorization consistency for permitted and restricted senders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->