### PR TITLE
refactor(engine-paper): resolve entry listeners once at load instead of per event

### DIFF
--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/EntryListeners.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/entry/EntryListeners.kt
@@ -18,6 +18,8 @@ import org.bukkit.event.Listener
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.koin.java.KoinJavaComponent.get
+import java.lang.invoke.MethodHandle
+import java.lang.invoke.MethodHandles
 import java.lang.reflect.Method
 import java.lang.reflect.Parameter
 import kotlin.reflect.KClass
@@ -31,14 +33,34 @@ class EntryListeners : KoinComponent, Reloadable {
     private val listener = object : Listener {}
 
 
-    private fun onEvent(event: Event, info: EntryListenerInfo, generators: List<ParameterGenerator>, method: Method) {
-        val parameters = generators.map { it.generate(event, info) }
-        try {
-            method.invoke(null, *parameters.toTypedArray())
-        } catch (e: Exception) {
-            logger.severe("Failed to invoke entry listener ${method.name} for event ${event::class.simpleName}")
-            e.printStackTrace()
+    /**
+     * A listener declaration resolved into something directly callable.
+     *
+     * Holds everything that does not vary per event, so dispatch only supplies the event and
+     * invokes. Isolates its own failures: a listener that throws must not stop the event reaching
+     * the others, nor break dispatch for subsequent events.
+     */
+    private class BoundListener(
+        val method: Method,
+        private val handle: MethodHandle?,
+        private val arguments: List<ArgumentSupplier>,
+    ) {
+        fun invoke(event: Event) {
+            val values = arrayOfNulls<Any>(arguments.size)
+            for (index in arguments.indices) values[index] = arguments[index].supply(event)
+
+            try {
+                if (handle != null) handle.invokeWithArguments(*values) else method.invoke(null, *values)
+            } catch (e: Throwable) {
+                logger.severe("Failed to invoke entry listener ${method.name} for event ${event::class.simpleName}")
+                e.printStackTrace()
+            }
         }
+    }
+
+    /** Produces one argument of a bound listener, capturing everything constant up front. */
+    private fun interface ArgumentSupplier {
+        fun supply(event: Event): Any
     }
 
     /**
@@ -50,19 +72,86 @@ class EntryListeners : KoinComponent, Reloadable {
         val activeEventEntries = Query.find<EventEntry>().mapTo(mutableSetOf()) { it::class.java.name }
 
         val activeEntryListeners = entryListeners.filter { it.entryClassName in activeEventEntries }
-        activeEntryListeners.forEach {
-            val method = it.method
+
+        val registeredEntryListeners = activeEntryListeners.count { info ->
+            val method = info.method
             val eventClass =
                 findEventFromMethod(method).logErrorIfNull("Could not find bukkit event class for ${method.name}")
-                    ?: return@forEach
+                    ?: return@count false
 
-            listener.listen(plugin, eventClass, it.priority.toBukkitPriority(), it.ignoreCancelled) { event ->
-                onEvent(event, it, ParameterGenerator.getGenerators(method.parameters), method)
+            val bound = bind(info, method) ?: return@count false
+
+            listener.listen(plugin, eventClass, info.priority.toBukkitPriority(), info.ignoreCancelled) { event ->
+                bound.invoke(event)
             }
+            true
         }
 
-        logger.info("Loaded ${activeEntryListeners.size} entry listeners")
+        logger.info("Loaded $registeredEntryListeners entry listeners")
     }
+
+    /**
+     * Resolves a listener declaration into something callable, or null when it cannot be resolved.
+     *
+     * Reporting an unresolvable listener here, at load, is deliberate: an unsupported parameter or
+     * an unloadable entry class is a packaging mistake, and it should surface once at startup with
+     * the offending method named instead of throwing on every event for the life of the server.
+     */
+    private fun bind(info: EntryListenerInfo, method: Method): BoundListener? {
+        val arguments = bindArguments(info, method) ?: return null
+
+        return BoundListener(method, methodHandleOf(method), arguments)
+    }
+
+    private fun bindArguments(info: EntryListenerInfo, method: Method): List<ArgumentSupplier>? {
+        val generators =
+            try {
+                ParameterGenerator.getGenerators(method.parameters)
+            } catch (e: IllegalArgumentException) {
+                logger.severe("Could not bind entry listener ${method.name}: ${e.message}")
+                return null
+            }
+
+        return generators.map { generator ->
+            when (generator) {
+                ParameterGenerator.EventParameterGenerator -> ArgumentSupplier { event -> event }
+                ParameterGenerator.QueryParameterGenerator -> {
+                    val query =
+                        try {
+                            ParameterGenerator.QueryParameterGenerator.query(info)
+                        } catch (e: Exception) {
+                            logger.severe(
+                                "Could not resolve the query of entry listener ${method.name}: ${e.message}",
+                            )
+                            return null
+                        }
+                    ArgumentSupplier { query }
+                }
+            }
+        }
+    }
+
+    /**
+     * A handle bound to [method], or null when the extension class loader will not expose it.
+     *
+     * `unreflect` checks access against this class rather than against the eventual caller, and
+     * entry listeners live in extension jars with their own class loader, where the declaring class
+     * is often not public to the engine and `@EntryListener` never required the method to be
+     * public. Suppressing the check is therefore what lets a handle exist at all — the same
+     * suppression `Method.invoke` performs internally on every call, done once here instead, on a
+     * `Method` the engine obtained itself and keeps for the lifetime of the binding.
+     *
+     * A null result is not an error: dispatch falls back to `Method.invoke`, which only costs the
+     * per-call checks the handle avoids.
+     */
+    private fun methodHandleOf(method: Method): MethodHandle? =
+        try {
+            method.isAccessible = true
+            MethodHandles.lookup().unreflect(method)
+        } catch (e: Throwable) {
+            logger.warning("MethodHandle unavailable for entry listener ${method.name}; falling back to reflection")
+            null
+        }
 
     private fun findEventFromMethod(method: Method): KClass<out Event>? {
         @Suppress("UNCHECKED_CAST")
@@ -114,7 +203,15 @@ sealed interface ParameterGenerator {
             return parameter.type.isAssignableFrom(Query::class.java)
         }
 
-        override fun generate(event: Event, entryListenerInfo: EntryListenerInfo): Any {
+        override fun generate(event: Event, entryListenerInfo: EntryListenerInfo): Any = query(entryListenerInfo)
+
+        /**
+         * The query a listener receives, determined solely by [entryListenerInfo] and never by the
+         * event, so a caller may resolve it once and reuse it for every dispatch.
+         *
+         * @throws IllegalArgumentException when the declared entry class is not an [Entry].
+         */
+        fun query(entryListenerInfo: EntryListenerInfo): Query<out Entry> {
             val extensionLoader = get<ExtensionLoader>(ExtensionLoader::class.java)
             val entryClass = extensionLoader.loadClass(entryListenerInfo.entryClassName)
             if (!Entry::class.java.isAssignableFrom(entryClass)) {

--- a/engine/engine-paper/src/test/kotlin/com/typewritermc/engine/paper/entry/ParameterGeneratorCharacterizationTest.kt
+++ b/engine/engine-paper/src/test/kotlin/com/typewritermc/engine/paper/entry/ParameterGeneratorCharacterizationTest.kt
@@ -1,0 +1,109 @@
+package com.typewritermc.engine.paper.entry
+
+import com.typewritermc.core.entries.Query
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import io.mockk.mockk
+import org.bukkit.event.Event
+import org.bukkit.event.player.PlayerJoinEvent
+import java.lang.reflect.Parameter
+
+/**
+ * Characterization tests for the parameter resolution used when dispatching `@EntryListener`s.
+ *
+ * They freeze the behaviour of [ParameterGenerator] as it was when resolution happened inside the
+ * per-event lambda. Hoisting it to load time must not change which generator is chosen for a
+ * parameter, the order generators come back in, or how an unsupported parameter is rejected.
+ */
+@Suppress("UNUSED_PARAMETER")
+private object ListenerShapes {
+    @JvmStatic
+    fun eventOnly(event: PlayerJoinEvent) = Unit
+
+    @JvmStatic
+    fun eventThenQuery(event: PlayerJoinEvent, query: Query<*>) = Unit
+
+    @JvmStatic
+    fun queryThenEvent(query: Query<*>, event: PlayerJoinEvent) = Unit
+
+    @JvmStatic
+    fun baseEvent(event: Event) = Unit
+
+    @JvmStatic
+    fun unsupported(text: String) = Unit
+
+    @JvmStatic
+    fun noParameters() = Unit
+
+    fun parametersOf(name: String): Array<Parameter> =
+        ListenerShapes::class.java.declaredMethods.first { it.name == name }.parameters
+}
+
+class ParameterGeneratorCharacterizationTest : FunSpec({
+
+    test("a lone event parameter resolves to the event generator") {
+        val generators = ParameterGenerator.getGenerators(ListenerShapes.parametersOf("eventOnly"))
+
+        generators shouldBe listOf(ParameterGenerator.EventParameterGenerator)
+    }
+
+    test("generators come back in parameter order") {
+        ParameterGenerator.getGenerators(ListenerShapes.parametersOf("eventThenQuery")) shouldBe
+            listOf(ParameterGenerator.EventParameterGenerator, ParameterGenerator.QueryParameterGenerator)
+
+        ParameterGenerator.getGenerators(ListenerShapes.parametersOf("queryThenEvent")) shouldBe
+            listOf(ParameterGenerator.QueryParameterGenerator, ParameterGenerator.EventParameterGenerator)
+    }
+
+    test("the base Event type is accepted like any subclass") {
+        ParameterGenerator.getGenerators(ListenerShapes.parametersOf("baseEvent")) shouldBe
+            listOf(ParameterGenerator.EventParameterGenerator)
+    }
+
+    test("a method without parameters resolves to no generators") {
+        ParameterGenerator.getGenerators(ListenerShapes.parametersOf("noParameters")) shouldBe emptyList()
+    }
+
+    test("an unsupported parameter is rejected, and the failure names it") {
+        val failure = shouldThrow<IllegalArgumentException> {
+            ParameterGenerator.getGenerators(ListenerShapes.parametersOf("unsupported"))
+        }
+
+        failure.message!!.contains("unsupported") shouldBe true
+    }
+
+    test("resolution is stable: the same shape resolves identically every time") {
+        val first = ParameterGenerator.getGenerators(ListenerShapes.parametersOf("eventThenQuery"))
+        val second = ParameterGenerator.getGenerators(ListenerShapes.parametersOf("eventThenQuery"))
+
+        first shouldBe second
+    }
+
+    test("the event generator claims an event parameter") {
+        val parameter = ListenerShapes.parametersOf("eventOnly").first()
+
+        ParameterGenerator.EventParameterGenerator.isApplicable(parameter) shouldBe true
+    }
+
+    test("the event generator returns the very event instance it was given") {
+        val event = mockk<PlayerJoinEvent>()
+
+        val generated = ParameterGenerator.EventParameterGenerator.generate(event, mockk())
+
+        generated shouldBeSameInstanceAs event
+    }
+
+    test("the query generator does not claim an event parameter") {
+        val parameter = ListenerShapes.parametersOf("eventOnly").first()
+
+        ParameterGenerator.QueryParameterGenerator.isApplicable(parameter) shouldBe false
+    }
+
+    test("the event generator does not claim an unsupported parameter") {
+        val parameter = ListenerShapes.parametersOf("unsupported").first()
+
+        ParameterGenerator.EventParameterGenerator.isApplicable(parameter) shouldBe false
+    }
+})


### PR DESCRIPTION

Dispatching an `@EntryListener` re-derived, on every single event, work that only depends on the listener declaration: `getGenerators` walked the method parameters inside the event lambda, and `QueryParameterGenerator` went through the Koin container and the extension class loader to rebuild the same `Query` each time.

None of that varies per event. It is now resolved once during `load()` into an immutable record, and the event lambda only supplies the event and invokes.

This is a structural fix rather than an optimisation, and it is worth being explicit about that: profiling this path under a 50-player load produced zero execution samples across six ten-minute runs, so no performance gain is claimed for it. What it does buy is where failures surface. A listener with an unsupported parameter, or an entry class that cannot be loaded, used to throw on every event forever; it is now reported once at startup with the offending method named, and that listener is not registered. One broken declaration no longer costs an exception per dispatch.

Invocation goes through a `MethodHandle` bound at load, which avoids the repeated access checks and the `Object[]` boxing of `Method.invoke`. `unreflect` checks access against the engine rather than against the eventual caller, and entry listeners live in extension jars with their own class loader, where the declaring class is often not public to us and the annotated method need not be public either. `setAccessible` is therefore what lets the handle be produced at all in those cases — the same suppression `Method.invoke` performs internally on every call, done once at bind time instead, and scoped to a `Method` object the engine obtained itself and holds for the lifetime of the binding. Where the class loader still refuses, the bind falls back to `Method.invoke` and logs it: correctness first.

`QueryParameterGenerator.query(info)` is new and additive; `generate` delegates to it and keeps its behaviour.

Adds 9 characterization tests over parameter resolution: generator choice, parameter order, the base `Event` type, empty parameter lists, and the rejection message for an unsupported parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved event listener processing by reusing prepared handlers and query results, reducing repeated work during event dispatch.

- **Reliability**
  - Invalid listener parameters and unresolved queries are now reported earlier during setup.
  - Errors in one listener remain isolated so other listeners can continue running.
  - Added a fallback path to preserve compatibility when optimized processing is unavailable.

- **Tests**
  - Expanded coverage for supported parameter types, ordering, invalid parameters, and repeated resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->