### PR TITLE
fix(BasicExtension): hold players in place during cinematics without granting real flight

### DIFF
--- a/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/utils/PlayerState.kt
+++ b/engine/engine-paper/src/main/kotlin/com/typewritermc/engine/paper/utils/PlayerState.kt
@@ -8,6 +8,7 @@ import com.github.retrooper.packetevents.protocol.item.type.ItemTypes
 import com.github.retrooper.packetevents.protocol.packettype.PacketType
 import com.github.retrooper.packetevents.resources.ResourceLocation
 import com.github.retrooper.packetevents.util.Dummy
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerPlayerAbilities
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetSlot
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerTimeUpdate
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerWindowItems
@@ -212,4 +213,58 @@ fun InterceptionBundle.keepFakeInventory() {
         packet.item = if (packet.slot in 0..8) fakeAir
         else com.github.retrooper.packetevents.protocol.item.ItemStack.EMPTY
     }
+}
+
+/**
+ * Tells this client it can fly, without the server handing out flight.
+ *
+ * Holding a player still in the air with [Player.setAllowFlight] puts real flight on them, which
+ * every other plugin can read back. Plugins that hand out flight themselves take that for flight of
+ * their own and can leave the player owed flight long after Typewriter is done with them. Only the
+ * client has to believe it, so only the client is told.
+ *
+ * Hold it with [keepFakeFlight] and end it with [sendRealAbilities].
+ */
+fun Player.sendFakeFlight() = sendAbilities(flying = true, flightAllowed = true)
+
+/**
+ * Puts this client back on the abilities the player actually has, ending [sendFakeFlight].
+ *
+ * Call it once the [keepFakeFlight] interception is cancelled and the player is standing where they
+ * are meant to end up. The interception rewrites this packet back into the faked flight while it is
+ * still up, and a player who is put back on real abilities in mid air drops out of it.
+ */
+fun Player.sendRealAbilities() = sendAbilities(flying = isFlying, flightAllowed = allowFlight)
+
+private fun Player.sendAbilities(flying: Boolean, flightAllowed: Boolean) {
+    WrapperPlayServerPlayerAbilities(
+        isInvulnerable || gameMode == GameMode.CREATIVE || gameMode == GameMode.SPECTATOR,
+        flying,
+        flightAllowed,
+        gameMode == GameMode.CREATIVE,
+        flySpeed.asPacketSpeed(),
+        walkSpeed.asPacketSpeed(),
+    ) sendPacketTo this
+}
+
+/** Bukkit reports a player's speeds at twice what the abilities packet carries. */
+private fun Float.asPacketSpeed() = this / 2
+
+/**
+ * Keeps a client held up by [sendFakeFlight] in the air.
+ *
+ * Anything writing the player's flight, speed or game mode makes the server send the abilities they
+ * really have, which would drop them out of the air halfway through. The client announces its own
+ * flight toggles as well, and the server answers those with the real abilities again.
+ *
+ * Add it to the bundle the caller intercepts with once [sendFakeFlight] has gone out, and keep that
+ * bundle for as long as the player is held. Cancelling it is what lets [sendRealAbilities] through.
+ */
+fun InterceptionBundle.keepFakeFlight() {
+    PacketType.Play.Server.PLAYER_ABILITIES { event ->
+        val packet = WrapperPlayServerPlayerAbilities(event)
+        packet.isFlying = true
+        packet.isFlightAllowed = true
+    }
+    !PacketType.Play.Client.PLAYER_ABILITIES
 }

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/bound/LockInteractionBoundEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/bound/LockInteractionBoundEntry.kt
@@ -41,6 +41,7 @@ import org.bukkit.event.entity.EntityDamageByBlockEvent
 import org.bukkit.event.entity.EntityDamageByEntityEvent
 import org.bukkit.event.entity.EntityDamageEvent
 import org.bukkit.event.entity.PlayerDeathEvent
+import org.bukkit.event.player.PlayerKickEvent
 import org.geysermc.geyser.api.connection.GeyserConnection
 import java.util.*
 
@@ -108,9 +109,9 @@ class LockInteractionBound(
 
     private suspend fun setup() {
         require(playerState == null)
-        playerState = player.state(LOCATION, FLYING, ALLOW_FLIGHT)
-        player.allowFlight = true
-        player.isFlying = true
+        // Flight is not captured. The bound only tells the client it can fly, so there is none to put back.
+        playerState = player.state(LOCATION)
+        player.sendFakeFlight()
         // For bedrock players we don't need to fake the inventory as we already hide the hotbar and item.
         if (!player.isFloodgate) {
             player.fakeClearInventory()
@@ -127,6 +128,7 @@ class LockInteractionBound(
         }
 
         interceptor = player.interceptPackets {
+            keepFakeFlight()
             Play.Client.PLAYER_INPUT { event ->
                 val packet = WrapperPlayClientPlayerInput(event)
                 if (packet.isForward || packet.isBackward || packet.isLeft || packet.isRight) {
@@ -196,6 +198,7 @@ class LockInteractionBound(
             // Revealed only after the player is restored, so nobody sees them reappear at the
             // position the bound moved them to.
             player.restore(playerState)
+            player.sendRealAbilities()
             playerHides.release(this@LockInteractionBound)
             playerState = null
         }
@@ -215,6 +218,16 @@ class LockInteractionBound(
 
     @EventHandler(priority = EventPriority.HIGHEST)
     fun onPlayerDamaged(event: EntityDamageByBlockEvent) = onPlayerDamaged(event as EntityDamageEvent)
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    fun onPlayerKicked(event: PlayerKickEvent) {
+        if (event.player.uniqueId != player.uniqueId) return
+        if (player.boundState == InteractionBoundState.IGNORING) return
+        // Faked flight leaves the server believing the player cannot fly, which is what the floating
+        // check disconnects them for.
+        if (event.cause != PlayerKickEvent.Cause.FLYING_PLAYER) return
+        event.isCancelled = true
+    }
 
     @EventHandler(priority = EventPriority.HIGHEST)
     fun onPlayerDeath(event: PlayerDeathEvent) {

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/cinematic/CameraCinematicEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/cinematic/CameraCinematicEntry.kt
@@ -42,6 +42,7 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent
 import org.bukkit.event.entity.EntityDamageEvent
 import org.bukkit.event.entity.EntityTargetEvent
 import org.bukkit.event.entity.EntityTargetLivingEntityEvent
+import org.bukkit.event.player.PlayerKickEvent
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.SkullMeta
 import org.bukkit.potion.PotionEffect
@@ -206,8 +207,6 @@ class CameraCinematicAction(
             originalState = state(
                 listOfNotNull(
                     LOCATION,
-                    ALLOW_FLIGHT,
-                    FLYING,
                     EffectStateProvider(INVISIBILITY),
                     VELOCITY.takeIf { entry.advancedCameraSettings.restoreVelocity }
                 )
@@ -215,9 +214,9 @@ class CameraCinematicAction(
             context[PlayerPositionOverride] = position
         }
 
+        sendFakeFlight()
+
         Dispatchers.Sync.switchContext {
-            allowFlight = true
-            isFlying = true
             addPotionEffect(PotionEffect(INVISIBILITY, INFINITE_DURATION, 0, false, false))
 
             // TODO: Remove this and the release in teardown once the visibility extension is
@@ -253,7 +252,15 @@ class CameraCinematicAction(
             if (it.target?.uniqueId != player?.uniqueId) return@listen
             it.isCancelled = true
         }
+        plugin.listen<PlayerKickEvent>(listener = listener!!) {
+            if (it.player.uniqueId != player?.uniqueId) return@listen
+            // Faked flight leaves the server believing the player cannot fly, which is what the
+            // floating check disconnects them for.
+            if (it.cause != PlayerKickEvent.Cause.FLYING_PLAYER) return@listen
+            it.isCancelled = true
+        }
         interceptor = this.interceptPackets {
+            keepFakeFlight()
             // If the player is a bedrock player, we don't want to modify the location.
             if (isFloodgate) return@interceptPackets
             keepFakeInventory()
@@ -295,6 +302,7 @@ class CameraCinematicAction(
             originalState?.let {
                 restore(it)
             }
+            sendRealAbilities()
             // Revealed only after the player is restored, so nobody sees them reappear at the
             // camera's position.
             playerHides.release(this@CameraCinematicAction)
@@ -389,8 +397,7 @@ private class DisplayCameraAction(
         setupPath(segment)
 
         player.teleportAsync(path.first().position.toBukkitLocation()).await()
-        player.allowFlight = true
-        player.isFlying = true
+        player.sendFakeFlight()
 
         entity.spawn(path.first().position.toPacketLocation())
         entity.addViewer(player.uniqueId)
@@ -463,8 +470,7 @@ private class TeleportCameraAction(
         val position = path.interpolate(frame)
         Dispatchers.Sync.switchContext {
             player.teleport(position.toBukkitLocation())
-            player.allowFlight = true
-            player.isFlying = true
+            player.sendFakeFlight()
         }
     }
 


### PR DESCRIPTION
Players could fly after a camera cinematic finished on servers running Lands, but only once they teleported or walked into a claim afterwards. Disconnecting partway through a cinematic avoided it, which pointed at state left behind rather than a cleanup call that never ran.

Camera cinematics and the lock interaction bound hold a player still by setting allowFlight and isFlying. That is real flight, and every other plugin on the server reads it back. One that tracks who may fly where sees a player who is allowed to, records that, and keeps handing flight out long after the shot is over. Putting the captured values back at the end does not undo what it already recorded.

Flight is faked on the client now. Typewriter never writes the server side value, so there is nothing for another plugin to observe and nothing to restore afterwards. Two things fall out of that. The server still believes the player cannot fly, so the vanilla floating check would disconnect them a few seconds in, and both call sites cancel that kick while they hold the player. The client also has to be told again whenever something writes the player's flight, speed or game mode, because the server answers those by sending the abilities the player really has. A cross world segment switch does exactly that, so the outgoing packet is rewritten for as long as the shot lasts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added client-side fake-flight support for locked interactions and cinematic camera sequences without granting actual flight permissions.
  * Players can remain suspended during these experiences while retaining normal game abilities afterward.

* **Bug Fixes**
  * Prevented players from being incorrectly kicked for flying while fake flight is active.
  * Ensured normal flight settings and player abilities are restored when the experience ends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->