### PR TITLE
Fix documentation typos

### DIFF
--- a/documentation/AGENTS.md
+++ b/documentation/AGENTS.md
@@ -40,7 +40,7 @@ and use the `<CodeSnippet tag="some_tag" json={require('../snippets.json')} />`
 component to embed them. This applies to every code snippet, especially pages
 under `develop`.
 
-Never write directly to the `snippets.json` file. It will be automcatically generated during the build.
+Never write directly to the `snippets.json` file. It will be automatically generated during the build.
 
 ## Common Components
 

--- a/documentation/docs/develop/02-extensions/04-entries/cinematic/index.mdx
+++ b/documentation/docs/develop/02-extensions/04-entries/cinematic/index.mdx
@@ -2,13 +2,13 @@ import CodeSnippet from "@site/src/components/CodeSnippet";
 
 # CinematicEntry
 
-The `CinematicEntry` does not have any decentends, but is very customizable. When a entry is needed in a cinematic page, it needs to inherit this.
+The `CinematicEntry` does not have any descendants, but is very customizable. When an entry is needed in a cinematic page, it needs to inherit this.
 
-`CinematicEntry` works by having at least 1 list of `Segment`'s. Segments are the parts of the cinematic and may have sub-properties defined. A segment needs to have at least a `startFrame` and `endFrame` which are the integers of the frames.
+`CinematicEntry` works by having at least 1 list of `Segment`s. Segments are the parts of the cinematic and may have sub-properties defined. A segment needs to have at least a `startFrame` and `endFrame` which are the integers of the frames.
 
-Frames are the ticks in a second. So there are 20 frames in a second. A cinematic takes as long as the latest `endFrame` of a segment from all it's entries.
+Frames are the ticks in a second. So there are 20 frames in a second. A cinematic takes as long as the latest `endFrame` of a segment from all its entries.
 
-Segments are defined in the entry using the `@Segments` annotation. And it needs to be a list of `Segment`'s.
+Segments are defined in the entry using the `@Segments` annotation. And it needs to be a list of `Segment`s.
 
 
 :::info
@@ -19,7 +19,7 @@ Though this is supported in the plugin, it is not yet implemented in the cinemat
 If you need this, reach out to me on [Discord](https://discord.gg/HtbKyuDDBw).
 :::
 
-As entries are not allowed to have any state, we create a `CinematicAction` everytime a entry is used in a cinematic for a player.
+As entries are not allowed to have any state, we create a `CinematicAction` every time an entry is used in a cinematic for a player.
 
 ## Usage
 <CodeSnippet tag="cinematic_entry" json={require("../../../snippets.json")} />
@@ -43,12 +43,12 @@ There are a few different lifecycle methods that can be used.
 - `teardown()` is called when the cinematic is finished. This is the place to remove any entities, etc.
 - `canFinish(frame: Int)` the only method that needs to be implemented. It is used by the `CinematicSequence` to determine if the cinematic is finished.
 
-If you need all the customization, you can can implement the `CinematicAction` directly:
+If you need all the customization, you can implement the `CinematicAction` directly:
 
 <CodeSnippet tag="cinematic_action" json={require("../../../snippets.json")} />
 
 ### SimpleCinematicAction
-Sometimes you don't need all the customization and flexiblity. If you only care about 1 segment track, and only need to do something when a segment starts or ends, you can use the `SimpleCinematicAction`.
+Sometimes you don't need all the customization and flexibility. If you only care about 1 segment track, and only need to do something when a segment starts or ends, you can use the `SimpleCinematicAction`.
 
 <CodeSnippet tag="cinematic_simple_action" json={require("../../../snippets.json")} />
 
@@ -58,7 +58,7 @@ One important detail is that the `tick` methods are not necessarily called in or
 It is important that the tick method should show the state of the action at the given frame.
 
 One place where this is definitely the case is when the player is viewing the cinematic in content mode.
-As the player is able to scroll through the cinematic, it might be the case that multiple frames are skipped, or rewinded.
+As the player is able to scroll through the cinematic, it might be the case that multiple frames are skipped or rewound.
 
 ## Simulation & Recording
 

--- a/documentation/docs/develop/02-extensions/04-entries/cinematic/index.mdx
+++ b/documentation/docs/develop/02-extensions/04-entries/cinematic/index.mdx
@@ -2,11 +2,15 @@ import CodeSnippet from "@site/src/components/CodeSnippet";
 
 # CinematicEntry
 
-The `CinematicEntry` does not have any descendants, but is very customizable. When an entry is needed in a cinematic page, it needs to inherit this.
+The `CinematicEntry` does not have any descendants, but is very customizable. When an entry is needed in a
+cinematic page, it needs to inherit this.
 
-`CinematicEntry` works by having at least 1 list of `Segment`s. Segments are the parts of the cinematic and may have sub-properties defined. A segment needs to have at least a `startFrame` and `endFrame` which are the integers of the frames.
+`CinematicEntry` works by having at least 1 list of `Segment`s. Segments are the parts of the cinematic and may
+have sub-properties defined. A segment needs to have at least a `startFrame` and `endFrame` which are the integers
+of the frames.
 
-Frames are the ticks in a second. So there are 20 frames in a second. A cinematic takes as long as the latest `endFrame` of a segment from all its entries.
+Frames are the ticks in a second. So there are 20 frames in a second. A cinematic takes as long as the latest
+`endFrame` of a segment from all its entries.
 
 Segments are defined in the entry using the `@Segments` annotation. And it needs to be a list of `Segment`s.
 
@@ -19,7 +23,8 @@ Though this is supported in the plugin, it is not yet implemented in the cinemat
 If you need this, reach out to me on [Discord](https://discord.gg/HtbKyuDDBw).
 :::
 
-As entries are not allowed to have any state, we create a `CinematicAction` every time an entry is used in a cinematic for a player.
+As entries are not allowed to have any state, we create a `CinematicAction` every time an entry is used in a
+cinematic for a player.
 
 ## Usage
 <CodeSnippet tag="cinematic_entry" json={require("../../../snippets.json")} />
@@ -48,7 +53,8 @@ If you need all the customization, you can implement the `CinematicAction` direc
 <CodeSnippet tag="cinematic_action" json={require("../../../snippets.json")} />
 
 ### SimpleCinematicAction
-Sometimes you don't need all the customization and flexibility. If you only care about 1 segment track, and only need to do something when a segment starts or ends, you can use the `SimpleCinematicAction`.
+Sometimes you don't need all the customization and flexibility. If you only care about 1 segment track, and only
+need to do something when a segment starts or ends, you can use the `SimpleCinematicAction`.
 
 <CodeSnippet tag="cinematic_simple_action" json={require("../../../snippets.json")} />
 

--- a/documentation/docs/develop/02-extensions/04-entries/index.mdx
+++ b/documentation/docs/develop/02-extensions/04-entries/index.mdx
@@ -7,7 +7,7 @@ There are four base interfaces that all entries extend one of. These are:
 1. **StaticEntry**: Represents static pages. These are used for content that does not change dynamically or trigger any actions. Examples include static text or images.
 2. **TriggerEntry**: Designed for entries that initiate other actions or events. These entries can trigger one or more additional entries, making them crucial for interactive sequences.
 3. **CinematicEntry**: Used for cinematic experiences. These entries are ideal for creating immersive story-driven sequences that engage players in a more visually dynamic way.
-4. **ManifestEntry**: Used for creating manifest pages, which are used to display statful content to the player.
+4. **ManifestEntry**: Used for creating manifest pages, which are used to display stateful content to the player.
 
 
 ### 1. StaticEntry
@@ -46,7 +46,7 @@ The following are the sub-types of `AudienceEntry`:
     - **LinesEntry**: Displays lines of text in things like sidebars or tablist.
 
 A whole nother category of `ManifestEntry` is meant for **Entities**.
-This has it's seperate page in the documentation.
+This has its separate page in the documentation.
 
 
 ## Implementation and Usage
@@ -57,7 +57,7 @@ For instance, a TriggerableEntry can be used to set up a quest that only activat
 Similarly, an ActionEntry can be used to create dynamic effects that change based on player actions, and a CinematicEntry can be used to create a visually dynamic story sequence.
 
 
-### Defining a Entry
+### Defining an Entry
 Typewriter takes care of the heavy lifting when it comes to creating and using entries.
 Developers only need to define the entry's class and its fields (and sometimes additional methods). 
 The rest is handled by Typewriter. 
@@ -77,7 +77,7 @@ The `@Entry` annotation is used to define the entry's type, name, and other prop
 To find out specific requirements for each entry type, check the documentation for the entry's interface.
 
 :::caution
-Enties are not allowed to have any state. This means that there can't be any fields that are not final.
+Entries are not allowed to have any state. This means that there can't be any fields that are not final.
 If you need to have state, use a `AudienceEntry`.
 :::
 

--- a/documentation/docs/develop/02-extensions/04-entries/trigger/action.mdx
+++ b/documentation/docs/develop/02-extensions/04-entries/trigger/action.mdx
@@ -2,7 +2,7 @@ import CodeSnippet from "@site/src/components/CodeSnippet";
 
 # ActionEntry
 
-The `ActionEntry` defines an action to take. When it is triggered, it will run it's `execute` method.
+The `ActionEntry` defines an action to take. When it is triggered, it will run its `execute` method.
 After which it will trigger all the next entries in the chain.
 
 :::danger[Immutable Entry]

--- a/documentation/docs/develop/02-extensions/04-entries/trigger/dialogue.mdx
+++ b/documentation/docs/develop/02-extensions/04-entries/trigger/dialogue.mdx
@@ -2,7 +2,7 @@ import CodeSnippet from "@site/src/components/CodeSnippet";
 
 # DialogueEntry
 
-The `DialogueEntry` is used to define a type of dialogue. When a `DialogueEntry` is triggered it's associated `DialogueMessenger` will be used to display the dialogue to the player.
+The `DialogueEntry` is used to define a type of dialogue. When a `DialogueEntry` is triggered, its associated `DialogueMessenger` will be used to display the dialogue to the player.
 Multiple `DialogueMessenger`'s can be associated with a single `DialogueEntry` and the `DialogueMessenger` that is used is determined by the `DialogueMessenger`'s `MessengerFilter`.
 
 :::info

--- a/documentation/docs/develop/02-extensions/04-entries/trigger/dialogue.mdx
+++ b/documentation/docs/develop/02-extensions/04-entries/trigger/dialogue.mdx
@@ -2,7 +2,8 @@ import CodeSnippet from "@site/src/components/CodeSnippet";
 
 # DialogueEntry
 
-The `DialogueEntry` is used to define a type of dialogue. When a `DialogueEntry` is triggered, its associated `DialogueMessenger` will be used to display the dialogue to the player.
+The `DialogueEntry` is used to define a type of dialogue. When a `DialogueEntry` is triggered, its associated
+`DialogueMessenger` will be used to display the dialogue to the player.
 Multiple `DialogueMessenger`'s can be associated with a single `DialogueEntry` and the `DialogueMessenger` that is used is determined by the `DialogueMessenger`'s `MessengerFilter`.
 
 :::info

--- a/documentation/docs/develop/02-extensions/05-interactions/bound.mdx
+++ b/documentation/docs/develop/02-extensions/05-interactions/bound.mdx
@@ -19,7 +19,7 @@ The bound itself doesn't determine the state - it only responds to the current s
 
 ## Implementation
 
-Here's how to create a interaction bound:
+Here's how to create an interaction bound:
 
 <CodeSnippet tag="interaction_bound" json={require("../../snippets.json")} />
 

--- a/documentation/docs/develop/02-extensions/06-querying.mdx
+++ b/documentation/docs/develop/02-extensions/06-querying.mdx
@@ -2,7 +2,7 @@ import CodeSnippet from "@site/src/components/CodeSnippet";
 
 # Query Entries
 
-Sometimes you need to find an entry by any of it's fields or by type. This can be done with the `Query` class.
+Sometimes you need to find an entry by any of its fields or by type. This can be done with the `Query` class.
 
 If you need to find all entries of a specific type:
 <CodeSnippet tag="query_multiple" json={require("../snippets.json")} />
@@ -11,7 +11,7 @@ Sometimes you need it by a specific filter:
 <CodeSnippet tag="query_multiple_with_filter" json={require("../snippets.json")} />
 
 
-Sometimes you need to find an entry by it's id:
+Sometimes you need to find an entry by its ID:
 <CodeSnippet tag="query_by_id" json={require("../snippets.json")} />
 
 Other times you need to find entries by their page:

--- a/documentation/docs/develop/02-extensions/09-api-changes/0.8.mdx
+++ b/documentation/docs/develop/02-extensions/09-api-changes/0.8.mdx
@@ -12,7 +12,7 @@ Make sure to read these changes before updating your extension.
 
 ## `build.gradle.kts` Changes
 
-Now the engine version is not specified in a seperate `engine` block, but in the `extension` block.
+Now the engine version is not specified in a separate `engine` block, but in the `extension` block.
 
 <Tabs>
     <TabItem value="release" label="Release" default>

--- a/documentation/docs/docs/03-creating-stories/01-interactions/01-options.mdx
+++ b/documentation/docs/docs/03-creating-stories/01-interactions/01-options.mdx
@@ -23,7 +23,7 @@ To create an option, follow these steps:
 
 <EntrySearch entryName='option' />
 
-## Configuring a Option
+## Configuring an Option
 
 Let's configure the option by doing the following steps:
 

--- a/documentation/docs/docs/03-creating-stories/02-cinematics/05-world-specific.mdx
+++ b/documentation/docs/docs/03-creating-stories/02-cinematics/05-world-specific.mdx
@@ -1,5 +1,5 @@
 ---
-dificulty: Normal
+difficulty: Normal
 ---
 
 import Player from "@site/src/components/Player";

--- a/documentation/docs/docs/03-creating-stories/05-questing/04-expanded/02-kill-zombie-objective.mdx
+++ b/documentation/docs/docs/03-creating-stories/05-questing/04-expanded/02-kill-zombie-objective.mdx
@@ -191,7 +191,7 @@ Now we need to increase the fact when the player kills a zombie. To do this we n
 
 <EntrySearch entryName="on_player_kill_entity" />
 
-Inside the entry enable the Enity Type and set the Entity Type to `Zombie`.
+Inside the entry, enable the Entity Type and set the Entity Type to `Zombie`.
 
 ### Increasing the fact
 Now we need to increase the fact when the player kills a zombie. To do this right click on the `On Player Kill Entity` and select `Link with ...` select the `Triggers | 1` and search for `Add Simple Action`.

--- a/documentation/docs/docs/03-creating-stories/07-advanced-interactions/01-interaction-context.mdx
+++ b/documentation/docs/docs/03-creating-stories/07-advanced-interactions/01-interaction-context.mdx
@@ -15,7 +15,7 @@ For this tutorial we recommend reading the [Interactions](./index.mdx) guide as 
 In this tutorial, you will learn about interaction contexts and how to use them. We will create an interaction where the player needs to specify the amount of flowers given.
 
 ## What is an interaction context?
-Interaction contexts is a powerfull concept that allow you to pass variables to subsequent entries in a sequence. This means you can capture user input, store it, and use it later to drive dynamic interactions\
+Interaction context is a powerful concept that allows you to pass variables to subsequent entries in a sequence. This means you can capture user input, store it, and use it later to drive dynamic interactions\
 whether it's using the input in future steps or triggering actions (like spawning effects on a clicked block). This flexibility makes your stories more adaptive and engaging.
 
 :::tip[Multiple Types]
@@ -39,7 +39,7 @@ Now we need to create an event that gets triggered when the player specifies the
 
 <EntrySearch entryName="give_item" />
 :::warning[Give Item Entry]
-If you don't how the Give Item Entry works than you should first read [Giving Items](../01-interactions/02-items.mdx)
+If you don't know how the Give Item Entry works, then you should first read [Giving Items](../01-interactions/02-items.mdx)
 :::
 
 ## Configuring the give flowers
@@ -52,7 +52,7 @@ Now inside the Give Item Entry at the item field create an extra component and s
 
 <EntrySearch entryName="interaction_context_variable" />
 
-When you have done that you can than select the `Integer Input Dialogue` entry at the entry field.
+When you have done that, you can then select the `Integer Input Dialogue` entry in the entry field.
 #### Video Tutorial
 <Player url={require("../../assets/interactions/configure-spoken-interaction-context.webm").default}/>
 

--- a/documentation/docs/docs/03-creating-stories/07-advanced-interactions/01-interaction-context.mdx
+++ b/documentation/docs/docs/03-creating-stories/07-advanced-interactions/01-interaction-context.mdx
@@ -15,7 +15,8 @@ For this tutorial we recommend reading the [Interactions](./index.mdx) guide as 
 In this tutorial, you will learn about interaction contexts and how to use them. We will create an interaction where the player needs to specify the amount of flowers given.
 
 ## What is an interaction context?
-Interaction context is a powerful concept that allows you to pass variables to subsequent entries in a sequence. This means you can capture user input, store it, and use it later to drive dynamic interactions\
+Interaction context is a powerful concept that allows you to pass variables to subsequent entries in a sequence.
+This means you can capture user input, store it, and use it later to drive dynamic interactions\
 whether it's using the input in future steps or triggering actions (like spawning effects on a clicked block). This flexibility makes your stories more adaptive and engaging.
 
 :::tip[Multiple Types]
@@ -39,7 +40,8 @@ Now we need to create an event that gets triggered when the player specifies the
 
 <EntrySearch entryName="give_item" />
 :::warning[Give Item Entry]
-If you don't know how the Give Item Entry works, then you should first read [Giving Items](../01-interactions/02-items.mdx)
+If you don't know how the Give Item Entry works, then you should first read
+[Giving Items](../01-interactions/02-items.mdx)
 :::
 
 ## Configuring the give flowers

--- a/documentation/docs/docs/03-creating-stories/07-advanced-interactions/02-custom-commands.mdx
+++ b/documentation/docs/docs/03-creating-stories/07-advanced-interactions/02-custom-commands.mdx
@@ -15,7 +15,9 @@ This guide assumes that you have already installed the [Basic Extension](../../0
 :::
 
 :::warning[Custom Commands]
-This guide shows you how to create a custom command with arguments. If you don't need arguments, you can use the [RunCommandEvent](../../../adapters/BasicAdapter/entries/event/on_run_command.mdx) to create a command without arguments.
+This guide shows you how to create a custom command with arguments. If you don't need arguments, you can use the
+[RunCommandEvent](../../../adapters/BasicAdapter/entries/event/on_run_command.mdx) to create a command without
+arguments.
 :::
 
 In this tutorial, you will learn about custom commands and how to create one. We will create a command where you can define a pseudo and an age to display a message to the player.

--- a/documentation/docs/docs/03-creating-stories/07-advanced-interactions/02-custom-commands.mdx
+++ b/documentation/docs/docs/03-creating-stories/07-advanced-interactions/02-custom-commands.mdx
@@ -15,7 +15,7 @@ This guide assumes that you have already installed the [Basic Extension](../../0
 :::
 
 :::warning[Custom Commands]
-This guide show you how to create a custom command with argument, if you don't need arguments, you can use the [RunCommandEvent](../../../adapters/BasicAdapter/entries/event/on_run_command.mdx) to create a command without arguments.
+This guide shows you how to create a custom command with arguments. If you don't need arguments, you can use the [RunCommandEvent](../../../adapters/BasicAdapter/entries/event/on_run_command.mdx) to create a command without arguments.
 :::
 
 In this tutorial, you will learn about custom commands and how to create one. We will create a command where you can define a pseudo and an age to display a message to the player.

--- a/documentation/docs/docs/03-creating-stories/07-advanced-interactions/03-interaction-bounds/02-option-bound.mdx
+++ b/documentation/docs/docs/03-creating-stories/07-advanced-interactions/03-interaction-bounds/02-option-bound.mdx
@@ -14,10 +14,10 @@ import TabItem from "@theme/TabItem";
 This guide is made for advanced users. It is recommended to have a good understanding of how [Interactions](../../01-interactions/index.mdx) and [Interaction Bounds](./) work.
 :::
 :::info[Story]
-The story of this guide will be a waiter that is asking at wich table the player would like to sit.
+The story of this guide will be a waiter who is asking at which table the player would like to sit.
 :::
 
-In this guide, you will learn how to create an option that has a interaction bound applied to it. This means that while scrolling thrue the options the players bound location can change.
+In this guide, you will learn how to create an option that has an interaction bound applied to it. This means that while scrolling through the options, the player's bound location can change.
 
 ## Creating the option
 :::info[Entity Extension]
@@ -78,8 +78,8 @@ For our restaurant scenario:
 4. Your `Case Variable` should look like this:
 <Image img={require("../../../assets/interactions/option-bound-case-variables.png")} width="400" />
 
-### Adding a Interaction Context Variable
-Now when the player scrolls thrue the options nothing happens yet. To do this we need to add a `Interaction Context Variable` to the `Case Variable` inside the `Lock Interaction Bound` entry.
+### Adding an Interaction Context Variable
+Now when the player scrolls through the options, nothing happens yet. To do this, we need to add an `Interaction Context Variable` to the `Case Variable` inside the `Lock Interaction Bound` entry.
 
 To do this, click on the <ActionButton button='dynamic-variable'/> icon at the `Selection` field inside the `Case Variable` entry and search for `Interaction Context Variable`.
 
@@ -90,7 +90,7 @@ To do this, click on the <ActionButton button='dynamic-variable'/> icon at the `
 This variable automatically provides the currently selected option index:
 
 1. Select the `Interaction Context Variable` entry
-2. In the inspector, click on `Select a Entry`
+2. In the inspector, click on `Select an Entry`
 3. Choose the `Option` entry we created earlier
 4. Your `Interaction Context Variable` should look like this:
 <Image img={require("../../../assets/interactions/option-bound-target-position.png")} width="400" />
@@ -118,7 +118,7 @@ When players interact with the waiter NPC, they'll see the option menu. As they 
 <Player url={require("../../../assets/interactions/option-bound-result.webm").default} />
 
 :::warning[Confirmation Key]
-While writing these docs a bug was found with the confirmation key. If your confirmation key is `SWAP_HANDS`(F) than while inside a interaction bound the dialogue will not continue. You need to press SPACE to do this!
+While writing these docs, a bug was found with the confirmation key. If your confirmation key is `SWAP_HANDS` (F), then while inside an interaction bound the dialogue will not continue. You need to press SPACE to do this!
 :::
 
 ## How it Works

--- a/documentation/docs/docs/03-creating-stories/07-advanced-interactions/03-interaction-bounds/02-option-bound.mdx
+++ b/documentation/docs/docs/03-creating-stories/07-advanced-interactions/03-interaction-bounds/02-option-bound.mdx
@@ -17,7 +17,8 @@ This guide is made for advanced users. It is recommended to have a good understa
 The story of this guide will be a waiter who is asking at which table the player would like to sit.
 :::
 
-In this guide, you will learn how to create an option that has an interaction bound applied to it. This means that while scrolling through the options, the player's bound location can change.
+In this guide, you will learn how to create an option that has an interaction bound applied to it. This means that
+while scrolling through the options, the player's bound location can change.
 
 ## Creating the option
 :::info[Entity Extension]
@@ -79,7 +80,8 @@ For our restaurant scenario:
 <Image img={require("../../../assets/interactions/option-bound-case-variables.png")} width="400" />
 
 ### Adding an Interaction Context Variable
-Now when the player scrolls through the options, nothing happens yet. To do this, we need to add an `Interaction Context Variable` to the `Case Variable` inside the `Lock Interaction Bound` entry.
+Now when the player scrolls through the options, nothing happens yet. To do this, we need to add an
+`Interaction Context Variable` to the `Case Variable` inside the `Lock Interaction Bound` entry.
 
 To do this, click on the <ActionButton button='dynamic-variable'/> icon at the `Selection` field inside the `Case Variable` entry and search for `Interaction Context Variable`.
 
@@ -118,7 +120,8 @@ When players interact with the waiter NPC, they'll see the option menu. As they 
 <Player url={require("../../../assets/interactions/option-bound-result.webm").default} />
 
 :::warning[Confirmation Key]
-While writing these docs, a bug was found with the confirmation key. If your confirmation key is `SWAP_HANDS` (F), then while inside an interaction bound the dialogue will not continue. You need to press SPACE to do this!
+While writing these docs, a bug was found with the confirmation key. If your confirmation key is `SWAP_HANDS` (F),
+then while inside an interaction bound the dialogue will not continue. You need to press SPACE to do this!
 :::
 
 ## How it Works

--- a/documentation/docs/docs/05-helpful-features/03-placeholderapi.mdx
+++ b/documentation/docs/docs/05-helpful-features/03-placeholderapi.mdx
@@ -41,10 +41,10 @@ Then, when calling the placeholder, it checks the ID and:
 - If their entry is a speaker, it gives the displayName back.
 - If their entry is a fact, it gives the fact value back.
 - If the entry is a sound, it gives the ID of the resource pack sound.
-- If the entry is a entity, it gives the displayName of the entity
+- If the entry is an entity, it gives the displayName of the entity
 - If the entry is a lines entry, it gives the content of the lines entry.
 - If the entry is a quest, it gives the displayName of the quest.
-- If the entry is a objective, it gives the formatted displayName of the objective.
+- If the entry is an objective, it gives the formatted displayName of the objective.
 - If the entry is a sidebar, it gives the title of the sidebar.
 
 ### Placeholder Parameters

--- a/documentation/docs/docs/05-helpful-features/04-shortcuts.mdx
+++ b/documentation/docs/docs/05-helpful-features/04-shortcuts.mdx
@@ -35,4 +35,5 @@ In the search menu there also are some shortcuts.
 | `!ae` or `!ne`                                            | Only show **new** entries                                                                |
 | `!ee `or` !a`                                             | Only show **existing** entries.                                                          |
 
-Pressing tab in the search menu allows you to easily go through all the entries. It also shows you a menu at the bottom with actions like `+Add` or `Open wiki`.
+Pressing tab in the search menu allows you to easily go through all the entries. It also shows you a menu at the
+bottom with actions like `+Add` or `Open wiki`.

--- a/documentation/docs/docs/05-helpful-features/04-shortcuts.mdx
+++ b/documentation/docs/docs/05-helpful-features/04-shortcuts.mdx
@@ -35,4 +35,4 @@ In the search menu there also are some shortcuts.
 | `!ae` or `!ne`                                            | Only show **new** entries                                                                |
 | `!ee `or` !a`                                             | Only show **existing** entries.                                                          |
 
-Pressing tab in the search menu allows you to easily go thrue all the entries. It also shows you a menu at the bottom actions like: `+Add` or `Open wiki`.
+Pressing tab in the search menu allows you to easily go through all the entries. It also shows you a menu at the bottom with actions like `+Add` or `Open wiki`.

--- a/documentation/docs/docs/05-helpful-features/05-snippets.mdx
+++ b/documentation/docs/docs/05-helpful-features/05-snippets.mdx
@@ -5,7 +5,7 @@ difficulty: Normal
 # What are Snippets?
 
 Snippets are small pieces of information that the extensions can use. Mostly related with how things are displayed to the users.
-Snippets allow you to customize all sorts of parts of different adpaters. For example, you can customize the way messages are displayed in the `Basic Extension`.
+Snippets allow you to customize all sorts of parts of different adapters. For example, you can customize the way messages are displayed in the `Basic Extension`.
 
 # How do I customize Snippets?
 Snippets can be customized by editing the `plugin/Typewriter/snippets.yml` file.
@@ -14,7 +14,7 @@ Snippets can be customized by editing the `plugin/Typewriter/snippets.yml` file.
 Note that Snippets are only written the first time they are used. So if you want to customize a snippet, you will need to trigger the entry that uses the snippet first.
 :::
 
-So for the `Basic Extension`, after the first person reiceves a `MessageDialogueEntry`, the `snippets.yml` file will look like this:
+So for the `Basic Extension`, after the first person receives a `MessageDialogueEntry`, the `snippets.yml` file will look like this:
 
 ```yaml title="plugin/Typewriter/snippets.yml"
 dialogue:

--- a/documentation/docs/docs/05-helpful-features/05-snippets.mdx
+++ b/documentation/docs/docs/05-helpful-features/05-snippets.mdx
@@ -5,7 +5,8 @@ difficulty: Normal
 # What are Snippets?
 
 Snippets are small pieces of information that the extensions can use. Mostly related with how things are displayed to the users.
-Snippets allow you to customize all sorts of parts of different adapters. For example, you can customize the way messages are displayed in the `Basic Extension`.
+Snippets allow you to customize all sorts of parts of different adapters. For example, you can customize the way
+messages are displayed in the `Basic Extension`.
 
 # How do I customize Snippets?
 Snippets can be customized by editing the `plugin/Typewriter/snippets.yml` file.
@@ -14,7 +15,8 @@ Snippets can be customized by editing the `plugin/Typewriter/snippets.yml` file.
 Note that Snippets are only written the first time they are used. So if you want to customize a snippet, you will need to trigger the entry that uses the snippet first.
 :::
 
-So for the `Basic Extension`, after the first person receives a `MessageDialogueEntry`, the `snippets.yml` file will look like this:
+So for the `Basic Extension`, after the first person receives a `MessageDialogueEntry`, the `snippets.yml` file
+will look like this:
 
 ```yaml title="plugin/Typewriter/snippets.yml"
 dialogue:

--- a/documentation/docs/docs/06-troubleshooting/playitgg.mdx
+++ b/documentation/docs/docs/06-troubleshooting/playitgg.mdx
@@ -14,14 +14,14 @@ In this tutorial you will learn how to make typewriter work with playit.gg
 Playit.gg is a service that allows you to make your localhost minecraft server be public for anyone to connect. This is useful for testing your server with friends or for making a public server for a short period of time.
 
 ## How to make typewriter work with playit.gg
-First go to [playit.gg](https://playit.gg/) and have a agent created and your minecraft server connected. There are plenty of tutorials out on the internet on how to do this.
+First, go to [playit.gg](https://playit.gg/) and create an agent connected to your Minecraft server. There are plenty of tutorials online explaining how to do this.
 
 ### Creating a new tunnel
 Inside the tunnels tab you can click on `+ Add tunnel`.
 
 <Image img={require("../assets/troubleshooting/tunnels.png")} alt="Tunnels" />
 
-Than inside the popup select your region and use the Tunnel Type `TCP (protocol)` than set the local port to `8080`(or the port you configured in the config.yml) and click on `Add tunnel`.
+Then, inside the popup, select your region and use the Tunnel Type `TCP (protocol)`. Set the local port to `8080` (or the port you configured in `config.yml`) and click on `Add tunnel`.
 
 <Image img={require("../assets/troubleshooting/create-tunnel.png")} alt="Create tunnel" />
 

--- a/documentation/docs/docs/06-troubleshooting/playitgg.mdx
+++ b/documentation/docs/docs/06-troubleshooting/playitgg.mdx
@@ -14,14 +14,16 @@ In this tutorial you will learn how to make typewriter work with playit.gg
 Playit.gg is a service that allows you to make your localhost minecraft server be public for anyone to connect. This is useful for testing your server with friends or for making a public server for a short period of time.
 
 ## How to make typewriter work with playit.gg
-First, go to [playit.gg](https://playit.gg/) and create an agent connected to your Minecraft server. There are plenty of tutorials online explaining how to do this.
+First, go to [playit.gg](https://playit.gg/) and create an agent connected to your Minecraft server. There are
+plenty of tutorials online explaining how to do this.
 
 ### Creating a new tunnel
 Inside the tunnels tab you can click on `+ Add tunnel`.
 
 <Image img={require("../assets/troubleshooting/tunnels.png")} alt="Tunnels" />
 
-Then, inside the popup, select your region and use the Tunnel Type `TCP (protocol)`. Set the local port to `8080` (or the port you configured in `config.yml`) and click on `Add tunnel`.
+Then, inside the popup, select your region and use the Tunnel Type `TCP (protocol)`. Set the local port to `8080`
+(or the port you configured in `config.yml`) and click on `Add tunnel`.
 
 <Image img={require("../assets/troubleshooting/create-tunnel.png")} alt="Create tunnel" />
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected spelling, grammar, punctuation, capitalization, and terminology across developer guides and tutorials.
  * Clarified instructions for entries, interactions, cinematics, querying, custom commands, shortcuts, snippets, and troubleshooting.
  * Fixed metadata and labels, including “difficulty,” “stateful,” “Entity Type,” and “ID.”
  * Improved guidance for configuring options, interaction bounds, Playit.gg tunnels, and story creation workflows.
  * Reformatted longer passages for improved readability without changing documented behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->