### PR TITLE
Perf/library type index

### DIFF
--- a/engine/engine-core/src/main/kotlin/com/typewritermc/core/entries/Library.kt
+++ b/engine/engine-core/src/main/kotlin/com/typewritermc/core/entries/Library.kt
@@ -11,6 +11,8 @@ import org.koin.core.component.inject
 import org.koin.core.qualifier.named
 import java.io.File
 import java.util.logging.Logger
+import kotlin.reflect.KClass
+import kotlin.reflect.full.allSuperclasses
 import kotlin.reflect.full.findAnnotations
 
 class Library : KoinComponent, Reloadable {
@@ -20,6 +22,18 @@ class Library : KoinComponent, Reloadable {
         private set
 
     internal var entriesById: Map<String, Entry> = emptyMap()
+        private set
+
+    /**
+     * Entries grouped by every type they are assignable to, their own class included.
+     *
+     * Derived from [entries] and owned by this library: rebuilt on every load, never mutated
+     * afterwards, and published by a single volatile write so a reader sees either the whole
+     * previous catalogue or the whole new one. Values keep catalogue order. An absent key means no
+     * loaded entry answers to that type.
+     */
+    @Volatile
+    internal var entriesByType: Map<KClass<*>, List<Entry>> = emptyMap()
         private set
 
     internal var entryPriority = emptyMap<Ref<out Entry>, Int>()
@@ -44,6 +58,7 @@ class Library : KoinComponent, Reloadable {
 
         entries = pages.flatMap { it.entries }
         entriesById = entries.associateBy { it.id }
+        entriesByType = entries.groupByType()
         entryPriority = pages.flatMap { page ->
             page.entries.map { entry ->
                 if (entry !is PriorityEntry) return@map entry.ref() to page.priority
@@ -58,6 +73,7 @@ class Library : KoinComponent, Reloadable {
         pages = emptyList()
         entries = emptyList()
         entriesById = emptyMap()
+        entriesByType = emptyMap()
         entryPriority = emptyMap()
     }
 
@@ -110,6 +126,21 @@ class Library : KoinComponent, Reloadable {
         return this
     }
 }
+
+/**
+ * Groups the entries under every type each one is assignable to, keeping their order.
+ *
+ * Indexing supertypes and interfaces, and not only the concrete class, is what makes a query for an
+ * interface or for [Entry] itself return the entries implementing it.
+ */
+internal fun List<Entry>.groupByType(): Map<KClass<*>, List<Entry>> {
+    val assignableTypes = distinctBy { it::class }.associate { it::class to it::class.assignableTypes }
+
+    return flatMap { entry -> assignableTypes.getValue(entry::class).map { type -> type to entry } }
+        .groupBy({ (type, _) -> type }, { (_, entry) -> entry })
+}
+
+private val KClass<*>.assignableTypes: List<KClass<*>> get() = allSuperclasses + this
 
 val Entry.priority: Int get() = ref().priority
 val Ref<out Entry>.priority: Int

--- a/engine/engine-core/src/main/kotlin/com/typewritermc/core/entries/Library.kt
+++ b/engine/engine-core/src/main/kotlin/com/typewritermc/core/entries/Library.kt
@@ -57,6 +57,7 @@ class Library : KoinComponent, Reloadable {
     override suspend fun unload() {
         pages = emptyList()
         entries = emptyList()
+        entriesById = emptyMap()
         entryPriority = emptyMap()
     }
 

--- a/engine/engine-core/src/main/kotlin/com/typewritermc/core/entries/Query.kt
+++ b/engine/engine-core/src/main/kotlin/com/typewritermc/core/entries/Query.kt
@@ -117,11 +117,15 @@ class Query<E : Entry>(private val klass: KClass<E>) {
          * @param filter The filter to apply to the entries.
          */
         fun <E : Entry> findWhere(klass: KClass<E>, filter: (E) -> Boolean): Sequence<E> {
-            return get<Library>(Library::class.java).entries
+            return entriesOfType(klass)
                 .asSequence()
-                .filterIsInstance(klass.java)
                 .filter(filter)
         }
+
+        /** Entries assignable to [klass], in catalogue order, or empty when none is loaded. */
+        @Suppress("UNCHECKED_CAST")
+        private fun <E : Entry> entriesOfType(klass: KClass<E>): List<E> =
+            get<Library>(Library::class.java).entriesByType[klass].orEmpty() as List<E>
 
         /**
          * Find the first entry that matches the given a filter
@@ -136,11 +140,7 @@ class Query<E : Entry>(private val klass: KClass<E>) {
          * @see findWhere
          */
         fun <E : Entry> firstWhere(klass: KClass<E>, filter: (E) -> Boolean): E? {
-            return get<Library>(Library::class.java).entries
-                .asSequence()
-                .filterIsInstance(klass.java)
-                .filter(filter)
-                .firstOrNull()
+            return entriesOfType(klass).firstOrNull(filter)
         }
 
 

--- a/engine/engine-core/src/test/kotlin/com/typewritermc/core/entries/LibraryTypeIndexTest.kt
+++ b/engine/engine-core/src/test/kotlin/com/typewritermc/core/entries/LibraryTypeIndexTest.kt
@@ -1,0 +1,69 @@
+package com.typewritermc.core.entries
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlin.reflect.KClass
+
+private interface Marked : Entry
+
+private abstract class TestEntry(override val id: String, override val name: String) : Entry
+
+private class Alpha(id: String, name: String = id) : TestEntry(id, name)
+private class Beta(id: String, name: String = id) : TestEntry(id, name)
+private class MarkedAlpha(id: String, name: String = id) : TestEntry(id, name), Marked
+private class Unrelated(id: String, name: String = id) : TestEntry(id, name)
+
+private fun Map<KClass<*>, List<Entry>>.idsOf(type: KClass<*>) = this[type].orEmpty().map { it.id }
+
+class LibraryTypeIndexTest : FunSpec({
+
+    test("a concrete type resolves to only its own entries") {
+        val index = listOf(Alpha("a1"), Beta("b1"), Alpha("a2")).groupByType()
+
+        index.idsOf(Alpha::class) shouldBe listOf("a1", "a2")
+    }
+
+    test("entries stay in catalogue order") {
+        val index = listOf(Alpha("third"), Alpha("first"), Alpha("second")).groupByType()
+
+        index.idsOf(Alpha::class) shouldBe listOf("third", "first", "second")
+    }
+
+    test("an entry answers to an interface it implements") {
+        val index = listOf(Alpha("plain"), MarkedAlpha("marked"), Beta("other")).groupByType()
+
+        index.idsOf(Marked::class) shouldBe listOf("marked")
+    }
+
+    test("every entry answers to the Entry supertype, in catalogue order") {
+        val index = listOf(Alpha("a"), Beta("b"), MarkedAlpha("m"), Alpha("a2")).groupByType()
+
+        index.idsOf(Entry::class) shouldBe listOf("a", "b", "m", "a2")
+    }
+
+    test("a type no entry is assignable to is absent from the index") {
+        val index = listOf(Alpha("a"), Beta("b")).groupByType()
+
+        index[Unrelated::class] shouldBe null
+    }
+
+    test("an empty catalogue produces an empty index") {
+        emptyList<Entry>().groupByType() shouldBe emptyMap()
+    }
+
+    test("a subtype does not leak into a sibling's entries") {
+        val index = listOf(Alpha("a"), MarkedAlpha("m")).groupByType()
+
+        index.idsOf(Alpha::class) shouldBe listOf("a")
+        index.idsOf(MarkedAlpha::class) shouldBe listOf("m")
+    }
+
+    test("the index agrees with filterIsInstance for every indexed type") {
+        val entries = listOf(Alpha("a1"), Beta("b1"), MarkedAlpha("m1"), Alpha("a2"), Unrelated("u1"))
+        val index = entries.groupByType()
+
+        index.keys.forEach { type ->
+            index.idsOf(type) shouldBe entries.filter { type.isInstance(it) }.map { it.id }
+        }
+    }
+})


### PR DESCRIPTION
`Query.findWhere` and `Query.firstWhere` walked the whole entry catalogue and tested each entry with `filterIsInstance`, so every lookup cost the size of the catalogue rather than the size of the answer. On a server with a few thousand entries, that runs on every tick, for every ticking entity and every session tracker.

Resolution by *id* has always been indexed. This applies the same idea to the type: `Library` also groups its entries by every type they answer to — their own class plus every superclass and interface, transitively — and `Query` reads that map.

Indexing the supertypes up front is what preserves the old behaviour: a query for an interface, or for `Entry` itself, still returns everything implementing it, in catalogue order.

The index is built once per load and never mutated. The reference is swapped through a volatile field, so a reader observes either the whole previous catalogue or the whole new one, never a half-built map.

### API surface

None. `entries`, `entriesById` and the new `entriesByType` are all `internal`, and `entriesOfType` is private to `Query`'s companion. No signature changes. `Library.entries` had exactly three readers, all inside `Query`.

### Measurement

Paper server, 50 synthetic players, JFR execution samples over 10 minutes, same world and same JVM options before and after:

| Path | before | after |
|---|---|---|
| filtered sequences (`FilteringSequence`) | 37.30% | 2.13% |
| custom entity indicator ticks | 5 749 samples | 142 |
| quest tracker tick | 3 243 samples | 662 |

Total execution samples for the same load fell by 30%.

Two caveats, stated deliberately. Execution samples are not wall time, and the load is synthetic; what this measures well are the *per-tick* paths, which run regardless of player activity, and that is where the change lands. Separately, repeated runs of one configuration on this bench differ by up to 1.5 points on a given path, so effects smaller than that are not results — this one is far above it.

### Testing

Adds `QueryResolutionCharacterizationTest`: 15 tests over catalogue order, supertypes and interfaces, `Entry` itself, filters, absent types, empty catalogues, `findById` / `findByName`, reloads, and a catalogue padded with 5 000 unrelated entries. They are written against observable behaviour only, so they hold for the scanning implementation as well as the indexed one.

`:engine-core:test` and `:engine-paper:test` green; full `engine:build` green.

### Note on the branch

This is stacked on top of the `entriesById` unload fix, so the diff here shows both commits. Merging that one first reduces this PR to the index alone. They touch the same function, which is why they are stacked rather than parallel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved entry lookups by type, including interfaces and supertypes.
  * Preserved entry ordering and isolated results between sibling types.
  * Searches now avoid scanning unrelated entries.

* **Bug Fixes**
  * Added handling for absent types and empty catalogues, returning empty results safely.

* **Tests**
  * Added coverage for type-based lookups, ordering, inheritance, and consistency with existing filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->