### PR TITLE
fix(engine-core): clear the id index when the library unloads

### DIFF
--- a/engine/engine-core/src/main/kotlin/com/typewritermc/core/entries/Library.kt
+++ b/engine/engine-core/src/main/kotlin/com/typewritermc/core/entries/Library.kt
@@ -57,6 +57,7 @@ class Library : KoinComponent, Reloadable {
     override suspend fun unload() {
         pages = emptyList()
         entries = emptyList()
+        entriesById = emptyMap()
         entryPriority = emptyMap()
     }
 


### PR DESCRIPTION
`Library.unload` resets the pages, the entries and the priorities, but leaves `entriesById` populated. `Query.findById` reads that map directly, so between an unload and the next load it keeps returning entries from a catalogue that is no longer loaded, while `Query.find` on the same types correctly returns nothing.

Clear it alongside the rest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed library unloading so previously loaded entries are fully cleared before the next load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->