### PR TITLE
perf(quest): spread the quest status sweep over ten ticks

### DIFF
--- a/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/QuestTracker.kt
+++ b/extensions/QuestExtension/src/main/kotlin/com/typewritermc/quest/QuestTracker.kt
@@ -17,6 +17,15 @@ import org.bukkit.entity.Player
 import org.koin.java.KoinJavaComponent.get
 import java.util.concurrent.ConcurrentHashMap
 
+/**
+ * How many ticks a full sweep of the quests is spread over.
+ *
+ * A quest status therefore lands at most this many ticks late, half a second at 20 TPS, while the
+ * polling cost is divided by the same factor. Raising it trades responsiveness for CPU; lowering it
+ * does the opposite.
+ */
+private const val REFRESH_INTERVAL_TICKS = 10
+
 @Factory
 class QuestTracker(
     @Parameter
@@ -24,13 +33,17 @@ class QuestTracker(
 ) : SessionTracker {
     private val quests = ConcurrentHashMap<Ref<QuestEntry>, QuestStatus>()
     private var trackedQuest: Ref<QuestEntry>? = null
+    private var tickCounter = 0
 
     override fun setup() {
         Query.find<QuestEntry>().forEach { refresh(it.ref()) }
     }
 
     override fun tick() {
-        Query.find<QuestEntry>().forEach { refresh(it.ref()) }
+        val slice = tickCounter++ % REFRESH_INTERVAL_TICKS
+        Query.find<QuestEntry>()
+            .filterIndexed { index, _ -> index % REFRESH_INTERVAL_TICKS == slice }
+            .forEach { refresh(it.ref()) }
     }
 
     override fun teardown() {}


### PR DESCRIPTION
`QuestTracker.tick` re-evaluated every quest of the catalogue, for every player, on every tick. The statuses it recomputes change on player action, not twenty times a second, so almost every sweep reached the same conclusion as the one before.

Each quest is now refreshed once per ten ticks, with the quests spread evenly across those ticks so the per-tick cost stays flat rather than spiking every tenth tick. `setup()` is untouched: a joining player still gets the full pass immediately, and the transition that matters most — a quest becoming ACTIVE — still fires from `refresh`.

The trade-off is explicit: a status can land up to half a second late.

Measured on a Paper server under a 50-player synthetic load, comparing JFR execution samples over 10 minutes: this path fell from 2.08% to 0.76% and 0.65% of sampled execution across two runs of the same configuration, against a measured run-to-run noise floor of 0.11 point on this path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Quest tracking now refreshes in staggered intervals, reducing unnecessary processing during each update.
  * Initial setup continues to perform a complete quest refresh for up-to-date results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->