### PR TITLE
feat(extensions): add the region extension

### DIFF
--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/LockHealthAudienceEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/LockHealthAudienceEntry.kt
@@ -1,0 +1,69 @@
+package com.typewritermc.basic.entries.audience
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.engine.paper.entry.entries.AudienceDisplay
+import com.typewritermc.engine.paper.entry.entries.AudienceEntry
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.TickableDisplay
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.core.utils.launch
+import com.typewritermc.engine.paper.utils.Sync
+import kotlinx.coroutines.Dispatchers
+import org.bukkit.attribute.Attribute
+import org.bukkit.entity.Player
+
+@Entry("lock_health_audience", "Hold the health of players at a set value", Colors.GREEN, "mdi:heart-pulse")
+/**
+ * The `Lock Health Audience` holds the health of the players in the audience at [health]. Damage
+ * still lands, so the hurt animation, the sound and the knockback all play, and the health is put
+ * back right after.
+ *
+ * To stop the damage from landing at all, use `Prevent Damage` instead.
+ *
+ * A value above the player's maximum health is clamped to it.
+ *
+ * ## How could this be used?
+ * Keep a player on half a heart through a scripted duel they are meant to survive, or hold a boss
+ * arena's challengers at a fixed health so the fight is about the mechanics, not the food they
+ * brought.
+ */
+class LockHealthAudienceEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("The health the players are held at. Two health is one heart.")
+    @Default("20.0")
+    val health: Var<Double> = ConstVar(20.0),
+) : AudienceEntry {
+    override suspend fun display(): AudienceDisplay = LockHealthAudienceDisplay(health)
+}
+
+class LockHealthAudienceDisplay(
+    private val health: Var<Double>,
+) : AudienceDisplay(), TickableDisplay {
+    override fun onPlayerAdd(player: Player) {}
+    override fun onPlayerRemove(player: Player) {}
+
+    // Reading the maximum health attribute and assigning health are both main thread work,
+    // and TickableDisplay.tick runs off it.
+    override fun tick() {
+        if (players.isEmpty()) return
+        Dispatchers.Sync.launch { applyHeldHealth() }
+    }
+
+    /** Applies the locked health to every audience player. Must run on the server main thread. */
+    internal fun applyHeldHealth() {
+        for (player in players) {
+            val maximum = player.getAttribute(Attribute.MAX_HEALTH)?.value ?: DEFAULT_MAX_HEALTH
+            val target = health.get(player).coerceIn(0.0, maximum)
+            if (player.health == target) continue
+            player.health = target
+        }
+    }
+
+    companion object {
+        private const val DEFAULT_MAX_HEALTH = 20.0
+    }
+}

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/PreventBlockBreakAudienceEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/PreventBlockBreakAudienceEntry.kt
@@ -1,0 +1,41 @@
+package com.typewritermc.basic.entries.audience
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.engine.paper.entry.entries.AudienceDisplay
+import com.typewritermc.engine.paper.entry.entries.AudienceEntry
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.block.BlockBreakEvent
+
+@Entry("prevent_block_break_audience", "Stop players from breaking blocks", Colors.GREEN, "mdi:pickaxe")
+/**
+ * The `Prevent Block Break Audience` stops the players in the audience from breaking any block,
+ * wherever they are.
+ *
+ * This is about the player, not about a place. To protect the blocks of one region from everyone,
+ * including a player standing outside it and mining inward, use the region's own block break flag
+ * instead.
+ *
+ * ## How could this be used?
+ * Freeze a player's ability to mine during a quest, or put it under an `In Region` audience so
+ * nobody digs up the town square.
+ */
+class PreventBlockBreakAudienceEntry(
+    override val id: String = "",
+    override val name: String = "",
+) : AudienceEntry {
+    override suspend fun display(): AudienceDisplay = PreventBlockBreakAudienceDisplay()
+}
+
+class PreventBlockBreakAudienceDisplay : AudienceDisplay() {
+    override fun onPlayerAdd(player: Player) {}
+    override fun onPlayerRemove(player: Player) {}
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onBreak(event: BlockBreakEvent) {
+        if (event.player !in this) return
+        event.isCancelled = true
+    }
+}

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/PreventBlockPlaceAudienceEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/PreventBlockPlaceAudienceEntry.kt
@@ -1,0 +1,40 @@
+package com.typewritermc.basic.entries.audience
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.engine.paper.entry.entries.AudienceDisplay
+import com.typewritermc.engine.paper.entry.entries.AudienceEntry
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.block.BlockPlaceEvent
+
+@Entry("prevent_block_place_audience", "Stop players from placing blocks", Colors.GREEN, "mdi:cube-off-outline")
+/**
+ * The `Prevent Block Place Audience` stops the players in the audience from placing any block,
+ * wherever they are.
+ *
+ * This is about the player, not about a place. To protect one region from everyone building in it,
+ * use the region's own block place flag instead.
+ *
+ * ## How could this be used?
+ * Stop players from towering out of an arena, or put it under an `In Region` audience so the
+ * cathedral keeps its skyline.
+ */
+class PreventBlockPlaceAudienceEntry(
+    override val id: String = "",
+    override val name: String = "",
+) : AudienceEntry {
+    override suspend fun display(): AudienceDisplay = PreventBlockPlaceAudienceDisplay()
+}
+
+class PreventBlockPlaceAudienceDisplay : AudienceDisplay() {
+    override fun onPlayerAdd(player: Player) {}
+    override fun onPlayerRemove(player: Player) {}
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onPlace(event: BlockPlaceEvent) {
+        if (event.player !in this) return
+        event.isCancelled = true
+    }
+}

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/PreventDamageAudienceEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/PreventDamageAudienceEntry.kt
@@ -1,0 +1,42 @@
+package com.typewritermc.basic.entries.audience
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.engine.paper.entry.entries.AudienceDisplay
+import com.typewritermc.engine.paper.entry.entries.AudienceEntry
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.entity.EntityDamageEvent
+
+@Entry("prevent_damage_audience", "Make players immune to all damage", Colors.GREEN, "mdi:shield-check")
+/**
+ * The `Prevent Damage Audience` makes the players in the audience immune to every source of damage:
+ * falling, mobs, fire, drowning and other players alike. The damage never lands, so there is no hurt
+ * animation and no knockback.
+ *
+ * To let the damage land and restore the health afterwards, which keeps the animation and the
+ * knockback, use `Lock Health` instead.
+ *
+ * ## How could this be used?
+ * Put it under an `In Region` audience to make a hub a true safe zone, or wrap a cinematic so a
+ * stray skeleton cannot kill a player mid scene.
+ */
+class PreventDamageAudienceEntry(
+    override val id: String = "",
+    override val name: String = "",
+) : AudienceEntry {
+    override suspend fun display(): AudienceDisplay = PreventDamageAudienceDisplay()
+}
+
+class PreventDamageAudienceDisplay : AudienceDisplay() {
+    override fun onPlayerAdd(player: Player) {}
+    override fun onPlayerRemove(player: Player) {}
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onDamage(event: EntityDamageEvent) {
+        val player = event.entity as? Player ?: return
+        if (player !in this) return
+        event.isCancelled = true
+    }
+}

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/PreventEatingAudienceEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/PreventEatingAudienceEntry.kt
@@ -1,0 +1,37 @@
+package com.typewritermc.basic.entries.audience
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.engine.paper.entry.entries.AudienceDisplay
+import com.typewritermc.engine.paper.entry.entries.AudienceEntry
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.player.PlayerItemConsumeEvent
+
+@Entry("prevent_eating_audience", "Stop players from eating or drinking", Colors.GREEN, "mdi:food-off")
+/**
+ * The `Prevent Eating Audience` stops the players in the audience from consuming anything: food,
+ * potions and milk alike. The item stays in their hand.
+ *
+ * ## How could this be used?
+ * Put it under an `In Region` audience so nobody can eat inside a cursed swamp, or wrap it around a
+ * boss fight so players cannot heal themselves out of trouble.
+ */
+class PreventEatingAudienceEntry(
+    override val id: String = "",
+    override val name: String = "",
+) : AudienceEntry {
+    override suspend fun display(): AudienceDisplay = PreventEatingAudienceDisplay()
+}
+
+class PreventEatingAudienceDisplay : AudienceDisplay() {
+    override fun onPlayerAdd(player: Player) {}
+    override fun onPlayerRemove(player: Player) {}
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onConsume(event: PlayerItemConsumeEvent) {
+        if (event.player !in this) return
+        event.isCancelled = true
+    }
+}

--- a/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/PreventHungerLossAudienceEntry.kt
+++ b/extensions/BasicExtension/src/main/kotlin/com/typewritermc/basic/entries/audience/PreventHungerLossAudienceEntry.kt
@@ -1,0 +1,39 @@
+package com.typewritermc.basic.entries.audience
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.engine.paper.entry.entries.AudienceDisplay
+import com.typewritermc.engine.paper.entry.entries.AudienceEntry
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.entity.FoodLevelChangeEvent
+
+@Entry("prevent_hunger_loss_audience", "Stop players from losing hunger", Colors.GREEN, "mdi:food-drumstick-off")
+/**
+ * The `Prevent Hunger Loss Audience` holds the hunger bar of the players in the audience where it
+ * is. They can still fill it by eating; it simply never drops.
+ *
+ * ## How could this be used?
+ * Put it under an `In Region` audience so a safe hub never starves anyone, or wrap a long puzzle so
+ * players are not interrupted by hunger halfway through.
+ */
+class PreventHungerLossAudienceEntry(
+    override val id: String = "",
+    override val name: String = "",
+) : AudienceEntry {
+    override suspend fun display(): AudienceDisplay = PreventHungerLossAudienceDisplay()
+}
+
+class PreventHungerLossAudienceDisplay : AudienceDisplay() {
+    override fun onPlayerAdd(player: Player) {}
+    override fun onPlayerRemove(player: Player) {}
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onFoodLevelChange(event: FoodLevelChangeEvent) {
+        val player = event.entity as? Player ?: return
+        if (player !in this) return
+        if (event.foodLevel >= player.foodLevel) return
+        event.isCancelled = true
+    }
+}

--- a/extensions/BasicExtension/src/test/kotlin/com/typewritermc/basic/entries/audience/AudienceTestSupport.kt
+++ b/extensions/BasicExtension/src/test/kotlin/com/typewritermc/basic/entries/audience/AudienceTestSupport.kt
@@ -1,0 +1,40 @@
+package com.typewritermc.basic.entries.audience
+
+import com.typewritermc.engine.paper.entry.entries.AudienceDisplay
+import com.typewritermc.engine.paper.interaction.PlayerSessionManager
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.spyk
+import org.bukkit.entity.Player
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+
+/**
+ * The display with [players] in its audience, ready for its handlers to be called directly.
+ *
+ * [AudienceDisplay.addPlayer] initializes the display on its first player, and initializing
+ * registers it with the running server through the `plugin` global, which no test has. The spy
+ * keeps every real behavior, membership included, and skips only that registration.
+ */
+internal inline fun <reified D : AudienceDisplay> D.activeWith(vararg players: Player): D {
+    val display = spyk(this)
+    every { display.initialize() } just Runs
+    every { display.dispose() } just Runs
+    players.forEach { display.addPlayer(it) }
+    return display
+}
+
+/**
+ * A bare `Var.get` call resolves an interaction context through Koin even for a `ConstVar` whose
+ * value never depends on it, so every spec that reads a `Var` needs this bootstrap.
+ */
+internal fun startAudienceKoin() {
+    startKoin {
+        modules(module { single { mockk<PlayerSessionManager>(relaxed = true) } })
+    }
+}
+
+internal fun stopAudienceKoin() = stopKoin()

--- a/extensions/BasicExtension/src/test/kotlin/com/typewritermc/basic/entries/audience/LockHealthAudienceSpec.kt
+++ b/extensions/BasicExtension/src/test/kotlin/com/typewritermc/basic/entries/audience/LockHealthAudienceSpec.kt
@@ -1,0 +1,120 @@
+package com.typewritermc.basic.entries.audience
+
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import org.bukkit.attribute.Attribute
+import org.bukkit.attribute.AttributeInstance
+import org.mockbukkit.mockbukkit.MockBukkit
+import org.mockbukkit.mockbukkit.ServerMock
+import org.mockbukkit.mockbukkit.entity.PlayerMock
+
+/**
+ * `AudienceDisplay.players` re-resolves every player from `server.getPlayer(uuid)` rather than
+ * keeping the reference handed to `addPlayer`, so spying a `PlayerMock` in place leaves the
+ * original, unspied instance registered with the server; `tick()` would then act on that instance
+ * and every stub or verification on the spy would silently observe nothing. Swapping the server's
+ * registration to the spy itself is what makes the assignment `tick()` performs observable.
+ *
+ * Spy the [player] only after its setup calls (like the starting health) have already landed on
+ * the plain instance, otherwise mockk records that setup as a call and `verify(exactly = 0)`
+ * assertions see it.
+ */
+private fun ServerMock.replaceWithSpy(player: PlayerMock): PlayerMock {
+    val spy = spyk(player)
+    playerList.disconnectPlayer(player)
+    playerList.addPlayer(spy)
+    return spy
+}
+
+/**
+ * The specs call [LockHealthAudienceDisplay.applyHeldHealth] instead of `tick`, because `tick`
+ * only schedules it onto the server main thread and MockBukkit has no dispatcher that runs that
+ * hop.
+ */
+class LockHealthAudienceSpec : FunSpec() {
+    private lateinit var server: ServerMock
+
+    init {
+        beforeSpec {
+            server = MockBukkit.mock()
+            startAudienceKoin()
+        }
+
+        afterSpec {
+            stopAudienceKoin()
+            MockBukkit.unmock()
+        }
+
+        test("a player in the audience is put back to the locked health") {
+            val player = server.addPlayer()
+            player.health = 4.0
+            val display = LockHealthAudienceDisplay(ConstVar(15.0)).activeWith(player)
+
+            display.applyHeldHealth()
+
+            player.health shouldBe (15.0 plusOrMinus 1e-9)
+        }
+
+        test("a player outside the audience keeps their own health") {
+            val member = server.addPlayer()
+            val outsider = server.addPlayer()
+            outsider.health = 4.0
+            val display = LockHealthAudienceDisplay(ConstVar(15.0)).activeWith(member)
+
+            display.applyHeldHealth()
+
+            outsider.health shouldBe (4.0 plusOrMinus 1e-9)
+        }
+
+        // MockBukkit's own setHealth silently clamps to the entity's maximum, so a MockBukkit
+        // player can't distinguish "our code clamped" from "MockBukkit clamped". Spying on a
+        // MockBukkit player (so server.getPlayer still resolves it) and stubbing the health
+        // setter to a no-op makes the exact value LockHealthAudienceDisplay assigns observable.
+        test("a locked health above the player's maximum is assigned exactly the maximum, not the raw target") {
+            val original = server.addPlayer()
+            original.health = 4.0
+            val player = server.replaceWithSpy(original)
+            val maxHealth = mockk<AttributeInstance>()
+            every { maxHealth.value } returns 20.0
+            every { player.getAttribute(Attribute.MAX_HEALTH) } returns maxHealth
+            every { player.health = any() } just Runs
+            val display = LockHealthAudienceDisplay(ConstVar(1000.0)).activeWith(player)
+
+            display.applyHeldHealth()
+
+            verify(exactly = 1) { player.health = 20.0 }
+        }
+
+        test("a locked health below zero is assigned exactly zero, never negative") {
+            val original = server.addPlayer()
+            original.health = 4.0
+            val player = server.replaceWithSpy(original)
+            every { player.health = any() } just Runs
+            val display = LockHealthAudienceDisplay(ConstVar(-5.0)).activeWith(player)
+
+            display.applyHeldHealth()
+
+            verify(exactly = 1) { player.health = 0.0 }
+        }
+
+        test("a player already at the locked health has its health setter never called") {
+            val original = server.addPlayer()
+            original.health = 15.0
+            val player = server.replaceWithSpy(original)
+            every { player.health = any() } just Runs
+            val display = LockHealthAudienceDisplay(ConstVar(15.0)).activeWith(player)
+
+            display.applyHeldHealth()
+
+            verify(exactly = 0) { player.health = any() }
+        }
+    }
+}

--- a/extensions/BasicExtension/src/test/kotlin/com/typewritermc/basic/entries/audience/PreventBlockEditingAudienceSpec.kt
+++ b/extensions/BasicExtension/src/test/kotlin/com/typewritermc/basic/entries/audience/PreventBlockEditingAudienceSpec.kt
@@ -1,0 +1,92 @@
+package com.typewritermc.basic.entries.audience
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.bukkit.Material
+import org.bukkit.event.block.BlockBreakEvent
+import org.bukkit.event.block.BlockPlaceEvent
+import org.bukkit.inventory.EquipmentSlot
+import org.bukkit.inventory.ItemStack
+import org.mockbukkit.mockbukkit.MockBukkit
+import org.mockbukkit.mockbukkit.ServerMock
+import org.mockbukkit.mockbukkit.world.WorldMock
+
+class PreventBlockEditingAudienceSpec : FunSpec() {
+    private lateinit var server: ServerMock
+    private lateinit var world: WorldMock
+
+    init {
+        beforeSpec {
+            server = MockBukkit.mock()
+            world = server.addSimpleWorld("blocks")
+            startAudienceKoin()
+        }
+
+        afterSpec {
+            stopAudienceKoin()
+            MockBukkit.unmock()
+        }
+
+        test("a player in the audience cannot break a block") {
+            val player = server.addPlayer()
+            val display = PreventBlockBreakAudienceDisplay().activeWith(player)
+
+            val event = BlockBreakEvent(world.getBlockAt(0, 64, 0), player)
+            display.onBreak(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("a player outside the audience can still break a block") {
+            val member = server.addPlayer()
+            val outsider = server.addPlayer()
+            val display = PreventBlockBreakAudienceDisplay().activeWith(member)
+
+            val event = BlockBreakEvent(world.getBlockAt(0, 64, 0), outsider)
+            display.onBreak(event)
+
+            event.isCancelled shouldBe false
+        }
+
+        test("a player in the audience cannot place a block") {
+            val player = server.addPlayer()
+            val display = PreventBlockPlaceAudienceDisplay().activeWith(player)
+
+            val placed = world.getBlockAt(0, 64, 0)
+            val against = world.getBlockAt(0, 63, 0)
+            val event = BlockPlaceEvent(
+                placed,
+                placed.state,
+                against,
+                ItemStack(Material.STONE),
+                player,
+                true,
+                EquipmentSlot.HAND,
+            )
+            display.onPlace(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("a player outside the audience can still place a block") {
+            val member = server.addPlayer()
+            val outsider = server.addPlayer()
+            val display = PreventBlockPlaceAudienceDisplay().activeWith(member)
+
+            val placed = world.getBlockAt(0, 64, 0)
+            val against = world.getBlockAt(0, 63, 0)
+            val event = BlockPlaceEvent(
+                placed,
+                placed.state,
+                against,
+                ItemStack(Material.STONE),
+                outsider,
+                true,
+                EquipmentSlot.HAND,
+            )
+            display.onPlace(event)
+
+            event.isCancelled shouldBe false
+        }
+    }
+}

--- a/extensions/BasicExtension/src/test/kotlin/com/typewritermc/basic/entries/audience/PreventDamageAudienceSpec.kt
+++ b/extensions/BasicExtension/src/test/kotlin/com/typewritermc/basic/entries/audience/PreventDamageAudienceSpec.kt
@@ -1,0 +1,59 @@
+package com.typewritermc.basic.entries.audience
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.bukkit.entity.EntityType
+import org.bukkit.event.entity.EntityDamageEvent
+import org.mockbukkit.mockbukkit.MockBukkit
+import org.mockbukkit.mockbukkit.ServerMock
+import org.mockbukkit.mockbukkit.world.WorldMock
+
+class PreventDamageAudienceSpec : FunSpec() {
+    private lateinit var server: ServerMock
+    private lateinit var world: WorldMock
+
+    init {
+        beforeSpec {
+            server = MockBukkit.mock()
+            world = server.addSimpleWorld("damage")
+            startAudienceKoin()
+        }
+
+        afterSpec {
+            stopAudienceKoin()
+            MockBukkit.unmock()
+        }
+
+        test("a player in the audience takes no damage") {
+            val player = server.addPlayer()
+            val display = PreventDamageAudienceDisplay().activeWith(player)
+
+            val event = EntityDamageEvent(player, EntityDamageEvent.DamageCause.FALL, 6.0)
+            display.onDamage(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("a player outside the audience still takes damage") {
+            val member = server.addPlayer()
+            val outsider = server.addPlayer()
+            val display = PreventDamageAudienceDisplay().activeWith(member)
+
+            val event = EntityDamageEvent(outsider, EntityDamageEvent.DamageCause.FALL, 6.0)
+            display.onDamage(event)
+
+            event.isCancelled shouldBe false
+        }
+
+        test("a mob standing next to a protected player still takes damage") {
+            val player = server.addPlayer()
+            val display = PreventDamageAudienceDisplay().activeWith(player)
+            val zombie = world.spawnEntity(world.spawnLocation, EntityType.ZOMBIE)
+
+            val event = EntityDamageEvent(zombie, EntityDamageEvent.DamageCause.FALL, 6.0)
+            display.onDamage(event)
+
+            event.isCancelled shouldBe false
+        }
+    }
+}

--- a/extensions/BasicExtension/src/test/kotlin/com/typewritermc/basic/entries/audience/PreventEatingAudienceSpec.kt
+++ b/extensions/BasicExtension/src/test/kotlin/com/typewritermc/basic/entries/audience/PreventEatingAudienceSpec.kt
@@ -1,0 +1,47 @@
+package com.typewritermc.basic.entries.audience
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.bukkit.Material
+import org.bukkit.event.player.PlayerItemConsumeEvent
+import org.bukkit.inventory.EquipmentSlot
+import org.bukkit.inventory.ItemStack
+import org.mockbukkit.mockbukkit.MockBukkit
+import org.mockbukkit.mockbukkit.ServerMock
+
+class PreventEatingAudienceSpec : FunSpec() {
+    private lateinit var server: ServerMock
+
+    init {
+        beforeSpec {
+            server = MockBukkit.mock()
+            startAudienceKoin()
+        }
+
+        afterSpec {
+            stopAudienceKoin()
+            MockBukkit.unmock()
+        }
+
+        test("a player in the audience cannot eat") {
+            val player = server.addPlayer()
+            val display = PreventEatingAudienceDisplay().activeWith(player)
+
+            val event = PlayerItemConsumeEvent(player, ItemStack(Material.BREAD), EquipmentSlot.HAND)
+            display.onConsume(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("a player outside the audience can still eat") {
+            val member = server.addPlayer()
+            val outsider = server.addPlayer()
+            val display = PreventEatingAudienceDisplay().activeWith(member)
+
+            val event = PlayerItemConsumeEvent(outsider, ItemStack(Material.BREAD), EquipmentSlot.HAND)
+            display.onConsume(event)
+
+            event.isCancelled shouldBe false
+        }
+    }
+}

--- a/extensions/BasicExtension/src/test/kotlin/com/typewritermc/basic/entries/audience/PreventHungerLossAudienceSpec.kt
+++ b/extensions/BasicExtension/src/test/kotlin/com/typewritermc/basic/entries/audience/PreventHungerLossAudienceSpec.kt
@@ -1,0 +1,57 @@
+package com.typewritermc.basic.entries.audience
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.bukkit.event.entity.FoodLevelChangeEvent
+import org.mockbukkit.mockbukkit.MockBukkit
+import org.mockbukkit.mockbukkit.ServerMock
+
+class PreventHungerLossAudienceSpec : FunSpec() {
+    private lateinit var server: ServerMock
+
+    init {
+        beforeSpec {
+            server = MockBukkit.mock()
+            startAudienceKoin()
+        }
+
+        afterSpec {
+            stopAudienceKoin()
+            MockBukkit.unmock()
+        }
+
+        test("a player in the audience never loses hunger") {
+            val player = server.addPlayer()
+            player.foodLevel = 20
+            val display = PreventHungerLossAudienceDisplay().activeWith(player)
+
+            val event = FoodLevelChangeEvent(player, 18)
+            display.onFoodLevelChange(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("a player in the audience can still gain hunger by eating") {
+            val player = server.addPlayer()
+            player.foodLevel = 12
+            val display = PreventHungerLossAudienceDisplay().activeWith(player)
+
+            val event = FoodLevelChangeEvent(player, 18)
+            display.onFoodLevelChange(event)
+
+            event.isCancelled shouldBe false
+        }
+
+        test("a player outside the audience still loses hunger") {
+            val member = server.addPlayer()
+            val outsider = server.addPlayer()
+            outsider.foodLevel = 20
+            val display = PreventHungerLossAudienceDisplay().activeWith(member)
+
+            val event = FoodLevelChangeEvent(outsider, 18)
+            display.onFoodLevelChange(event)
+
+            event.isCancelled shouldBe false
+        }
+    }
+}

--- a/extensions/RegionExtension/build.gradle.kts
+++ b/extensions/RegionExtension/build.gradle.kts
@@ -1,0 +1,21 @@
+repositories {}
+
+typewriter {
+    namespace = "typewritermc"
+
+    extension {
+        name = "Region"
+        shortDescription = "Whatever region you need, we got it."
+        description = """
+            |The Region extension adds spatial regions, 3D volumes you can hook into events,
+            |audience filters, facts, variables, and actions. Regions can be static (anchored
+            |to fixed coordinates) or dynamic (anchored to NPC/player locations, fact-driven
+            |positions, or interpolated paths) using the same definition shape.
+            """.trimMargin()
+
+        engineVersion = rootProject.extra["typewriterEngineVersion"] as String
+        channel = com.typewritermc.moduleplugin.ReleaseChannel.NONE
+
+        paper()
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/CoroutineShutdown.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/CoroutineShutdown.kt
@@ -1,0 +1,30 @@
+package com.typewritermc.region
+
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * How long a shutdown waits for a coroutine to finish its cleanup before giving up on it.
+ */
+private val SHUTDOWN_TIMEOUT: Duration = 2.seconds
+
+/**
+ * Cancels the job and waits for it to actually finish.
+ *
+ * Cancelling alone is not enough. A reload closes the extension's class loader as soon as every
+ * `Initializable` has shut down, so a coroutine that is still winding down resumes into a class
+ * loader that is gone, and fails with a `NoClassDefFoundError` while running the cleanup that was
+ * supposed to despawn its entities. Waiting keeps that cleanup inside the class loader's
+ * lifetime.
+ *
+ * The wait is bounded, because a cleanup can also be unable to finish: on a server shutdown the
+ * Bukkit scheduler is already disposed, so a hop to the main thread may never be dispatched.
+ * Waiting without a bound would hang the shutdown in that case; the bound leaves a warning in
+ * the log instead.
+ */
+internal suspend fun Job.cancelAndJoinBounded(timeout: Duration = SHUTDOWN_TIMEOUT) {
+    cancel()
+    withTimeoutOrNull(timeout) { join() }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/RegionCommand.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/RegionCommand.kt
@@ -1,0 +1,401 @@
+package com.typewritermc.region
+
+import com.typewritermc.core.entries.ref
+import com.typewritermc.core.extension.Initializable
+import com.typewritermc.core.extension.annotations.Singleton
+import com.typewritermc.core.extension.annotations.TypewriterCommand
+import com.typewritermc.core.interaction.context
+import com.typewritermc.core.utils.UntickedAsync
+import com.typewritermc.core.utils.switchContext
+import com.typewritermc.engine.paper.command.dsl.*
+import com.typewritermc.engine.paper.content.ContentContext
+import com.typewritermc.engine.paper.content.ContentModeSwapTrigger
+import com.typewritermc.engine.paper.entry.triggerFor
+import com.typewritermc.engine.paper.logger
+import com.typewritermc.engine.paper.snippets.snippet
+import com.typewritermc.engine.paper.utils.Sync
+import com.typewritermc.engine.paper.utils.TICK_MS
+import com.typewritermc.engine.paper.utils.msg
+import com.typewritermc.engine.paper.utils.sendMini
+import com.typewritermc.engine.paper.utils.toPosition
+import com.typewritermc.region.content.*
+import com.typewritermc.region.data.RegionDefinitionEntry
+import com.typewritermc.region.data.RegionReferenceData
+import com.typewritermc.region.data.displayColor
+import com.typewritermc.region.flag.RegionFlagManager
+import com.typewritermc.region.flag.centerPosition
+import com.typewritermc.region.flag.flagReport
+import com.typewritermc.region.flag.standingReport
+import io.papermc.paper.command.brigadier.CommandSourceStack
+import kotlinx.coroutines.*
+import org.bukkit.Location
+import org.bukkit.Material
+import org.bukkit.block.Block
+import org.bukkit.entity.Player
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import org.koin.java.KoinJavaComponent
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+
+private val visualizeMode by snippet(
+    "region.visualize.mode",
+    "multiple",
+    "How the visualize command behaves without an explicit single/multiple argument. " +
+            "With multiple, shown regions stack; with single, showing a region hides the previous one.",
+)
+
+private fun exclusiveByDefault(): Boolean = when (visualizeMode.lowercase()) {
+    "multiple" -> false
+    "single" -> true
+    else -> {
+        logger.warning("Invalid region.visualize.mode '$visualizeMode', falling back to multiple. Valid values: multiple, single.")
+        false
+    }
+}
+
+@TypewriterCommand
+fun CommandTree.regionCommand() = literal("region") {
+    withPermission("typewriter.region")
+    literal("visualize") {
+        withPermission("typewriter.region.visualize")
+        entry<RegionDefinitionEntry>("definition") { definition ->
+            literal("single") { visualizeArguments(definition, exclusive = true) }
+            literal("multiple") { visualizeArguments(definition, exclusive = false) }
+            visualizeArguments(definition, exclusive = null)
+        }
+        executePlayerOrTarget { target -> hideAllVisualizations(target) }
+    }
+    literal("edit") {
+        withPermission("typewriter.region.edit")
+        entry<RegionDefinitionEntry>("definition") { definition ->
+            executePlayerOrTarget { target -> startRegionEditor(target, definition()) }
+        }
+        executePlayerOrTarget { target -> startWorkspace(target) }
+    }
+    literal("debug") {
+        withPermission("typewriter.region.debug")
+        entry<RegionDefinitionEntry>("definition") { definition ->
+            executePlayerOrTarget { target -> startDebugMode(target, definition()) }
+        }
+    }
+    literal("flags") {
+        withPermission("typewriter.region.flags")
+        flagsArguments()
+    }
+}
+
+// The commands swap instead of pushing: running them from inside a region mode replaces
+// that mode, so repeated commands cannot stack sub mode onto sub mode. Outside a content
+// interaction a swap starts one, exactly like a push.
+private fun ExecutionContext<CommandSourceStack>.startRegionEditor(target: Player, definition: RegionDefinitionEntry) {
+    val registry = KoinJavaComponent.get<RegionEditRegistry>(RegionEditRegistry::class.java)
+    if (registry.isEditing(target.uniqueId, definition.id)) {
+        sender.msg("${target.name} is already editing <blue>${definition.name}</blue>.")
+        return
+    }
+    val session = registry.sessionOf(definition.id)
+    if (session != null && session.editorId != target.uniqueId) {
+        sender.msg("<red>${session.editorName} is editing ${definition.name} right now.")
+        return
+    }
+    if (registry.activeMode(target.uniqueId) == RegionModeKind.Editor) {
+        sender.msg("<red>${target.name} has another region editor open. Apply or close it first.")
+        return
+    }
+    val contentContext = regionEditorContext(definition)
+    val mode = regionEditorMode(definition, contentContext, target) ?: run {
+        sender.msg("<red>${definition.name} has no in-game editor.")
+        return
+    }
+    ContentModeSwapTrigger(contentContext, mode).triggerFor(target, context())
+    sender.msg("Opened the region editor of <blue>${definition.name}</blue> for ${target.name}.")
+}
+
+private fun ExecutionContext<CommandSourceStack>.startWorkspace(target: Player) {
+    val registry = KoinJavaComponent.get<RegionEditRegistry>(RegionEditRegistry::class.java)
+    if (registry.activeMode(target.uniqueId) == RegionModeKind.Workspace) {
+        sender.msg("The region workspace is already open for ${target.name}.")
+        return
+    }
+    // Swapping modes disposes the outgoing one, and an editor's unsaved writes go with it.
+    if (registry.activeMode(target.uniqueId) == RegionModeKind.Editor) {
+        sender.msg("<red>${target.name} has a region editor open. Apply or close it first.")
+        return
+    }
+    val contentContext = ContentContext(emptyMap())
+    ContentModeSwapTrigger(contentContext, RegionWorkspaceContentMode(contentContext, target))
+        .triggerFor(target, context())
+    sender.msg("Opened the region workspace for ${target.name}. Aim at a region and right-click the compass to edit it.")
+}
+
+private fun ExecutionContext<CommandSourceStack>.startDebugMode(target: Player, definition: RegionDefinitionEntry) {
+    val registry = KoinJavaComponent.get<RegionEditRegistry>(RegionEditRegistry::class.java)
+    // Swapping modes disposes the outgoing one, and an editor's unsaved writes go with it.
+    if (registry.activeMode(target.uniqueId) == RegionModeKind.Editor) {
+        sender.msg("<red>${target.name} has a region editor open. Apply or close it first.")
+        return
+    }
+    val contentContext = ContentContext(mapOf("entryId" to definition.id))
+    ContentModeSwapTrigger(contentContext, RegionDebugContentMode(contentContext, target))
+        .triggerFor(target, context())
+    sender.msg("Debugging <blue>${definition.name}</blue> for ${target.name}. The exit item closes the debugger.")
+}
+
+private const val FLAGS_REACH = 32.0
+private const val MAX_FLAGS_HIGHLIGHT_SECONDS = 300
+private val DEFAULT_FLAGS_HIGHLIGHT = 5.seconds
+
+/**
+ * Why a block can or cannot be changed: every region [target] stands in with the flags it
+ * carries, then every flag type in force at the block [target] is looking at, the region that
+ * decided it, and its priority. A flag no region decides is reported as undecided. The aimed block is
+ * highlighted for [duration] so the answer is never ambiguous about which block was judged.
+ */
+private fun ExecutionContext<CommandSourceStack>.showFlagReport(target: Player, duration: Duration) {
+    val index = KoinJavaComponent.get<RegionFlagManager>(RegionFlagManager::class.java).index
+    if (index == null) {
+        sender.msg("The region flag index has not loaded yet.")
+        return
+    }
+
+    sender.msg("<blue>${target.name}</blue> is standing in:")
+    standingReport(index, target.location.toPosition(), target).forEach(sender::sendMini)
+
+    val block = target.rayTraceBlocks(FLAGS_REACH)?.hitBlock
+    if (block == null) {
+        sender.msg("${target.name} is not looking at a block within ${FLAGS_REACH.toInt()} blocks.")
+        return
+    }
+
+    sender.msg("Looking at <blue>${block.x}, ${block.y}, ${block.z}</blue>:")
+    flagReport(index, block.centerPosition(), target).forEach(sender::sendMini)
+
+    KoinJavaComponent.get<FlagHighlighter>(FlagHighlighter::class.java).show(target, block, duration)
+}
+
+// The seconds argument must be registered before executePlayerOrTarget's target selector,
+// so numeric input parses as a duration and not as a player name.
+private fun CommandTree.visualizeArguments(
+    definition: ArgumentReference<RegionDefinitionEntry>,
+    exclusive: Boolean?,
+) {
+    int("seconds", min = 1, max = 3600) { seconds ->
+        executePlayerOrTarget { target ->
+            startVisualization(target, definition(), exclusive, seconds().seconds)
+        }
+    }
+    executePlayerOrTarget { target ->
+        toggleVisualization(target, definition(), exclusive)
+    }
+}
+
+// The seconds argument must be registered before executePlayerOrTarget's target selector,
+// so numeric input parses as a duration and not as a player name.
+private fun CommandTree.flagsArguments() {
+    // Minutes rather than the visualize command's hour: the highlight can be aimed at another
+    // player, whose only way out of it is to log off. Nothing hides it for them.
+    int("seconds", min = 1, max = MAX_FLAGS_HIGHLIGHT_SECONDS) { seconds ->
+        executePlayerOrTarget { target -> showFlagReport(target, seconds().seconds) }
+    }
+    executePlayerOrTarget { target -> showFlagReport(target, DEFAULT_FLAGS_HIGHLIGHT) }
+}
+
+private fun ExecutionContext<CommandSourceStack>.hideAllVisualizations(target: Player) {
+    val visualizer = KoinJavaComponent.get<RegionVisualizer>(RegionVisualizer::class.java)
+    val count = visualizer.hideAll(target)
+    if (count == 0) {
+        sender.msg("No regions were being visualized.")
+        return
+    }
+    sender.msg("No longer showing <blue>$count</blue> visualized region${if (count == 1) "" else "s"}.")
+}
+
+private fun ExecutionContext<CommandSourceStack>.toggleVisualization(
+    target: Player,
+    definition: RegionDefinitionEntry,
+    exclusive: Boolean?,
+) {
+    val visualizer = KoinJavaComponent.get<RegionVisualizer>(RegionVisualizer::class.java)
+    if (visualizer.hide(target, definition)) {
+        sender.msg("No longer showing the boundary of <blue>${definition.name}</blue>.")
+        return
+    }
+    visualizer.show(target, definition, Duration.INFINITE, exclusive ?: exclusiveByDefault())
+    sender.msg("Showing the boundary of <blue>${definition.name}</blue>. Run the command again to stop.")
+}
+
+private fun ExecutionContext<CommandSourceStack>.startVisualization(
+    target: Player,
+    definition: RegionDefinitionEntry,
+    exclusive: Boolean?,
+    duration: Duration,
+) {
+    val visualizer = KoinJavaComponent.get<RegionVisualizer>(RegionVisualizer::class.java)
+    visualizer.show(target, definition, duration, exclusive ?: exclusiveByDefault())
+    sender.msg("Showing the boundary of <blue>${definition.name}</blue> for ${duration.inWholeSeconds} seconds.")
+}
+
+/**
+ * Renders region boundaries outside of content mode, for inspecting and debugging
+ * definitions, dynamic ones in particular. Each shown region draws as glowing display
+ * entity edge lines in its color, which move with a dynamic region instead of leaving a
+ * particle trail behind it. One session per player and definition. A session ends when its
+ * duration passes, when the player leaves, or on [hide].
+ */
+@Singleton
+class RegionVisualizer : Initializable, KoinComponent {
+    private val engine: RegionEngine by inject()
+    private val editRegistry: RegionEditRegistry by inject()
+    private val sessions = ConcurrentHashMap<SessionKey, Job>()
+    private var scope: CoroutineScope? = null
+
+    override suspend fun initialize() {
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.UntickedAsync)
+    }
+
+    override suspend fun shutdown() {
+        val scope = this.scope ?: return
+        this.scope = null
+        scope.coroutineContext.job.cancelAndJoinBounded()
+        sessions.clear()
+    }
+
+    /**
+     * Shows the boundary of [definition] to [player] for [duration], replacing an active
+     * session for the same pair. When [exclusive], every other region shown to the player
+     * is hidden first. The definition is resolved again every tick, so the outline follows a
+     * dynamic region.
+     */
+    fun show(player: Player, definition: RegionDefinitionEntry, duration: Duration, exclusive: Boolean) {
+        val scope = scope ?: return
+        if (exclusive) hideAll(player)
+
+        val key = SessionKey(player.uniqueId, definition.id)
+        val data = RegionReferenceData(definition.ref())
+        val color = definition.displayColor(definition.id)
+        val deadline = TimeSource.Monotonic.markNow() + duration
+
+        val job = scope.launch {
+            val outline = RegionOutline(player)
+            try {
+                while (deadline.hasNotPassedNow() && player.isOnline) {
+                    val tracker = if (editRegistry.isEditing(player.uniqueId, definition.id)) {
+                        null
+                    } else {
+                        engine.query(data, player)
+                    }
+                    val transform = tracker?.lastTransform
+                    Dispatchers.Sync.switchContext {
+                        val world = transform?.let { resolveBukkitWorld(it.world.identifier) }
+                        if (tracker == null || transform == null || world == null) {
+                            outline.despawn()
+                        } else {
+                            val anchor = transform.worldOrigin
+                            outline.update(
+                                Location(world, anchor.x, anchor.y, anchor.z),
+                                transform.yawDegrees,
+                                transform.pitchDegrees,
+                                tracker.shape,
+                                color,
+                                rollDegrees = transform.rollDegrees,
+                            )
+                        }
+                    }
+                    delay(TICK_MS.milliseconds)
+                }
+            } finally {
+                withContext(NonCancellable) {
+                    Dispatchers.Sync.switchContext { outline.despawn() }
+                }
+            }
+        }
+        sessions.put(key, job)?.cancel()
+        job.invokeOnCompletion { sessions.remove(key, job) }
+    }
+
+    /** Stops an active session. Returns `false` when none was active. */
+    fun hide(player: Player, definition: RegionDefinitionEntry): Boolean {
+        val job = sessions.remove(SessionKey(player.uniqueId, definition.id)) ?: return false
+        job.cancel()
+        return true
+    }
+
+    /** Stops every active session of [player]. Returns how many were active. */
+    fun hideAll(player: Player): Int {
+        var count = 0
+        val iterator = sessions.entries.iterator()
+        while (iterator.hasNext()) {
+            val entry = iterator.next()
+            if (entry.key.playerId != player.uniqueId) continue
+            iterator.remove()
+            entry.value.cancel()
+            count++
+        }
+        return count
+    }
+
+    private data class SessionKey(val playerId: UUID, val definitionId: String)
+}
+
+/**
+ * Highlights one block with a glowing wireframe box for up to [Duration], so a player running
+ * `/tw region flags` can see which block the report is about. One highlight per player: showing
+ * a new one replaces the last.
+ *
+ * The box is spawned once, since the aimed block does not move, but the session keeps polling
+ * until the duration elapses so the box is despawned as soon as the player quits.
+ */
+@Singleton
+class FlagHighlighter : Initializable, KoinComponent {
+    private val sessions = ConcurrentHashMap<UUID, Job>()
+    private var scope: CoroutineScope? = null
+
+    override suspend fun initialize() {
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.UntickedAsync)
+    }
+
+    override suspend fun shutdown() {
+        val scope = this.scope ?: return
+        this.scope = null
+        scope.coroutineContext.job.cancelAndJoinBounded()
+        sessions.clear()
+    }
+
+    /**
+     * Draws a glowing box around [block], visible only to [player], for [duration], ending early
+     * if [player] disconnects first.
+     */
+    fun show(player: Player, block: Block, duration: Duration) {
+        val scope = scope ?: return
+        val anchor = block.location
+        val glow = org.bukkit.Color.fromRGB(255, 70, 70)
+        val deadline = TimeSource.Monotonic.markNow() + duration
+
+        val job = scope.launch {
+            val guide = GuideDisplay(player)
+            try {
+                Dispatchers.Sync.switchContext {
+                    guide.update(anchor, BLOCK_OUTLINE_SEGMENTS, Material.RED_CONCRETE, glow, HIGHLIGHT_THICKNESS)
+                }
+                while (deadline.hasNotPassedNow() && player.isOnline) {
+                    delay(TICK_MS.milliseconds)
+                }
+            } finally {
+                withContext(NonCancellable) {
+                    Dispatchers.Sync.switchContext { guide.despawn() }
+                }
+            }
+        }
+        sessions.put(player.uniqueId, job)?.cancel()
+        job.invokeOnCompletion { sessions.remove(player.uniqueId, job) }
+    }
+
+    companion object {
+        private const val HIGHLIGHT_THICKNESS = 0.06f
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/RegionEngine.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/RegionEngine.kt
@@ -1,0 +1,909 @@
+package com.typewritermc.region
+
+import com.google.common.cache.CacheBuilder
+import com.google.common.collect.Sets
+import com.typewritermc.core.entries.Query
+import com.typewritermc.core.extension.Initializable
+import com.typewritermc.core.extension.annotations.Singleton
+import com.typewritermc.core.utils.UntickedAsync
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.World
+import com.typewritermc.engine.paper.logger
+import com.typewritermc.engine.paper.plugin
+import com.typewritermc.engine.paper.utils.Sync
+import com.typewritermc.engine.paper.utils.TICK_MS
+import com.typewritermc.engine.paper.utils.position
+import com.typewritermc.engine.paper.utils.server
+import com.typewritermc.engine.paper.utils.toPosition
+import com.typewritermc.region.RegionEngine.Companion.MAX_INDEXED_CHUNK_SPAN
+import com.typewritermc.region.data.CrossingCause
+import com.typewritermc.region.data.RegionData
+import com.typewritermc.region.data.RegionDefinition
+import com.typewritermc.region.data.RegionDefinitionEntry
+import com.typewritermc.region.data.buildShapeOrNull
+import com.typewritermc.region.data.describeInLog
+import com.typewritermc.region.data.hasConstPlacement
+import com.typewritermc.region.handler.LazyInsideQueryHandler
+import com.typewritermc.region.handler.RegionHandler
+import com.typewritermc.region.tracker.RegionTracker
+import com.typewritermc.region.tracker.Tier
+import com.typewritermc.region.tracker.TrackerKey
+import it.unimi.dsi.fastutil.objects.ObjectHeapPriorityQueue
+import it.unimi.dsi.fastutil.objects.ReferenceLinkedOpenHashSet
+import kotlinx.coroutines.*
+import org.bukkit.Location
+import org.bukkit.entity.Entity
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.HandlerList
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerJoinEvent
+import org.bukkit.event.player.PlayerMoveEvent
+import org.bukkit.event.player.PlayerQuitEvent
+import org.bukkit.event.player.PlayerTeleportEvent
+import org.bukkit.event.vehicle.VehicleMoveEvent
+import org.bukkit.util.BoundingBox
+import org.koin.core.component.KoinComponent
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
+import java.util.concurrent.ConcurrentLinkedQueue
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * The entry point of the extension. Consumers obtain it via Koin and call [observe] or
+ * [query].
+ *
+ * The engine keeps a registry of trackers keyed by [TrackerKey]. Static trackers with a
+ * bounded AABB live in a chunk index, so a move only consults the trackers around the
+ * crossed chunks, the trackers the player is currently a member of, and the few unindexable
+ * ones. A Bukkit listener dispatches moves and teleports on the main thread, where
+ * [cancellation][RegionHandler.onClassification] is possible. A tick loop refreshes dynamic
+ * trackers at their refresh rate through an every tick bucket and a due time heap, instead
+ * of scanning all trackers each tick.
+ *
+ * All shared state lives in concurrent collections. The due time heap is only touched by
+ * the tick loop coroutine and is fed through [pendingScheduling]. A suspending mutex cannot
+ * be used here because the producers run inside non suspending Bukkit event handlers.
+ */
+@Singleton
+class RegionEngine : Initializable, Listener, KoinComponent {
+    private val trackers = ConcurrentHashMap<TrackerKey, RegionTracker>()
+
+    private val chunkIndex = ConcurrentHashMap<ChunkKey, MutableSet<RegionTracker>>()
+    private val indexedChunks = ConcurrentHashMap<RegionTracker, List<ChunkKey>>()
+    private val unindexed: MutableSet<RegionTracker> = Sets.newConcurrentHashSet()
+
+    private val playerTrackers = ConcurrentHashMap<UUID, MutableSet<RegionTracker>>()
+
+    /** Trackers holding a refusal against a player, so it can be lifted when their next move lands. */
+    private val refusedTrackers = ConcurrentHashMap<UUID, MutableSet<RegionTracker>>()
+
+    /** Maintained here because the server's own list is not safe to walk off the main thread. */
+    private val online = ConcurrentHashMap<UUID, Player>()
+
+    /**
+     * `false` until [initialize] has read the roster.
+     *
+     * Nothing orders the extension's [Initializable]s, so handlers attach and dispatch before the
+     * engine knows who is online. An empty roster is "not heard of yet" there, not "gone", and
+     * treating the two alike would evict every player during a publish.
+     */
+    @Volatile
+    private var rosterKnown = false
+
+    /**
+     * Trackers for regions nobody subscribes to, kept so repeated fact and variable reads
+     * do not rebuild one per call.
+     *
+     * The cache is bounded and evicts one entry at a time. Its natural size is players
+     * times definitions, so any fixed bound is reached on a busy server, and a map emptied
+     * whenever it fills would make every read that follows evaluate every placement variable
+     * again, on exactly the servers that need the cache. Evicting one entry keeps the rest
+     * warm.
+     */
+    private val queryCache: ConcurrentMap<TrackerKey, RegionTracker> = CacheBuilder.newBuilder()
+        .maximumSize(QUERY_CACHE_MAX)
+        .build<TrackerKey, RegionTracker>()
+        .asMap()
+
+    private val everyTick: MutableSet<RegionTracker> = Sets.newConcurrentHashSet()
+    private val pendingScheduling = ConcurrentLinkedQueue<RegionTracker>()
+
+    /** The tick each still failing tracker first threw on, so it is logged at an interval, not every tick. */
+    private val failingTrackers = ConcurrentHashMap<RegionTracker, Long>()
+
+    /** Trackers whose dispatch threw, so a broken region is named once rather than on every move. */
+    private val failingDispatch: MutableSet<RegionTracker> = Sets.newConcurrentHashSet()
+
+    /** The definitions already named for having no usable shape, emptied on every publish. */
+    private val reportedUnusable: MutableSet<RegionDefinition> = Sets.newConcurrentHashSet()
+
+    private var tickJob: Job? = null
+    private var scope: CoroutineScope? = null
+
+    override suspend fun initialize() {
+        reportedUnusable.clear()
+        queryCache.clear()
+        reportUnbuildableDefinitions()
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.UntickedAsync)
+        // The listener is registered before the roster is read, because this runs off the main
+        // thread on every
+        // publish: a player joining between the two would be in neither, and the engine would
+        // not see them again until the next reload. Recording a joiner twice costs nothing.
+        server.pluginManager.registerEvents(this, plugin)
+        // On the main thread because the server's list is the one PlayerList mutates there, and
+        // the roster is recorded there too: a player quitting between the read and the writes
+        // would be put back into [online] by them, and nothing would ever take them out again.
+        withContext(Dispatchers.Sync) { recordRoster(server.onlinePlayers) }
+        seedTrackersRegisteredBeforeTheRoster()
+        tickJob = scope?.launch { runTickLoop() }
+    }
+
+    /**
+     * Records who is online, after which a viewer missing from the roster is a viewer who has
+     * left. Internal so a test can drive the roster without a whole [initialize].
+     */
+    internal fun recordRoster(players: Collection<Player>) {
+        players.forEach { online[it.uniqueId] = it }
+        rosterKnown = true
+    }
+
+    /**
+     * Aligns the handlers that attached before this engine knew who was online.
+     *
+     * Nothing orders the extension's [Initializable]s, so the event binder and the audience
+     * manager can attach handlers here before [initialize] runs. Their seeding walks a roster
+     * that is still empty, leaving every player standing inside a region a non member, and the
+     * first move each of them makes fires an enter. Once per publish, for everyone indoors.
+     */
+    private fun seedTrackersRegisteredBeforeTheRoster() {
+        val players = onlinePlayers()
+        if (players.isEmpty()) return
+        for (tracker in trackers.values) {
+            if (!tracker.isRegistered) continue
+            // Each tracker is isolated, as in every other loop over them. A placement variable that
+            // throws while being seeded would otherwise leave every tracker behind it unaligned,
+            // and each of those fires a spurious enter for everyone already standing inside.
+            runCatching {
+                tracker.seedHandlers(players)
+                for (player in players) updateMembershipIndex(player, tracker)
+            }.onFailure {
+                logger.severe("Region '${tracker.definitionName}' could not be aligned after the publish:")
+                logger.severe(it.stackTraceToString())
+            }
+        }
+    }
+
+    /**
+     * Names every named definition whose fields do not describe a valid shape. Such a definition
+     * is skipped everywhere else in silence, and a region that quietly matches nothing is
+     * the hardest kind of failure for a builder to diagnose.
+     *
+     * An inline definition has no entry of its own to sweep, so it is named through
+     * [reportUnusableShape] when something first tries to resolve it.
+     */
+    private fun reportUnbuildableDefinitions() {
+        for (entry in Query.find<RegionDefinitionEntry>()) {
+            if (entry.buildShapeOrNull()?.usable != true) reportUnusableShape(entry)
+        }
+    }
+
+    /**
+     * Names [definition] in the console for having no usable shape, once per publish.
+     *
+     * The lookups that reach this run per fact read and per display tick, and an unusable shape
+     * stays unusable, so the definitions already named are remembered rather than repeated.
+     */
+    private fun reportUnusableShape(definition: RegionDefinition) {
+        if (!reportedUnusable.add(definition)) return
+
+        val consequence =
+            "Every event, audience, fact and display pointing at it does nothing until it is fixed."
+        val failure = runCatching { definition.buildShape() }.exceptionOrNull()
+        if (failure != null) {
+            logger.warning("${definition.describeInLog()} has no usable shape: ${failure.message} $consequence")
+            return
+        }
+        logger.warning(
+            "${definition.describeInLog()} has no usable shape: its fields do not describe a volume, " +
+                    "like a polygon of fewer than three points. $consequence"
+        )
+    }
+
+    override suspend fun shutdown() {
+        HandlerList.unregisterAll(this)
+
+        tickJob?.cancelAndJoinBounded()
+        tickJob = null
+        scope?.coroutineContext?.job?.cancelAndJoinBounded()
+        scope = null
+
+        trackers.clear()
+        chunkIndex.clear()
+        indexedChunks.clear()
+        unindexed.clear()
+        playerTrackers.clear()
+        refusedTrackers.clear()
+        rosterKnown = false
+        online.clear()
+        queryCache.clear()
+        everyTick.clear()
+        pendingScheduling.clear()
+        failingTrackers.clear()
+        failingDispatch.clear()
+        reportedUnusable.clear()
+    }
+
+    /**
+     * Subscribes a handler to a region. All subscribers of a constant placement definition
+     * share one tracker. Viewer dependent definitions get one tracker per [viewer].
+     *
+     * Returns `null` when [data] is an unresolved reference, or when the definition is
+     * viewer dependent and no [viewer] was given.
+     */
+    fun observe(data: RegionData, viewer: Player?, handler: RegionHandler): Subscription? {
+        val definition = data.resolveDefinition() ?: return null
+        val shared = definition.hasConstPlacement
+        if (!shared && viewer == null) return null
+
+        val key = TrackerKey(definition, if (shared) null else viewer?.uniqueId)
+        while (true) {
+            val tracker = trackers[key] ?: claim(key, definition, viewer.takeUnless { shared }) ?: return null
+
+            // The handler is attached under the registry's own lock, so it cannot land between
+            // another thread
+            // finding this tracker empty and removing it. That handler would be subscribed to a
+            // tracker no dispatch reaches any more, and its entry would never fire again.
+            val attached = trackers.computeIfPresent(key) { _, current ->
+                if (current === tracker) current.attach(handler)
+                current
+            }
+            if (attached === tracker) {
+                reindex(tracker)
+                // The handler is attached by now, so a throwing seed must not escape: the caller
+                // would never receive the subscription that cancels it, and a handler nothing can
+                // detach keeps its tracker, and the player it captured, alive until the next
+                // publish. Seeding only aligns the starting membership; the handler works without it.
+                runCatching { seed(tracker, handler) }.onFailure {
+                    logger.severe("Region '${tracker.definitionName}' failed to align a new subscriber:")
+                    logger.severe(it.stackTraceToString())
+                }
+                return Subscription(this, key, handler, tracker)
+            }
+            // A concurrent detach removed the tracker from the registry, or replaced it. Retry.
+        }
+    }
+
+    /**
+     * Registers a tracker for [key], or returns the one another thread registered first.
+     * `null` when the definition's fields do not describe a valid shape.
+     *
+     * The resolve runs before the insert and outside the map on purpose. It evaluates the
+     * definition's placement `Var`s, which is user code that may call back into the engine,
+     * and a [ConcurrentHashMap] mapping function would hold a bin lock across that.
+     */
+    private fun claim(key: TrackerKey, definition: RegionDefinition, viewer: Player?): RegionTracker? {
+        val shape = definition.buildShapeOrNull()
+        if (shape?.usable != true) reportUnusableShape(definition)
+        if (shape == null) return null
+        val fresh = RegionTracker(viewer, definition)
+        fresh.isRegistered = true
+        // The first read of the placement variables, and the one place they are read before the
+        // tracker is registered anywhere. A throw here escaping would reach whichever subscriber
+        // asked, and the event binder is mid way through replacing that player's subscriptions
+        // when it does: they would lose every region event for the rest of the session.
+        val resolved = runCatching { fresh.refresh() }.onFailure {
+            logger.severe("${definition.describeInLog()} could not resolve its placement:")
+            logger.severe(it.stackTraceToString())
+        }
+        if (resolved.isFailure) return null
+
+        val winner = trackers.putIfAbsent(key, fresh)
+        if (winner != null) {
+            fresh.isRegistered = false
+            return winner
+        }
+        register(key, fresh)
+
+        // The roster is read after the insert, and the quit handler empties it before it sweeps
+        // the registry, so one of the two always sees the other: a tracker claimed for a player
+        // who is already leaving would otherwise outlive them, keep their Player object reachable,
+        // and sit in the unindexed set that every move of every other player walks.
+        val viewerId = key.viewerId
+        if (viewerId != null && rosterKnown && !online.containsKey(viewerId)) {
+            trackers.remove(key, fresh)
+            unregister(key, fresh)
+            return null
+        }
+        return fresh
+    }
+
+    /**
+     * Resolves a tracker for an immediate read, without subscribing. Returns the registered
+     * tracker when one exists, otherwise a cached tracker without subscribers. The cached
+     * tracker's transform is refreshed on every call for dynamic definitions.
+     *
+     * Facts, variables and one shot actions should use this. Callers that want
+     * notifications should use [observe].
+     */
+    fun query(data: RegionData, viewer: Player): RegionTracker? {
+        val definition = data.resolveDefinition() ?: return null
+        val shared = definition.hasConstPlacement
+        val key = TrackerKey(definition, if (shared) null else viewer.uniqueId)
+
+        trackers[key]?.let { return it }
+        queryCache[key]?.let { tracker ->
+            if (tracker.tier == Tier.Dynamic) tracker.refresh()
+            return tracker
+        }
+
+        // The shape is checked below the cache lookups, so a cache hit never pays for building one.
+        val shape = definition.buildShapeOrNull()
+        if (shape?.usable != true) reportUnusableShape(definition)
+        if (shape == null) return null
+        val tracker = RegionTracker(viewer.takeUnless { shared }, definition)
+        tracker.refresh()
+        return queryCache.putIfAbsent(key, tracker) ?: tracker
+    }
+
+    /**
+     * The registered tracker events and audiences of [data] observe for [viewer], or `null`
+     * when nothing observes it. Unlike [query] this never creates a tracker, so diagnostics
+     * can tell "the region resolves fine" apart from "nothing is subscribed at all".
+     */
+    fun registeredTracker(data: RegionData, viewer: Player): RegionTracker? {
+        val definition = data.resolveDefinition() ?: return null
+        val shared = definition.hasConstPlacement
+        return trackers[TrackerKey(definition, if (shared) null else viewer.uniqueId)]
+    }
+
+    private fun register(key: TrackerKey, tracker: RegionTracker) {
+        queryCache.remove(key)
+        schedule(tracker)
+    }
+
+    /**
+     * Aligns a fresh handler's membership with the current player positions without firing
+     * callbacks. Without this, subscribing again after a publish would fire enter events for
+     * every player who was already inside.
+     */
+    private fun seed(tracker: RegionTracker, handler: RegionHandler) {
+        if (handler is LazyInsideQueryHandler) return
+
+        val tracked = handler.tracked
+        if (tracked != null) {
+            val player = server.getPlayer(tracked) ?: return
+            tracker.seedHandler(player, handler)
+            updateMembershipIndex(player, tracker)
+            return
+        }
+
+        for (player in onlinePlayers()) {
+            tracker.seedHandler(player, handler)
+            updateMembershipIndex(player, tracker)
+        }
+    }
+
+    internal fun detach(key: TrackerKey, handler: RegionHandler) {
+        var emptied: RegionTracker? = null
+        // The detach and the emptiness decision share the registry's lock with [observe]'s
+        // attach, so a subscription arriving in between is never dropped on a tracker that is
+        // about to leave the registry.
+        val kept = trackers.computeIfPresent(key) { _, tracker ->
+            tracker.detach(handler)
+            if (!tracker.isEmpty()) return@computeIfPresent tracker
+            emptied = tracker
+            null
+        }
+        kept?.let { reindex(it) }
+        emptied?.let { unregister(key, it) }
+    }
+
+    private fun unregister(key: TrackerKey, tracker: RegionTracker) {
+        tracker.isRegistered = false
+        everyTick.remove(tracker)
+        failingTrackers.remove(tracker)
+        failingDispatch.remove(tracker)
+        reindex(tracker)
+
+        for (memberships in playerTrackers.values) {
+            memberships.remove(tracker)
+        }
+        for (refusals in refusedTrackers.values) {
+            refusals.remove(tracker)
+        }
+    }
+
+    /**
+     * Places a tracker in the spatial structures. A tracker with a bounded margin and a chunk
+     * span within [MAX_INDEXED_CHUNK_SPAN] goes into the chunk index. Every other tracker goes
+     * into the [unindexed] set, which every move consults.
+     *
+     * A dynamic tracker is indexed too, and reindexed each time it refreshes. Excluding them
+     * puts one entry per viewer per moving region into [unindexed], and every move of every
+     * player then walks all of them.
+     */
+    private fun reindex(tracker: RegionTracker) {
+        placeInIndex(tracker)
+        // The check inside and the writes it makes are not one step, so an unregister running
+        // alongside can strip the tracker and then have this thread put it back. The sweep is
+        // repeated with the flag as it stands after the writes, which either finds the tracker
+        // still registered and leaves it alone, or takes it out for good.
+        if (!tracker.isRegistered) placeInIndex(tracker)
+    }
+
+    private fun placeInIndex(tracker: RegionTracker) {
+        // The read of the old keys, the writes and the strip are one update of this map, so two
+        // threads reindexing the same tracker cannot both work from the same starting set. When
+        // one of those two writes loses, the tracker sits in chunks that nothing records, and no
+        // later reindex or unregister can take it out of them again.
+        indexedChunks.compute(tracker) { _, indexed ->
+            val previous = indexed.orEmpty()
+            // An unregistered tracker leaves the structures entirely. Treating it as merely
+            // unindexable parks it in [unindexed], which every move walks, and the tracker holds
+            // its viewer, so one logout would pin that player for the life of the server.
+            if (!tracker.isRegistered) {
+                unindexed.remove(tracker)
+                stripFromChunkIndex(tracker, previous, keeping = emptySet())
+                return@compute null
+            }
+            val keys = chunkKeysFor(tracker)
+            if (keys == null) {
+                unindexed.add(tracker)
+                stripFromChunkIndex(tracker, previous, keeping = emptySet())
+                return@compute null
+            }
+            if (keys == previous) return@compute previous
+
+            // The new keys are added before the stale ones are stripped, with the new set in hand, so
+            // a move dispatching in between always finds the tracker under one set of keys or the
+            // other. Stripping first opens a window where the tracker is in no chunk at all, and a
+            // crossing in that window is simply lost.
+            for (chunkKey in keys) {
+                chunkIndex.compute(chunkKey) { _, set ->
+                    (set ?: Sets.newConcurrentHashSet()).apply { add(tracker) }
+                }
+            }
+            stripFromChunkIndex(tracker, previous, keeping = keys.toSet())
+            unindexed.remove(tracker)
+            keys
+        }
+    }
+
+    /** The chunks [tracker] belongs in, or `null` when it cannot be indexed by chunk at all. */
+    private fun chunkKeysFor(tracker: RegionTracker): List<ChunkKey>? {
+        if (tracker.marginUnbounded) return null
+        val aabb = tracker.cachedAabb ?: return null
+
+        val spanX = aabb.maxChunkX - aabb.minChunkX + 1
+        val spanZ = aabb.maxChunkZ - aabb.minChunkZ + 1
+        if (spanX.toLong() * spanZ > MAX_INDEXED_CHUNK_SPAN) return null
+
+        val keys = ArrayList<ChunkKey>(spanX * spanZ)
+        for (chunkX in aabb.minChunkX..aabb.maxChunkX) {
+            for (chunkZ in aabb.minChunkZ..aabb.maxChunkZ) {
+                keys.add(ChunkKey(aabb.world, chunkX, chunkZ))
+            }
+        }
+        return keys
+    }
+
+    private fun stripFromChunkIndex(tracker: RegionTracker, previous: List<ChunkKey>, keeping: Set<ChunkKey>) {
+        for (chunkKey in previous) {
+            if (chunkKey in keeping) continue
+            // The removal happens inside compute so it cannot delete a bucket another thread is
+            // in the middle of populating.
+            chunkIndex.compute(chunkKey) { _, set ->
+                set?.apply { remove(tracker) }?.takeIf { it.isNotEmpty() }
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    fun onMove(event: PlayerMoveEvent) {
+        // PlayerTeleportEvent extends PlayerMoveEvent. Teleports are handled in onTeleport,
+        // so they are skipped here to fire each crossing exactly once.
+        if (event is PlayerTeleportEvent) return
+        if (!event.hasChangedBlock()) return
+        val player = event.player
+        // The player steering a vehicle gets this event from the vehicle's packet, and cancelling
+        // it puts the rider back without the vehicle, which carries them across on its next packet
+        // anyway. So a ride crosses with no event to refuse, like a passenger who sends none, and
+        // no refusal is recorded for a crossing that stands.
+        val revocable = event.takeUnless { player.isInsideVehicle }
+        dispatchMove(player, event.from, event.to, CrossingCause.PLAYER_MOVED, revocable)
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    fun onTeleport(event: PlayerTeleportEvent) {
+        dispatchMove(event.player, event.from, event.to, CrossingCause.TELEPORTED, event)
+    }
+
+    /**
+     * Only the player steering a vehicle sends move packets, so only they get a [PlayerMoveEvent]
+     * while riding. Anyone else aboard a boat or a minecart, and anyone in a minecart rolling on
+     * its own, crosses a static region's boundary with nothing firing unless the vehicle's own
+     * event is watched. Boats and minecarts are the only vehicles that fire one; a second rider
+     * on a camel crosses unseen until the region moves and its reconcile catches them.
+     *
+     * The steering player is dispatched twice per crossing, once from each event. The second
+     * classifies them where the first already put them, so it fires nothing.
+     *
+     * [VehicleMoveEvent] cannot be cancelled, so a crossing on this path ignores cancellation
+     * requests the same way an engulf does.
+     */
+    @EventHandler(priority = EventPriority.MONITOR)
+    fun onVehicleMove(event: VehicleMoveEvent) {
+        if (event.from.blockX == event.to.blockX &&
+            event.from.blockY == event.to.blockY &&
+            event.from.blockZ == event.to.blockZ &&
+            event.from.world == event.to.world
+        ) return
+
+        for (player in ridingPlayers(event.vehicle)) {
+            dispatchMove(player, event.from, player.location, CrossingCause.PLAYER_MOVED, null)
+        }
+    }
+
+    /** Every player riding [vehicle], however deep the stack of mounts is. */
+    private fun ridingPlayers(vehicle: Entity): List<Player> = vehicle.passengers.flatMap { passenger ->
+        if (passenger is Player) listOf(passenger) else ridingPlayers(passenger)
+    }
+
+    // LOWEST so the roster holds the joiner before anything else binds to a region. The audience
+    // manager and the event binder both subscribe from this event at NORMAL, and a subscription
+    // for a viewer the roster has never heard of is read as a subscription for someone who has
+    // already left: their trackers would be claimed and immediately thrown away again.
+    @EventHandler(priority = EventPriority.LOWEST)
+    fun onJoin(event: PlayerJoinEvent) {
+        online[event.player.uniqueId] = event.player
+    }
+
+    // LOWEST so the final leave dispatch runs before other listeners, like the event
+    // binder's MONITOR cleanup, cancel their subscriptions.
+    @EventHandler(priority = EventPriority.LOWEST)
+    fun onQuit(event: PlayerQuitEvent) {
+        val player = event.player
+        val uuid = player.uniqueId
+        // The roster entry goes first: the tick loop reconciles against this map, and a reconcile landing
+        // after the memberships below are cleared would put the leaver straight back into them.
+        online.remove(uuid)
+
+        releaseRefusals(player)
+        // Then every tracker, not only the ones that held a refusal. A handler also remembers which
+        // way the player crossed it last, so it can tell a rollback of its own crossing from one it
+        // had no part in, and a player whose last crossing took them out of a region is in none of
+        // the sets a later dispatch or the sweep below would reach. Left behind, that one entry per
+        // player per handler is never read again and never freed.
+        for (tracker in trackers.values) tracker.clearRefusals(player)
+        // Each tracker is isolated: the leave callbacks run the subscribing entries' own code, and a
+        // throw from one of them would take the sweep below with it, leaving the quitter's
+        // trackers in the registry and their Player reachable for as long as the server runs.
+        playerTrackers.remove(uuid)?.forEach { tracker ->
+            runCatching { tracker.evict(player, CrossingCause.DISCONNECTED) }.onFailure {
+                logger.severe("Region '${tracker.definitionName}' failed to release ${player.name} on quit:")
+                logger.severe(it.stackTraceToString())
+            }
+        }
+        // The registry is swept, with no index of each viewer's keys. Such an index has to be
+        // written outside the registry's own lock, and a subscription landing during the quit
+        // then leaves a tracker nothing sweeps. A quit is rare enough to pay for a pass over the
+        // registry, which the query cache below pays for too.
+        for (key in trackers.keys.filter { it.viewerId == uuid }) {
+            trackers.remove(key)?.let { unregister(key, it) }
+        }
+        queryCache.keys.removeIf { it.viewerId == uuid }
+    }
+
+    /**
+     * Dispatches a crossing on the main thread. The candidates are the trackers indexed
+     * under the from and to chunks, the unindexed ones, and the trackers the player is a
+     * member of. When a handler requests cancellation, the Bukkit event is cancelled and
+     * every touched tracker is resynced against the pre move position, so no handler keeps
+     * state from the rolled back crossing.
+     */
+    private fun dispatchMove(
+        player: Player,
+        from: Location,
+        to: Location,
+        cause: CrossingCause,
+        event: PlayerMoveEvent?,
+    ) {
+        val toPosition = to.toPosition()
+
+        val candidates = ReferenceLinkedOpenHashSet<RegionTracker>()
+        val toChunk = ChunkKey(toPosition.world, to.blockX shr 4, to.blockZ shr 4)
+        chunkIndex[toChunk]?.let(candidates::addAll)
+        val fromChunk = ChunkKey(World(from.world.uid.toString()), from.blockX shr 4, from.blockZ shr 4)
+        if (fromChunk != toChunk) chunkIndex[fromChunk]?.let(candidates::addAll)
+        candidates.addAll(unindexed)
+        playerTrackers[player.uniqueId]?.let(candidates::addAll)
+        if (candidates.isEmpty()) {
+            releaseRefusals(player)
+            return
+        }
+
+        var cancelled = false
+        val box = player.boundingBox
+        val touched = ArrayList<RegionTracker>(candidates.size)
+        for (tracker in candidates) {
+            if (!tracker.isRegistered) continue
+            if (!tracker.wantsDispatch()) continue
+            if (!withinInfluence(tracker, box, toPosition) && !tracker.hasMember(player)) continue
+
+            touched.add(tracker)
+            if (dispatchIsolated(tracker, player, toPosition, cause, event)) cancelled = true
+            updateMembershipIndex(player, tracker)
+        }
+        if (!cancelled || touched.isEmpty() || event == null) {
+            releaseRefusals(player)
+            return
+        }
+
+        event.isCancelled = true
+        val fromPosition = from.toPosition()
+        for (tracker in touched) {
+            runCatching { tracker.resyncAt(player, fromPosition) }
+                .onFailure { reportDispatchFailure(tracker, it) }
+            updateMembershipIndex(player, tracker)
+        }
+        refusedTrackers.computeIfAbsent(player.uniqueId) { Sets.newConcurrentHashSet() }.addAll(touched)
+    }
+
+    /**
+     * Dispatches one tracker, keeping its failures to itself.
+     *
+     * A dispatch runs the subscribing entries' own code, and the band a proximity handler reads is
+     * a variable that throws on every read once its entry is deleted. Letting that escape skips
+     * every candidate behind this one, so unrelated regions miss the crossing entirely, leaves the
+     * membership index disagreeing with the handler, and strands the refusal from the previous
+     * move, which the tracker then keeps replaying until some later move happens to lift it.
+     */
+    private fun dispatchIsolated(
+        tracker: RegionTracker,
+        player: Player,
+        position: Position,
+        cause: CrossingCause,
+        event: PlayerMoveEvent?,
+    ): Boolean {
+        val cancelled = runCatching { tracker.dispatch(player, position, cause, event) }
+            .onFailure {
+                reportDispatchFailure(tracker, it)
+                // Nothing rolls a throwing tracker back, so nothing would ever lift a refusal it
+                // recorded on the way down either. Left held, it answers every later crossing of
+                // that player and the region stops seeing them entirely.
+                runCatching { tracker.clearRefusals(player) }
+            }
+            .getOrNull() ?: return false
+
+        if (failingDispatch.remove(tracker)) {
+            logger.warning("Region '${tracker.definitionName}' reacts to crossings again.")
+        }
+        return cancelled
+    }
+
+    /**
+     * Names a tracker whose dispatch threw, once.
+     *
+     * A move fires per player per tick, so the same broken region would otherwise print a stack
+     * trace several times a second. It stays silent until the tracker works again, which
+     * [dispatchIsolated] says out loud.
+     */
+    private fun reportDispatchFailure(tracker: RegionTracker, failure: Throwable) {
+        if (!failingDispatch.add(tracker)) return
+        logger.severe(
+            "Region '${tracker.definitionName}' failed on a crossing. It stops reacting to them:"
+        )
+        logger.severe(failure.stackTraceToString())
+    }
+
+    /**
+     * Forgets every refusal held against [player]. A refusal only means "the crossing you just
+     * made was undone", so the first move of theirs that survives ends it.
+     *
+     * Without this the refusal outlives its move: a player rolled back out of a tracker's
+     * reach is never dispatched to it again, and the tracker would still be holding their
+     * refusal the next time they teleport in.
+     */
+    private fun releaseRefusals(player: Player) {
+        if (refusedTrackers.isEmpty()) return
+        val trackers = refusedTrackers.remove(player.uniqueId) ?: return
+        for (tracker in trackers) tracker.clearRefusals(player)
+    }
+
+    private fun withinInfluence(tracker: RegionTracker, box: BoundingBox, position: Position): Boolean {
+        if (tracker.marginUnbounded) return true
+        val aabb = tracker.cachedAabb ?: return false
+        return aabb.reachableBy(position, box)
+    }
+
+    private fun updateMembershipIndex(player: Player, tracker: RegionTracker) {
+        val uuid = player.uniqueId
+        val member = tracker.hasMember(player)
+        var departed = false
+
+        // A reconcile in flight can land after the quit handler cleared this player, and
+        // recreating their entry here would keep the tracker, and their Player, alive forever.
+        // The roster is read inside the update so the two share the bin lock: read outside it,
+        // a quit landing in between is simply overwritten by the write that follows.
+        playerTrackers.compute(uuid) { _, memberships ->
+            if (rosterKnown && !online.containsKey(uuid)) {
+                departed = true
+                return@compute memberships?.apply { remove(tracker) }
+            }
+            if (!member) return@compute memberships?.apply { remove(tracker) }
+            (memberships ?: Sets.newConcurrentHashSet()).apply { add(tracker) }
+        }
+        if (!departed) return
+
+        // The handlers are evicted as well as the index entry: the same late dispatch will have
+        // written the player back into their membership sets, and on their next login the tracker
+        // would believe they never left.
+        //
+        // The player is evicted without asking Bukkit whether they are gone: a quitting player
+        // is still online for the whole quit chain, so that question is always answered "no"
+        // here. The dispatch that wrote the membership back fired an enter, the tracker is
+        // already out of the index above so the quit's own sweep will not reach it, and nothing
+        // else pairs a leave with that enter.
+        tracker.evict(player, CrossingCause.DISCONNECTED)
+    }
+
+    private fun schedule(tracker: RegionTracker) {
+        if (tracker.tier != Tier.Dynamic) return
+
+        if (tracker.refreshRateTicks <= 1) {
+            everyTick.add(tracker)
+        } else {
+            pendingScheduling.add(tracker)
+        }
+    }
+
+    /**
+     * The due time heap is only used inside this coroutine. New dynamic trackers arrive
+     * through [pendingScheduling]. Unregistered trackers are dropped when they come due.
+     */
+    private suspend fun runTickLoop() {
+        val heap = ObjectHeapPriorityQueue<ScheduledRefresh>(compareBy { it.dueTick })
+        var tick = 0L
+        var failingSince = 0L
+
+        while (true) {
+            val tickStart = System.currentTimeMillis()
+            tick += 1
+            try {
+                tickDynamicTrackers(heap, tick)
+                if (failingSince != 0L) {
+                    logger.warning("RegionEngine tick recovered after ${tick - failingSince} failed ticks.")
+                    failingSince = 0L
+                }
+            } catch (throwable: Throwable) {
+                // The first failure in full and the ones after it at an interval, so a persistent
+                // failure is visible in the console without filling it every tick.
+                if (failingSince == 0L) {
+                    failingSince = tick
+                    logger.severe("RegionEngine tick failed. Dynamic regions stop updating while this persists:")
+                    logger.severe(throwable.stackTraceToString())
+                } else if ((tick - failingSince) % FAILURE_LOG_INTERVAL_TICKS == 0L) {
+                    logger.warning("RegionEngine tick still failing (${throwable::class.simpleName}: ${throwable.message})")
+                }
+            }
+
+            val elapsed = System.currentTimeMillis() - tickStart
+            val wait = TICK_MS - elapsed
+            // The tick body has no suspension point, so without this a tick that runs
+            // longer than TICK_MS leaves the loop with nowhere to observe cancellation and
+            // shutdown can only time out.
+            if (wait > 0) delay(wait.milliseconds) else yield()
+        }
+    }
+
+    private fun tickDynamicTrackers(heap: ObjectHeapPriorityQueue<ScheduledRefresh>, tick: Long) {
+        for (tracker in everyTick) {
+            if (!tracker.isRegistered) {
+                everyTick.remove(tracker)
+                continue
+            }
+            refreshIsolated(tracker, tick)
+        }
+
+        while (true) {
+            val tracker = pendingScheduling.poll() ?: break
+            if (!tracker.isRegistered) continue
+            heap.enqueue(ScheduledRefresh(tick + tracker.refreshRateTicks, tracker))
+        }
+
+        while (!heap.isEmpty && heap.first().dueTick <= tick) {
+            val tracker = heap.dequeue().tracker
+            if (!tracker.isRegistered) continue
+
+            refreshIsolated(tracker, tick)
+            heap.enqueue(ScheduledRefresh(tick + tracker.refreshRateTicks, tracker))
+        }
+    }
+
+    /**
+     * Refreshes one tracker, keeping its failures to itself.
+     *
+     * A placement variable whose entry was deleted throws on every read, and the dispatch that
+     * follows runs the subscribing entries' own code. Letting either escape would skip every
+     * tracker behind this one in the tick, leave the scheduling queue unread, and take the
+     * failing tracker out of the heap for good: one broken region would freeze every moving
+     * region on the server.
+     */
+    private fun refreshIsolated(tracker: RegionTracker, tick: Long) {
+        val failure = runCatching { refreshAndReconcile(tracker) }.exceptionOrNull()
+        if (failure == null) {
+            val failingSince = failingTrackers.remove(tracker) ?: return
+            logger.warning("Region '${tracker.definitionName}' updates again after ${tick - failingSince} failed ticks.")
+            return
+        }
+
+        val failingSince = failingTrackers.putIfAbsent(tracker, tick)
+        if (failingSince == null) {
+            logger.severe("Region '${tracker.definitionName}' failed to update. It stops following its placement:")
+            logger.severe(failure.stackTraceToString())
+            return
+        }
+        if ((tick - failingSince) % FAILURE_LOG_INTERVAL_TICKS == 0L) {
+            logger.warning(
+                "Region '${tracker.definitionName}' still failing " +
+                        "(${failure::class.simpleName}: ${failure.message})"
+            )
+        }
+    }
+
+    /**
+     * Resolves the transform again, since a dynamic placement may have moved, and reconciles
+     * every online player with [CrossingCause.ENGULFED]. Cancellation requests are ignored
+     * on this path. Internal so tests can drive the reconcile deterministically.
+     */
+    internal fun refreshAndReconcile(tracker: RegionTracker) {
+        tracker.refresh()
+        reindex(tracker)
+        if (!tracker.wantsDispatch()) return
+
+        // A per viewer tracker only carries handlers for that one viewer, so classifying anyone
+        // else is work whose result is thrown away by the handler's own filter.
+        for (player in tracker.viewer?.let(::listOf) ?: onlinePlayers()) {
+            if (!player.isOnline) continue
+            val position = player.position
+            if (!withinInfluence(tracker, player.boundingBox, position) && !tracker.hasMember(player)) continue
+
+            tracker.dispatch(player, position, CrossingCause.ENGULFED, null)
+            updateMembershipIndex(player, tracker)
+        }
+    }
+
+    /**
+     * The online players, as a collection safe to walk off the main thread.
+     *
+     * `server.onlinePlayers` is a live view over the list the server mutates when someone joins
+     * or leaves, so iterating it from the tick loop throws as soon as either happens.
+     */
+    internal fun onlinePlayers(): Collection<Player> = online.values
+
+    /**
+     * Handle returned to a subscriber, used to detach later. The [tracker] is exposed so
+     * displays can read the cached transform without querying again.
+     */
+    class Subscription internal constructor(
+        private val engine: RegionEngine,
+        private val key: TrackerKey,
+        private val handler: RegionHandler,
+        val tracker: RegionTracker,
+    ) {
+        fun cancel() = engine.detach(key, handler)
+    }
+
+    private class ScheduledRefresh(val dueTick: Long, val tracker: RegionTracker)
+
+    private data class ChunkKey(val world: World, val x: Int, val z: Int)
+
+    companion object {
+        private const val QUERY_CACHE_MAX = 2048L
+        private const val MAX_INDEXED_CHUNK_SPAN = 1024L
+        private const val FAILURE_LOG_INTERVAL_TICKS = 100L
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/RegionEventBinder.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/RegionEventBinder.kt
@@ -1,0 +1,167 @@
+package com.typewritermc.region
+
+import com.typewritermc.core.entries.Query
+import com.typewritermc.core.extension.Initializable
+import com.typewritermc.core.extension.annotations.Singleton
+import com.typewritermc.engine.paper.logger
+import com.typewritermc.engine.paper.plugin
+import com.typewritermc.engine.paper.utils.Sync
+import com.typewritermc.engine.paper.utils.server
+import com.typewritermc.region.data.hasConstPlacement
+import com.typewritermc.region.entries.event.*
+import com.typewritermc.region.handler.EnterExitHandler
+import com.typewritermc.region.handler.ProximityHandler
+import com.typewritermc.region.handler.RegionHandler
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.HandlerList
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerJoinEvent
+import org.bukkit.event.player.PlayerQuitEvent
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Connects the region event entries ([RegionEnterEventEntry], [RegionExitEventEntry],
+ * [RegionProximityEventEntry]) to the [RegionEngine].
+ *
+ * A constant placement region gets one shared handler per entry, bound once at initialize.
+ * The shared tracker classifies every crossing player against it, so a crossing fires the
+ * entry once regardless of how many players are online. Viewer dependent regions are bound
+ * per player on join, so only the viewer's own crossings of their own region fire.
+ *
+ * No explicit rebinding is needed on publish. `TypewriterCore.load()` reruns every
+ * `Initializable` together with the entry library, so [initialize] always sees fresh
+ * entries.
+ *
+ * The handler callbacks return [RegionEventDispatch]'s `shouldCancel` result. The
+ * [RegionEngine] applies it by cancelling the Bukkit event and resyncing handler state to
+ * the pre move position. Engulf crossings fire from the async tick loop and cannot be
+ * cancelled.
+ */
+@Singleton
+class RegionEventBinder : Initializable, Listener, KoinComponent {
+    private val engine: RegionEngine by inject()
+    private val sharedSubscriptions = CopyOnWriteArrayList<RegionEngine.Subscription>()
+    private val playerSubscriptions = ConcurrentHashMap<UUID, List<RegionEngine.Subscription>>()
+
+    /**
+     * Resolved once at initialize, because [Query.find] filters the whole entry library and
+     * [bindFor] would otherwise run three of those while a player is logging in.
+     */
+    @Volatile
+    private var perPlayerEntries: List<RegionEventEntry> = emptyList()
+
+    override suspend fun initialize() {
+        server.pluginManager.registerEvents(this, plugin)
+        reportUnresolvedRegions()
+
+        perPlayerEntries = regionEventEntries().filterNot { it.isShared() }
+        bindShared()
+        // On the main thread because the server's list is the one PlayerList mutates there.
+        withContext(Dispatchers.Sync) { server.onlinePlayers.toList() }.forEach(::bindFor)
+    }
+
+    private fun regionEventEntries(): List<RegionEventEntry> =
+        Query.find<RegionEnterEventEntry>().toList() +
+                Query.find<RegionExitEventEntry>().toList() +
+                Query.find<RegionProximityEventEntry>().toList()
+
+    /**
+     * Names every event entry whose region does not resolve. Binding one is a no op, so the
+     * entry sits on the page looking configured and never fires. Deleting the definition an
+     * event points at is the easiest way to get there.
+     */
+    private fun reportUnresolvedRegions() {
+        val unresolved = (
+                Query.find<RegionEnterEventEntry>() +
+                        Query.find<RegionExitEventEntry>() +
+                        Query.find<RegionProximityEventEntry>()
+                ).filter { it.region.resolveDefinition() == null }
+
+        for (entry in unresolved) {
+            logger.warning("Region event '${entry.name}' points at a region that does not resolve, so it never fires.")
+        }
+    }
+
+    override suspend fun shutdown() {
+        HandlerList.unregisterAll(this)
+        sharedSubscriptions.forEach(RegionEngine.Subscription::cancel)
+        sharedSubscriptions.clear()
+        playerSubscriptions.values.forEach { it.forEach(RegionEngine.Subscription::cancel) }
+        playerSubscriptions.clear()
+    }
+
+    @EventHandler
+    fun onJoin(event: PlayerJoinEvent) = bindFor(event.player)
+
+    // MONITOR so the engine's LOWEST priority quit dispatch fires final leave events
+    // before these subscriptions are cancelled.
+    @EventHandler(priority = EventPriority.MONITOR)
+    fun onQuit(event: PlayerQuitEvent) {
+        playerSubscriptions.remove(event.player.uniqueId)?.forEach(RegionEngine.Subscription::cancel)
+    }
+
+    private fun bindShared() {
+        for (entry in regionEventEntries()) {
+            if (!entry.isShared()) continue
+            engine.observe(entry.region, null, handlerFor(entry, tracked = null))
+                ?.let(sharedSubscriptions::add)
+        }
+    }
+
+    private fun bindFor(player: Player) {
+        // A player can quit between the roster snapshot and this bind. Their subscriptions would
+        // hold a tracker that holds them, and only their own reconnect would ever cancel it.
+        if (!player.isOnline) return
+        // The subscriptions are taken outside the map update. Resolving a region evaluates its
+        // placement variables,
+        // which is user code, and a variable that reaches back into the binder from inside the
+        // update would deadlock on the bin it holds. A join racing a reload binds twice, and the
+        // set that loses the put is cancelled by the one that wins.
+        val fresh = perPlayerEntries.mapNotNull { entry ->
+            engine.observe(entry.region, player, handlerFor(entry, tracked = player.uniqueId))
+        }
+        playerSubscriptions.put(player.uniqueId, fresh)?.forEach(RegionEngine.Subscription::cancel)
+    }
+
+    private fun handlerFor(entry: RegionEventEntry, tracked: UUID?): RegionHandler = when (entry) {
+        is RegionEnterEventEntry -> enterHandler(entry, tracked)
+        is RegionExitEventEntry -> exitHandler(entry, tracked)
+        is RegionProximityEventEntry -> proximityHandler(entry, tracked)
+        else -> error("Unknown region event entry ${entry::class.simpleName}")
+    }
+
+    private fun RegionEventEntry.isShared(): Boolean =
+        region.resolveDefinition()?.hasConstPlacement == true
+
+    private fun enterHandler(entry: RegionEnterEventEntry, tracked: UUID?) = EnterExitHandler(
+        owner = entry,
+        tracked = tracked,
+        boundaryInset = entry.boundaryInset,
+        onEnter = { player, cause, _ -> RegionEventDispatch.fireEnter(entry, player, cause) },
+    )
+
+    private fun exitHandler(entry: RegionExitEventEntry, tracked: UUID?) = EnterExitHandler(
+        owner = entry,
+        tracked = tracked,
+        boundaryInset = entry.boundaryInset,
+        onLeave = { player, cause, _ -> RegionEventDispatch.fireExit(entry, player, cause) },
+    )
+
+    private fun proximityHandler(entry: RegionProximityEventEntry, tracked: UUID?) = ProximityHandler(
+        owner = entry,
+        tracked = tracked,
+        distance = entry.distance,
+        distanceMode = entry.distanceMode,
+        boundaryInset = entry.boundaryInset,
+        onEnterBand = { player, cause, _ -> RegionEventDispatch.fireProximity(entry, player, cause) },
+        onLeaveBand = { player, cause, _ -> RegionEventDispatch.fireProximity(entry, player, cause) },
+    )
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/BoundaryPreview.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/BoundaryPreview.kt
@@ -1,0 +1,96 @@
+package com.typewritermc.region.content
+
+import com.github.retrooper.packetevents.protocol.particle.data.ParticleDustData
+import com.github.retrooper.packetevents.protocol.particle.type.ParticleTypes
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerParticle
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.engine.paper.extensions.packetevents.sendPacketTo
+import com.typewritermc.engine.paper.snippets.snippet
+import com.typewritermc.engine.paper.utils.Color
+import com.typewritermc.engine.paper.utils.toPacketVector3d
+import com.typewritermc.engine.paper.utils.toPacketVector3f
+import com.typewritermc.region.data.ResolvedTransform
+import com.typewritermc.region.shape.Shape
+import io.github.retrooper.packetevents.util.SpigotConversionUtil
+import org.bukkit.Location
+import org.bukkit.entity.Player
+import com.github.retrooper.packetevents.protocol.particle.Particle as PacketParticle
+
+internal val previewRenderDistance by snippet(
+    "region.content.preview_render_distance",
+    48.0,
+    "Max distance in blocks from the player at which region editor preview particles render.",
+)
+
+internal val previewDensity by snippet(
+    "region.content.preview_density",
+    0.1,
+    "Samples per unit boundary area for region editor shape previews.",
+)
+
+internal const val MAX_PREVIEW_PARTICLES = 512
+private const val SURFACE_DUST_SIZE = 1.4f
+
+/**
+ * A sparse dust sampling of the boundary surface. The editor renders it between the solid
+ * display entity edge lines, capped at [MAX_PREVIEW_PARTICLES] and limited by the
+ * `region.content.preview_render_distance` and `region.content.preview_density` snippets.
+ */
+internal fun renderSurfacePreview(
+    player: Player,
+    transform: ResolvedTransform,
+    shape: Shape,
+    color: Color,
+    budget: ParticleBudget = ParticleBudget(MAX_PREVIEW_PARTICLES),
+) {
+    if (transform.world.identifier != player.world.uid.toString()) return
+
+    val eye = player.location
+    for (local in shape.sampleBoundary(previewDensity)) {
+        val worldPos = transform.toWorld(local)
+        if (!withinPreviewDistance(worldPos, eye)) continue
+        if (!budget.take()) return
+        emitDustParticle(player, worldPos, color, SURFACE_DUST_SIZE)
+    }
+}
+
+/** A per tick particle cap shared by the edge and surface passes. */
+internal class ParticleBudget(private var remaining: Int) {
+    fun take(): Boolean {
+        if (remaining <= 0) return false
+        remaining -= 1
+        return true
+    }
+}
+
+internal fun withinPreviewDistance(worldPos: Vector, eye: Location): Boolean {
+    val dx = worldPos.x - eye.x
+    val dy = worldPos.y - eye.y
+    val dz = worldPos.z - eye.z
+    return dx * dx + dy * dy + dz * dz <= previewRenderDistance * previewRenderDistance
+}
+
+/** A single particle of any type, used for capture markers. */
+internal fun emitPreviewParticle(player: Player, worldPos: Vector, particle: org.bukkit.Particle) {
+    WrapperPlayServerParticle(
+        PacketParticle(SpigotConversionUtil.fromBukkitParticle(particle)),
+        true,
+        worldPos.toPacketVector3d(),
+        Vector.ZERO.toPacketVector3f(),
+        0f,
+        1,
+        true,
+    ) sendPacketTo player
+}
+
+internal fun emitDustParticle(player: Player, worldPos: Vector, color: Color, size: Float) {
+    WrapperPlayServerParticle(
+        PacketParticle(ParticleTypes.DUST, ParticleDustData(size, color.red, color.green, color.blue)),
+        true,
+        worldPos.toPacketVector3d(),
+        Vector.ZERO.toPacketVector3f(),
+        0f,
+        1,
+        true,
+    ) sendPacketTo player
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/EditHistory.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/EditHistory.kt
@@ -1,0 +1,227 @@
+package com.typewritermc.region.content
+
+import java.util.concurrent.ConcurrentLinkedDeque
+
+/**
+ * Bounded undo and redo history over named state values. Each recorded change stores which
+ * tool made it and the before and after values of only the keys it touched, all values
+ * absolute: undoing a change applies its before values, redoing applies its after values.
+ *
+ * Tool scoped undo removes the tool's newest entry out of order, which is safe exactly
+ * when no newer entry touches any of its keys; otherwise the result is
+ * [ToolHistoryResult.Entangled] and nothing moves. Entries are never mutated or consumed
+ * by a refusal, so the global history can always unwind in order.
+ *
+ * Bursts of the same gesture, like scroll notches, collapse into one entry when recorded
+ * with a coalesce window. A burst is bounded by the gap between notches and by a total
+ * duration cap, keys that return to their start value drop out on merge, and an entry
+ * left without an effect pops off the stack. Entries recorded without a window never
+ * coalesce, so a click never absorbs a following scroll.
+ *
+ * Mutations happen on the server main thread. The deques are concurrent because the
+ * editor's async tick reads the counts for the undo item and the hologram.
+ */
+internal class EditHistory(private val capacity: Int = DEFAULT_CAPACITY) {
+    private val undoStack = ConcurrentLinkedDeque<HistoryEntry>()
+    private val redoStack = ConcurrentLinkedDeque<HistoryEntry>()
+
+    init {
+        require(capacity > 0) { "History capacity must be positive, got $capacity" }
+    }
+
+    val undoCount: Int get() = undoStack.size
+    val redoCount: Int get() = redoStack.size
+
+    /**
+     * Records the difference between [before] and [after]. Returns `false` when nothing
+     * changed. A recorded change makes the redo entries unreachable, so they are dropped.
+     * With a positive [coalesceMillis] the change joins a coalescible top entry carrying
+     * the same [tool] and [label] when the gap and the total burst duration allow it.
+     */
+    fun record(
+        tool: String,
+        label: String,
+        before: Map<String, Any?>,
+        after: Map<String, Any?>,
+        coalesceMillis: Long = 0,
+        now: Long = System.currentTimeMillis(),
+    ): Boolean {
+        val delta = changedDelta(before, after) ?: return false
+        redoStack.clear()
+
+        val top = undoStack.peekFirst()
+        if (top != null && coalesceMillis > 0 && top.coalescible && top.tool == tool && top.label == label &&
+            now - top.lastRecordedAt < coalesceMillis && now - top.firstRecordedAt < MAX_BURST_MILLIS
+        ) {
+            if (!top.merge(delta, now)) undoStack.removeFirstOccurrence(top)
+            return true
+        }
+
+        undoStack.addFirst(
+            HistoryEntry(
+                tool = tool,
+                label = label,
+                before = delta.before,
+                after = delta.after,
+                firstRecordedAt = now,
+                lastRecordedAt = now,
+                coalescible = coalesceMillis > 0,
+            ),
+        )
+        while (undoStack.size > capacity) undoStack.pollLast()
+        return true
+    }
+
+    /** The newest change; the caller applies [RestoredChange.values]. */
+    fun undoLast(): RestoredChange? {
+        val entry = undoStack.pollFirst() ?: return null
+        redoStack.addFirst(entry)
+        return RestoredChange(entry.label, entry.before, 1)
+    }
+
+    fun redoLast(): RestoredChange? {
+        val entry = redoStack.pollFirst() ?: return null
+        undoStack.addFirst(entry)
+        return RestoredChange(entry.label, entry.after, 1)
+    }
+
+    /**
+     * Every change merged into one restore, oldest before values winning per key. The
+     * entries move to the redo stack one by one, so they can still be redone step by step.
+     */
+    fun undoAll(): RestoredChange? {
+        if (undoStack.isEmpty()) return null
+        val values = mutableMapOf<String, Any?>()
+        var count = 0
+        var label = ""
+        while (true) {
+            val entry = undoStack.pollFirst() ?: break
+            redoStack.addFirst(entry)
+            values.putAll(entry.before)
+            label = entry.label
+            count++
+        }
+        return RestoredChange(if (count == 1) label else "$count changes", values, count)
+    }
+
+    fun redoAll(): RestoredChange? {
+        if (redoStack.isEmpty()) return null
+        val values = mutableMapOf<String, Any?>()
+        var count = 0
+        var label = ""
+        while (true) {
+            val entry = redoStack.pollFirst() ?: break
+            undoStack.addFirst(entry)
+            values.putAll(entry.after)
+            label = entry.label
+            count++
+        }
+        return RestoredChange(if (count == 1) label else "$count changes", values, count)
+    }
+
+    /**
+     * Undoes [tool]'s newest change while keeping every other tool's work in place. The
+     * entry is removed out of order, which is only safe when nothing newer touches its
+     * keys: otherwise the result is [ToolHistoryResult.Entangled] naming the tool whose
+     * newer change overlaps, nothing moves, and the arrow can unwind the history in order.
+     */
+    fun undoTool(tool: String): ToolHistoryResult {
+        val entries = undoStack.toList()
+        val index = entries.indexOfFirst { it.tool == tool }
+        if (index < 0) return ToolHistoryResult.NothingLeft
+
+        val entry = entries[index]
+        val blocker = entries.subList(0, index).firstOrNull { newer -> newer.keys.any(entry.keys::contains) }
+        if (blocker != null) return ToolHistoryResult.Entangled(blocker.tool)
+
+        undoStack.removeFirstOccurrence(entry)
+        redoStack.addFirst(entry)
+        return ToolHistoryResult.Restored(RestoredChange(entry.label, entry.before, 1))
+    }
+
+    /**
+     * Redoes [tool]'s newest undone change: the mirror of [undoTool] on the redo stack,
+     * with the same out of order rule against the redo entries in front of it.
+     */
+    fun redoTool(tool: String): ToolHistoryResult {
+        val entries = redoStack.toList()
+        val index = entries.indexOfFirst { it.tool == tool }
+        if (index < 0) return ToolHistoryResult.NothingLeft
+
+        val entry = entries[index]
+        val blocker = entries.subList(0, index).firstOrNull { ahead -> ahead.keys.any(entry.keys::contains) }
+        if (blocker != null) return ToolHistoryResult.Entangled(blocker.tool)
+
+        redoStack.removeFirstOccurrence(entry)
+        undoStack.addFirst(entry)
+        return ToolHistoryResult.Restored(RestoredChange(entry.label, entry.after, 1))
+    }
+
+    private class HistoryEntry(
+        val tool: String,
+        val label: String,
+        before: Map<String, Any?>,
+        after: Map<String, Any?>,
+        val firstRecordedAt: Long,
+        @Volatile var lastRecordedAt: Long,
+        val coalescible: Boolean,
+    ) {
+        @Volatile
+        var before: Map<String, Any?> = before
+            private set
+
+        @Volatile
+        var after: Map<String, Any?> = after
+            private set
+
+        val keys: Set<String> get() = before.keys
+
+        /**
+         * Joins a burst continuation into this entry, keeping the oldest before and the
+         * newest after per key and dropping keys that returned to their start value.
+         * Returns `false` when no key changes anything anymore; the caller pops the entry.
+         */
+        fun merge(changed: Delta, now: Long): Boolean {
+            val merged = changedDelta(changed.before + before, after + changed.after) ?: return false
+            before = merged.before
+            after = merged.after
+            lastRecordedAt = now
+            return true
+        }
+    }
+
+    /** The values to apply to the working state, all keys absolute. */
+    data class RestoredChange(val label: String, val values: Map<String, Any?>, val count: Int)
+
+    companion object {
+        private const val DEFAULT_CAPACITY = 64
+        internal const val MAX_BURST_MILLIS = 4000L
+    }
+}
+
+/** The outcome of a tool scoped undo or redo. */
+internal sealed interface ToolHistoryResult {
+    /** The entry moved and [change] holds the values to apply. */
+    data class Restored(val change: EditHistory.RestoredChange) : ToolHistoryResult
+
+    /** A newer change by [blockingTool] overlaps the entry's keys; nothing moved. */
+    data class Entangled(val blockingTool: String) : ToolHistoryResult
+
+    /** The tool has no entry to move. */
+    data object NothingLeft : ToolHistoryResult
+}
+
+/** A change reduced to the keys whose value actually moved, absolute on both sides. */
+private class Delta(val before: Map<String, Any?>, val after: Map<String, Any?>)
+
+/**
+ * The [Delta] between [before] and [after], or `null` when nothing changed. Recording and
+ * burst merging share this rule, so both always agree on what counts as a change and every
+ * entry's before and after maps stay on the same key set, which the tool undo conflict
+ * check relies on.
+ */
+private fun changedDelta(before: Map<String, Any?>, after: Map<String, Any?>): Delta? {
+    val changedKeys = (before.keys + after.keys).filter { before[it] != after[it] }
+    if (changedKeys.isEmpty()) return null
+    return Delta(changedKeys.associateWith { before[it] }, changedKeys.associateWith { after[it] })
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/EditorHologram.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/EditorHologram.kt
@@ -1,0 +1,68 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.engine.paper.plugin
+import com.typewritermc.engine.paper.utils.asMini
+import org.bukkit.Color
+import org.bukkit.Location
+import org.bukkit.entity.Display
+import org.bukkit.entity.Player
+import org.bukkit.entity.TextDisplay
+
+/**
+ * A floating readout above the edited region, visible only to the editing player. The
+ * display interpolates teleports, so it glides along while the region is carried.
+ *
+ * Every method must run on the server main thread; the content mode hops to the sync
+ * dispatcher for its per tick update.
+ */
+internal class EditorHologram(private val player: Player) {
+    private var display: TextDisplay? = null
+    private var lastText: String? = null
+
+    fun update(anchor: Location?, text: String) {
+        if (anchor == null || anchor.world != player.world ||
+            anchor.distanceSquared(player.location) > RANGE_SQUARED
+        ) {
+            despawn()
+            return
+        }
+        // world.spawn force loads its chunk, and a hologram in an unloaded chunk is not
+        // visible anyway, so it is skipped until the chunk loads.
+        if (!anchor.world.isChunkLoaded(anchor.blockX shr 4, anchor.blockZ shr 4)) {
+            despawn()
+            return
+        }
+
+        val current = display?.takeIf { it.isValid } ?: spawn(anchor)
+        if (current.location.distanceSquared(anchor) > MOVE_EPSILON_SQUARED) current.teleport(anchor)
+        if (text != lastText) {
+            lastText = text
+            current.text(text.asMini())
+        }
+    }
+
+    fun despawn() {
+        display?.remove()
+        display = null
+        lastText = null
+    }
+
+    private fun spawn(location: Location): TextDisplay =
+        location.world.spawn(location, TextDisplay::class.java) { hologram ->
+            hologram.isPersistent = false
+            hologram.isVisibleByDefault = false
+            hologram.billboard = Display.Billboard.CENTER
+            hologram.isSeeThrough = true
+            hologram.teleportDuration = 2
+            hologram.alignment = TextDisplay.TextAlignment.CENTER
+            hologram.backgroundColor = Color.fromARGB(0xB4, 0x11, 0x12, 0x1A)
+            hologram.brightness = Display.Brightness(15, 15)
+            hologram.lineWidth = 220
+            player.showEntity(plugin, hologram)
+        }.also { display = it }
+
+    companion object {
+        private const val RANGE_SQUARED = 96.0 * 96.0
+        private const val MOVE_EPSILON_SQUARED = 0.0025
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/EditorInput.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/EditorInput.kt
@@ -1,0 +1,321 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.core.utils.point.Vector
+import org.bukkit.GameMode
+import org.bukkit.Location
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerGameModeChangeEvent
+import org.bukkit.event.player.PlayerInputEvent
+import org.bukkit.event.player.PlayerItemHeldEvent
+import org.bukkit.event.player.PlayerMoveEvent
+import org.bukkit.event.player.PlayerQuitEvent
+import org.bukkit.event.player.PlayerRespawnEvent
+import org.bukkit.event.player.PlayerTeleportEvent
+import kotlin.math.abs
+import kotlin.math.floor
+
+/**
+ * Turns hotbar scrolling into tool input. Minecraft has no scroll packet, so the held slot
+ * change is the signal. The handler returns `true` to consume the scroll, which cancels
+ * the slot switch and keeps the tool in hand; returning `false` lets the player switch
+ * items normally.
+ *
+ * A consumed scroll also resends the held slot, because the client has already switched by
+ * the time the cancelled packet arrives and can be left showing the wrong slot. And for
+ * [CONSUME_GRACE_MILLIS] after a consumed scroll every further notch is swallowed even when
+ * the handler declines it, so releasing sneak a moment before the wheel stops cannot switch
+ * the hotbar away from the tool mid gesture.
+ */
+internal class ScrollListener(
+    private val player: Player,
+    private val onScroll: (heldSlot: Int, steps: Int) -> Boolean,
+) : Listener {
+    private var lastConsumedAt = 0L
+
+    @EventHandler
+    fun onHeldItemChange(event: PlayerItemHeldEvent) {
+        if (event.player.uniqueId != player.uniqueId) return
+        val steps = scrollSteps(event.previousSlot, event.newSlot)
+        if (steps == 0) return
+        val now = System.currentTimeMillis()
+        val withinGrace = now - lastConsumedAt <= CONSUME_GRACE_MILLIS
+        // A hotbar key arrives as the same packet as a wheel notch, and the two cannot be told
+        // apart. The wheel only ever sends one notch per packet, so a wider jump is a builder
+        // reaching for a tool, and answering it as a gesture would edit the geometry and refuse
+        // the tool change at once. Inside the grace window it is the client catching up on
+        // notches already answered, and letting those through would switch the hotbar away from
+        // the tool mid gesture. A key press onto the neighbouring slot stays ambiguous either way.
+        if (steps > 1 || steps < -1) {
+            if (!withinGrace) return
+            event.isCancelled = true
+            player.inventory.heldItemSlot = event.previousSlot
+            return
+        }
+        val consumed = onScroll(event.previousSlot, steps)
+        if (!consumed && !withinGrace) return
+        if (consumed) lastConsumedAt = now
+        event.isCancelled = true
+        player.inventory.heldItemSlot = event.previousSlot
+    }
+
+    private companion object {
+        const val CONSUME_GRACE_MILLIS = 250L
+    }
+}
+
+/** A key command from the locked spectator editing state. */
+internal enum class SpectatorKey { FORWARD, BACKWARD, LEFT, RIGHT, UP, DOWN, MARK }
+
+/** A recognized spectator gesture: the lock toggle chord, the free flight secondary chord, or a locked key. */
+internal sealed interface SpectatorSignal {
+    data object LockChord : SpectatorSignal
+    data object SecondaryChord : SpectatorSignal
+    data class Key(val key: SpectatorKey) : SpectatorSignal
+}
+
+/**
+ * Interprets the raw spectator key states. A spectator client sends no left click, drop,
+ * swap or hotbar packets (the vanilla client gates them out), but right clicks do arrive,
+ * so those carry the click duties while the key states drive everything else.
+ *
+ * Jump plus sneak is the lock toggle in both states. Unlocked, sprint plus sneak is the
+ * secondary gesture. Locked, WASD fire on press and sprint is [SpectatorKey.MARK]; jump
+ * and sneak fire [SpectatorKey.UP] and [SpectatorKey.DOWN] on RELEASE, so a hold that
+ * turns into the lock chord never also counts as a nudge.
+ */
+internal class SpectatorInputTracker {
+    private var forward = false
+    private var backward = false
+    private var left = false
+    private var right = false
+    private var jump = false
+    private var sneak = false
+    private var sprint = false
+    private var jumpConsumed = false
+    private var sneakConsumed = false
+    private var lockChordHeld = false
+    private var secondaryChordHeld = false
+
+    fun update(
+        locked: Boolean,
+        forward: Boolean,
+        backward: Boolean,
+        left: Boolean,
+        right: Boolean,
+        jump: Boolean,
+        sneak: Boolean,
+        sprint: Boolean,
+    ): List<SpectatorSignal> {
+        val signals = mutableListOf<SpectatorSignal>()
+
+        val lockChord = jump && sneak
+        if (lockChord && !lockChordHeld) {
+            signals += SpectatorSignal.LockChord
+            jumpConsumed = true
+            sneakConsumed = true
+        }
+        val secondaryChord = sneak && sprint
+        if (!locked && secondaryChord && !secondaryChordHeld && !lockChord && !lockChordHeld) {
+            signals += SpectatorSignal.SecondaryChord
+            sneakConsumed = true
+        }
+
+        if (locked && signals.isEmpty()) {
+            if (forward && !this.forward) signals += SpectatorSignal.Key(SpectatorKey.FORWARD)
+            if (backward && !this.backward) signals += SpectatorSignal.Key(SpectatorKey.BACKWARD)
+            if (left && !this.left) signals += SpectatorSignal.Key(SpectatorKey.LEFT)
+            if (right && !this.right) signals += SpectatorSignal.Key(SpectatorKey.RIGHT)
+            if (sprint && !this.sprint) {
+                signals += SpectatorSignal.Key(SpectatorKey.MARK)
+                // A jump or sneak held through a mark reads as a modifier, not a pending nudge.
+                if (jump) jumpConsumed = true
+                if (sneak) sneakConsumed = true
+            }
+            if (!jump && this.jump && !jumpConsumed) signals += SpectatorSignal.Key(SpectatorKey.UP)
+            if (!sneak && this.sneak && !sneakConsumed) signals += SpectatorSignal.Key(SpectatorKey.DOWN)
+        }
+
+        if (!jump) jumpConsumed = false
+        if (!sneak) sneakConsumed = false
+        this.forward = forward
+        this.backward = backward
+        this.left = left
+        this.right = right
+        this.jump = jump
+        this.sneak = sneak
+        this.sprint = sprint
+        lockChordHeld = lockChord
+        secondaryChordHeld = secondaryChord
+        return signals
+    }
+}
+
+/**
+ * The spectator control scheme of the region editor.
+ *
+ * Free flight: jump + sneak locks the player in place, sprint + sneak is the secondary
+ * gesture. Locked: the mode freezes movement with fly speed zero while [anchor] pins the
+ * position against the client side scroll speed override, the camera stays free so the
+ * player can still aim, and every key state change arrives here as a tool command. A
+ * teleport, a game mode change or a quit while locked forces a release, so the frozen fly
+ * speed can never leak out of the editing state.
+ */
+internal class SpectatorInputListener(
+    private val player: Player,
+    private val anchor: () -> Location?,
+    private val onLockChord: () -> Unit,
+    private val onSecondaryChord: () -> Unit,
+    private val onKey: (SpectatorKey) -> Unit,
+    private val onForcedRelease: () -> Unit,
+) : Listener {
+    private val tracker = SpectatorInputTracker()
+
+    @EventHandler
+    fun onInput(event: PlayerInputEvent) {
+        if (event.player.uniqueId != player.uniqueId) return
+        if (event.player.gameMode != GameMode.SPECTATOR) return
+        val input = event.input
+        val signals = tracker.update(
+            locked = anchor() != null,
+            forward = input.isForward,
+            backward = input.isBackward,
+            left = input.isLeft,
+            right = input.isRight,
+            jump = input.isJump,
+            sneak = input.isSneak,
+            sprint = input.isSprint,
+        )
+        for (signal in signals) {
+            when (signal) {
+                SpectatorSignal.LockChord -> onLockChord()
+                SpectatorSignal.SecondaryChord -> onSecondaryChord()
+                is SpectatorSignal.Key -> onKey(signal.key)
+            }
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    fun onMove(event: PlayerMoveEvent) {
+        if (event is PlayerTeleportEvent) return
+        if (event.player.uniqueId != player.uniqueId) return
+        val anchor = anchor() ?: return
+        val to = event.to
+        if (to.x == anchor.x && to.y == anchor.y && to.z == anchor.z) return
+        event.to = anchor.clone().apply {
+            yaw = to.yaw
+            pitch = to.pitch
+        }
+    }
+
+    @EventHandler
+    fun onTeleport(event: PlayerTeleportEvent) {
+        if (event.player.uniqueId != player.uniqueId) return
+        val anchor = anchor() ?: return
+        if (!leavesAnchor(event.to, anchor)) return
+        onForcedRelease()
+    }
+
+    @EventHandler
+    fun onGameModeChange(event: PlayerGameModeChangeEvent) {
+        if (event.player.uniqueId != player.uniqueId) return
+        if (event.newGameMode == GameMode.SPECTATOR) return
+        if (anchor() != null) onForcedRelease()
+    }
+
+    // Fly speed is written to the player file, and the content mode's teardown restores it
+    // several suspend hops after the quit, past the save in this tick. Without a synchronous
+    // release here the player reconnects with fly speed zero.
+    @EventHandler(priority = EventPriority.LOWEST)
+    fun onQuit(event: PlayerQuitEvent) {
+        if (event.player.uniqueId != player.uniqueId) return
+        if (anchor() != null) onForcedRelease()
+    }
+}
+
+/**
+ * Whether a teleport destination actually leaves the lock [anchor]. The position pin
+ * rewrites drifting moves back onto the anchor, and Paper delivers a modified move
+ * destination as a PLUGIN teleport to that exact spot, so releasing on every teleport
+ * would unlock in the same instant the lock engages.
+ */
+internal fun leavesAnchor(to: Location, anchor: Location): Boolean =
+    to.world != anchor.world ||
+            abs(to.x - anchor.x) > PIN_EPSILON ||
+            abs(to.y - anchor.y) > PIN_EPSILON ||
+            abs(to.z - anchor.z) > PIN_EPSILON
+
+private const val PIN_EPSILON = 1e-6
+
+/** The world axis cardinal the yaw looks along. Minecraft yaw: 0 = +Z, 90 = -X, 180 = -Z, 270 = +X. */
+internal fun cardinalFromYaw(yaw: Float): Vector = when (Math.floorMod(Math.round(yaw / 90f), 4)) {
+    0 -> Vector(0.0, 0.0, 1.0)
+    1 -> Vector(-1.0, 0.0, 0.0)
+    2 -> Vector(0.0, 0.0, -1.0)
+    else -> Vector(1.0, 0.0, 0.0)
+}
+
+/** The world direction a locked spectator key nudges toward, relative to the [yaw] facing. */
+internal fun spectatorKeyDirection(key: SpectatorKey, yaw: Float): Vector? {
+    val facing = cardinalFromYaw(yaw)
+    return when (key) {
+        SpectatorKey.FORWARD -> facing
+        SpectatorKey.BACKWARD -> facing * -1.0
+        SpectatorKey.LEFT -> Vector(facing.z, 0.0, -facing.x)
+        SpectatorKey.RIGHT -> Vector(-facing.z, 0.0, facing.x)
+        SpectatorKey.UP -> Vector(0.0, 1.0, 0.0)
+        SpectatorKey.DOWN -> Vector(0.0, -1.0, 0.0)
+        SpectatorKey.MARK -> null
+    }
+}
+
+/**
+ * Ends a gesture when the player is moved by something the editor did not do.
+ *
+ * A carried region, a grabbed face and a carried polygon corner are all measured from the eye and
+ * followed every tick, so a teleport, a portal or a respawn drags them along to wherever the
+ * player lands. The editor's own teleport tool refuses to run mid gesture; nothing else asks
+ * permission first.
+ *
+ * The spectator lock pins the player by rewriting their movement, which the server delivers as a
+ * teleport of its own, so a destination that does not leave [anchor] is the lock holding them
+ * still rather than anything moving them.
+ */
+internal class DisplacementListener(
+    private val player: Player,
+    private val anchor: () -> Location?,
+    private val onDisplaced: () -> Unit,
+) : Listener {
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    fun onTeleport(event: PlayerTeleportEvent) {
+        if (event.player.uniqueId != player.uniqueId) return
+        val anchor = anchor()
+        if (anchor != null && !leavesAnchor(event.to, anchor)) return
+        onDisplaced()
+    }
+
+    @EventHandler
+    fun onRespawn(event: PlayerRespawnEvent) {
+        if (event.player.uniqueId != player.uniqueId) return
+        onDisplaced()
+    }
+}
+
+/**
+ * Scroll notches between two hotbar slots, positive when the wheel scrolls up. The hotbar
+ * wraps around, so the shortest way around is the scrolled amount.
+ */
+internal fun scrollSteps(previousSlot: Int, newSlot: Int): Int {
+    var delta = newSlot - previousSlot
+    if (delta > 4) delta -= 9
+    if (delta < -4) delta += 9
+    return -delta
+}
+
+/** Rounds to the half block grid carried regions snap onto. */
+internal fun snapToHalfGrid(value: Double): Double = floor(value * 2.0 + 0.5) / 2.0
+
+/** Rounds to the quarter block grid face drags snap onto. */
+internal fun snapToQuarterGrid(value: Double): Double = floor(value * 4.0 + 0.5) / 4.0

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/GuideGeometry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/GuideGeometry.kt
@@ -1,0 +1,390 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.region.shape.LocalBounds
+import kotlin.math.abs
+import kotlin.math.atan2
+import kotlin.math.ceil
+import kotlin.math.cos
+import kotlin.math.roundToInt
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+internal const val GUIDE_THICKNESS = 0.16f
+
+/** Beyond this distance from the region origin, the guides anchor near the player instead. */
+internal const val GUIDE_NEAR_RANGE = 24.0
+
+/** The axis length used when the guide is anchored at the boundary instead of the origin. */
+internal const val FAR_ANCHOR_AXIS_LENGTH = 8.0
+
+/** Far anchored rings only draw the arc within this range of the player. */
+internal const val RING_VISIBLE_RANGE = 48.0
+
+private const val AXIS_MARGIN = 1.0
+private const val MIN_AXIS_LENGTH = 2.0
+private const val MAX_AXIS_LENGTH = 24.0
+private const val GUIDE_PIECE_LENGTH = 4.0
+private const val ARROW_HEAD_FRACTION = 0.18
+private const val MIN_ARROW_HEAD = 0.5
+private const val MAX_ARROW_HEAD = 1.5
+private const val ARROW_ANGLE_DEGREES = 30.0
+private const val PRONG_SNAP_DEGREES = 15.0
+
+private const val RING_MARGIN = 0.5
+private const val MIN_RING_RADIUS = 1.25
+
+// The ring is a compact gizmo at the origin, not a hoop around the region: the outline
+// already shows the rotation live, so past this radius the ring only gets harder to read.
+private const val MAX_NEAR_RING_RADIUS = 8.0
+private const val RING_SEGMENT_LENGTH = 3.0
+private const val MIN_RING_SEGMENTS = 16
+private const val MAX_RING_SEGMENTS = 96
+
+/** The twelve edges of a unit cube, relative to its minimum corner. */
+internal val BLOCK_OUTLINE_SEGMENTS: List<Pair<Vector, Vector>> = buildList {
+    val axes = listOf(Vector(1.0, 0.0, 0.0), Vector(0.0, 1.0, 0.0), Vector(0.0, 0.0, 1.0))
+    for (axis in axes) {
+        val (u, v) = axes.filter { it != axis }
+        add(Vector.ZERO to axis)
+        add(u to u + axis)
+        add(v to v + axis)
+        add(u + v to u + v + axis)
+    }
+}
+
+/** The half extent of [bounds] along the world axis [direction] points down. */
+internal fun halfExtentAlong(bounds: LocalBounds, direction: Vector): Double {
+    val x = (bounds.maxX - bounds.minX) / 2
+    val y = (bounds.maxY - bounds.minY) / 2
+    val z = (bounds.maxZ - bounds.minZ) / 2
+    return when {
+        abs(direction.y) > abs(direction.x) && abs(direction.y) > abs(direction.z) -> y
+        abs(direction.x) >= abs(direction.z) -> x
+        else -> z
+    }
+}
+
+/**
+ * How far the move guide reaches: proportional to the region so a small one gets a small
+ * arrow, but never so short that it disappears, nor so long that it stretches out of sight.
+ */
+internal fun moveAxisLength(bounds: LocalBounds, direction: Vector): Double =
+    (halfExtentAlong(bounds, direction) + AXIS_MARGIN)
+        .coerceIn(MIN_AXIS_LENGTH, MAX_AXIS_LENGTH)
+
+/**
+ * A segment cut into pieces of at most [pieceLength] blocks. Each guide piece gets its own
+ * display entity anchored where it is drawn, so a long axis still reaches the client when
+ * the player stands at its far end.
+ */
+internal fun splitGuideSegment(
+    from: Vector,
+    to: Vector,
+    pieceLength: Double = GUIDE_PIECE_LENGTH,
+): List<Pair<Vector, Vector>> {
+    val count = ceil((to - from).length / pieceLength).toInt().coerceAtLeast(1)
+    return (0 until count).map { index ->
+        lerp(from, to, index.toDouble() / count) to lerp(from, to, (index + 1).toDouble() / count)
+    }
+}
+
+/**
+ * The direction the arrowhead prongs spread along: perpendicular to the axis, and chosen so
+ * the flat arrow faces the viewer looking along [viewDirection]. Snapped to
+ * [PRONG_SNAP_DEGREES] steps so the guide does not render again on every step the player takes.
+ * Falls back to an arbitrary perpendicular when the view runs along the axis.
+ */
+internal fun prongBasis(axis: Vector, viewDirection: Vector): Vector {
+    val (u, v) = perpendicularBasis(axis)
+    val raw = viewDirection.cross(axis)
+    if (raw.length < 1e-6) return u
+    val angle = atan2(raw.dot(v), raw.dot(u))
+    val step = Math.toRadians(PRONG_SNAP_DEGREES)
+    val snapped = step * (angle / step).roundToInt()
+    return u * cos(snapped) + v * sin(snapped)
+}
+
+/**
+ * The move guide as anchor relative segments: the axis from the anchor along [direction],
+ * split so every piece's display stays near the player, and a flat two pronged arrowhead
+ * at the tip, rotated by [viewDirection] (viewer toward tip) so it always faces the player.
+ */
+internal fun moveGuideSegments(
+    bounds: LocalBounds,
+    direction: Vector,
+    viewDirection: Vector,
+    length: Double = moveAxisLength(bounds, direction),
+): List<Pair<Vector, Vector>> {
+    val axis = direction.normalize()
+    val tip = axis * length
+    val head = (length * ARROW_HEAD_FRACTION).coerceIn(MIN_ARROW_HEAD, MAX_ARROW_HEAD)
+    val angle = Math.toRadians(ARROW_ANGLE_DEGREES)
+    val back = axis * (-cos(angle) * head)
+    val spread = sin(angle) * head
+    val side = prongBasis(axis, viewDirection)
+
+    val prongs = listOf(side * spread, side * -spread).map { offset ->
+        tip to (tip + back + offset)
+    }
+    return splitGuideSegment(Vector.ZERO, tip) + prongs
+}
+
+internal const val PUSH_AXIS_REACH = 1.5
+
+private val POINT_BOUNDS = LocalBounds(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+/**
+ * The push axis of a selected polygon point: a line through the point along [direction],
+ * with the arrowhead on the push end only, so the bare tail marks the pull direction.
+ * [viewDirection] turns the flat arrowhead toward the viewer, like the move guide's.
+ */
+internal fun pushAxisSegments(
+    direction: Vector,
+    viewDirection: Vector,
+    reach: Double = PUSH_AXIS_REACH,
+): List<Pair<Vector, Vector>> =
+    listOf(direction * -reach to Vector.ZERO) +
+            moveGuideSegments(POINT_BOUNDS, direction, viewDirection, reach)
+
+/** The radius of the rotation ring: hugging a small region, capped to a compact gizmo. */
+internal fun rotationRingRadius(bounds: LocalBounds, pitchPlane: Boolean): Double {
+    val horizontal = maxOf(bounds.maxX - bounds.minX, bounds.maxZ - bounds.minZ) / 2
+    val vertical = (bounds.maxY - bounds.minY) / 2
+    val extent = if (pitchPlane) maxOf(horizontal, vertical) else horizontal
+    return (extent + RING_MARGIN).coerceIn(MIN_RING_RADIUS, MAX_NEAR_RING_RADIUS)
+}
+
+/**
+ * The radius of a far anchored rotation ring. It passes through the player while they are
+ * inside the region, tracing the arc their own spot would sweep, but it never grows past
+ * the region's reach in the ring's plane: outside the region that arc says nothing about
+ * the rotation, so the ring falls back to the border radius. The near gizmo radius is the
+ * floor, which also keeps the ring drawable for a player standing on the rotation axis.
+ */
+internal fun farRingRadius(bounds: LocalBounds, playerDistance: Double, pitchPlane: Boolean): Double {
+    val lower = rotationRingRadius(bounds, pitchPlane)
+    val upper = (planarReach(bounds, pitchPlane) + RING_MARGIN).coerceAtLeast(lower)
+    return playerDistance.coerceIn(lower, upper)
+}
+
+/** The farthest [bounds] reaches from the anchor within the ring's plane. */
+private fun planarReach(bounds: LocalBounds, pitchPlane: Boolean): Double {
+    val x = maxOf(abs(bounds.minX), abs(bounds.maxX))
+    val y = maxOf(abs(bounds.minY), abs(bounds.maxY))
+    val z = maxOf(abs(bounds.minZ), abs(bounds.maxZ))
+    val radial = if (pitchPlane) y else x
+    return sqrt(radial * radial + z * z)
+}
+
+/** The center of [bounds], as an offset from the region anchor the guides hang on. */
+internal fun boundsCenter(bounds: LocalBounds): Vector = Vector(
+    (bounds.minX + bounds.maxX) / 2,
+    (bounds.minY + bounds.maxY) / 2,
+    (bounds.minZ + bounds.maxZ) / 2,
+)
+
+/**
+ * The tilt facing quantized to the region's own frame: whichever of the region's four
+ * horizontal cardinals (its yaw rotated forward and sideways axes, either way along each)
+ * lies nearest the viewer's direction toward the region, given as ([dx], [dz]). A tilt is
+ * then always a clean pitch or a clean roll of the region instead of a diagonal mix, and
+ * the dial only renders again when the player crosses into another quadrant. A viewer right
+ * above the center gets the region's own facing.
+ */
+internal fun quantizedTiltFacing(dx: Double, dz: Double, yawDegrees: Float): Vector {
+    val yaw = Math.toRadians(yawDegrees.toDouble())
+    val forward = Vector(-sin(yaw), 0.0, cos(yaw))
+    val sideways = Vector(cos(yaw), 0.0, sin(yaw))
+    return listOf(forward, forward * -1.0, sideways, sideways * -1.0)
+        .maxBy { it.x * dx + it.z * dz }
+}
+
+/**
+ * Steps the stored tilt angles by [deltaDegrees] in the plane the quantized [facing]
+ * selects: pitch when the viewer looks along the region's forward axis, roll from the
+ * flanks. A positive delta always tips the region's top away from the viewer. The angles
+ * step directly so every tilt stays a clean pitch or roll; composing the rotation in
+ * world space and decomposing it back would smear one step across all three angles once
+ * the region is already rotated. Returns the new pitch and roll.
+ */
+internal fun steppedTilt(
+    pitchDegrees: Float,
+    rollDegrees: Float,
+    facing: Vector,
+    yawDegrees: Float,
+    deltaDegrees: Float,
+): Pair<Float, Float> {
+    val yaw = Math.toRadians(yawDegrees.toDouble())
+    val along = -sin(yaw) * facing.x + cos(yaw) * facing.z
+    val across = cos(yaw) * facing.x + sin(yaw) * facing.z
+    if (abs(along) >= abs(across)) {
+        val step = if (along >= 0.0) deltaDegrees else -deltaDegrees
+        return normalizeDegrees(pitchDegrees + step) to rollDegrees
+    }
+    val step = if (across >= 0.0) -deltaDegrees else deltaDegrees
+    return pitchDegrees to normalizeDegrees(rollDegrees + step)
+}
+
+/** How many segments a ring of [radius] needs for its chords to stay near [RING_SEGMENT_LENGTH]. */
+internal fun ringSegmentCount(radius: Double): Int =
+    ceil(2.0 * Math.PI * radius / RING_SEGMENT_LENGTH).toInt().coerceIn(MIN_RING_SEGMENTS, MAX_RING_SEGMENTS)
+
+/**
+ * A ring of [ringSegmentCount] chords in the plane spanned by [uBasis] and [vBasis], offset
+ * by [planeOffset] from the anchor. The bases carry the caller's frame, so the same builder
+ * serves the world aligned yaw ring and the region rotated pitch ring.
+ */
+internal fun ringSegments(
+    radius: Double,
+    planeOffset: Vector,
+    uBasis: Vector,
+    vBasis: Vector,
+): List<Pair<Vector, Vector>> {
+    val count = ringSegmentCount(radius)
+    val points = (0 until count).map { index ->
+        val angle = 2.0 * Math.PI * index / count
+        planeOffset + uBasis * (sin(angle) * radius) + vBasis * (cos(angle) * radius)
+    }
+    return points.indices.map { points[it] to points[(it + 1) % points.size] }
+}
+
+/** The segments whose midpoint lies within [range] of [viewerOffset] (both anchor relative). */
+internal fun cullSegmentsNear(
+    segments: List<Pair<Vector, Vector>>,
+    viewerOffset: Vector,
+    range: Double = RING_VISIBLE_RANGE,
+): List<Pair<Vector, Vector>> {
+    val limit = range * range
+    return segments.filter { (from, to) ->
+        (lerp(from, to, 0.5) - viewerOffset).lengthSquared <= limit
+    }
+}
+
+private fun lerp(from: Vector, to: Vector, fraction: Double): Vector = from + (to - from) * fraction
+
+/**
+ * The marked block the view ray passes through, nearest along the ray. The cubes are
+ * inflated a touch so aiming at a point does not demand pixel precision, and terrain is
+ * ignored on purpose: outline points usually sit inside walls, where the clicked block
+ * can never reach them.
+ */
+internal fun pickHoveredBlock(
+    blocks: List<CapturedBlock>,
+    worldId: String,
+    eye: Vector,
+    direction: Vector,
+    range: Double,
+): CapturedBlock? {
+    var best: CapturedBlock? = null
+    var bestEntry = Double.MAX_VALUE
+    for (block in blocks) {
+        if (block.world.identifier != worldId) continue
+        val entry = rayCubeEntry(block, eye, direction) ?: continue
+        if (entry > range || entry >= bestEntry) continue
+        bestEntry = entry
+        best = block
+    }
+    return best
+}
+
+/**
+ * Distance along the ray to where it enters the block's inflated cube, `0.0` when the eye
+ * is already inside it, or `null` when the ray misses.
+ */
+private fun rayCubeEntry(block: CapturedBlock, eye: Vector, direction: Vector): Double? {
+    var entry = 0.0
+    var exit = Double.MAX_VALUE
+    for (axis in 0..2) {
+        val origin = when (axis) {
+            0 -> eye.x
+            1 -> eye.y
+            else -> eye.z
+        }
+        val dir = when (axis) {
+            0 -> direction.x
+            1 -> direction.y
+            else -> direction.z
+        }
+        val low = when (axis) {
+            0 -> block.x
+            1 -> block.y
+            else -> block.z
+        } - HOVER_INFLATE
+        val high = low + 1.0 + 2 * HOVER_INFLATE
+        if (abs(dir) < Vector.EPSILON) {
+            if (origin < low || origin > high) return null
+            continue
+        }
+        val near = (low - origin) / dir
+        val far = (high - origin) / dir
+        entry = maxOf(entry, minOf(near, far))
+        exit = minOf(exit, maxOf(near, far))
+        if (entry > exit) return null
+    }
+    return entry
+}
+
+private const val HOVER_INFLATE = 0.1
+
+/** How close the aim must come to a corner edge to acquire it, and to keep it once selected. */
+internal const val VERTEX_PICK_RADIUS = 0.4
+internal const val VERTEX_KEEP_RADIUS = 0.65
+
+/**
+ * The closest approach between the view ray `eye + t * direction`, `t >= 0`, and the
+ * segment from [a] to [b]: the distance and the ray parameter at that point. [direction]
+ * must be unit length.
+ */
+internal fun raySegmentDistance(eye: Vector, direction: Vector, a: Vector, b: Vector): Pair<Double, Double> {
+    val v = b - a
+    val w = eye - a
+    val vv = v.dot(v)
+    val uv = direction.dot(v)
+    val uw = direction.dot(w)
+    val vw = w.dot(v)
+    val denominator = vv - uv * uv
+    var s = when {
+        vv < 1e-12 -> 0.0
+        abs(denominator) < 1e-9 -> (vw / vv).coerceIn(0.0, 1.0)
+        else -> ((vw - uw * uv) / denominator).coerceIn(0.0, 1.0)
+    }
+    val t = (s * uv - uw).coerceAtLeast(0.0)
+    if (vv >= 1e-12) s = ((w + direction * t).dot(v) / vv).coerceIn(0.0, 1.0)
+    val offset = w + direction * t - v * s
+    return offset.length to t
+}
+
+/**
+ * The corner whose vertical edge the view ray passes closest to, straight through terrain.
+ * [preferredIndex] adds hysteresis, mirroring [pickFace]: the already selected corner wins
+ * while it is still a full hit within [VERTEX_PICK_RADIUS]; a clear hit on another corner
+ * beats a selection that has drifted into the [VERTEX_KEEP_RADIUS] band; and the band only
+ * holds the selection while nothing else qualifies, so the pick neither flickers at the
+ * acquire boundary nor refuses a corner the player is now aiming dead at.
+ */
+internal fun pickVertexEdge(
+    edges: List<Pair<Vector, Vector>>,
+    eye: Vector,
+    direction: Vector,
+    range: Double,
+    preferredIndex: Int? = null,
+): Int? {
+    var best: Int? = null
+    var bestAlong = Double.MAX_VALUE
+    var preferredDistance = Double.MAX_VALUE
+    for ((index, edge) in edges.withIndex()) {
+        val (distance, along) = raySegmentDistance(eye, direction, edge.first, edge.second)
+        if (along > range) continue
+        if (index == preferredIndex) preferredDistance = distance
+        if (distance > VERTEX_PICK_RADIUS) continue
+        if (along < bestAlong) {
+            bestAlong = along
+            best = index
+        }
+    }
+    if (preferredDistance <= VERTEX_PICK_RADIUS) return preferredIndex
+    if (best != null) return best
+    if (preferredDistance <= VERTEX_KEEP_RADIUS) return preferredIndex
+    return null
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/InlineRegionContentMode.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/InlineRegionContentMode.kt
@@ -1,0 +1,64 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.core.entries.Entry
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.utils.failure
+import com.typewritermc.engine.paper.content.ContentComponent
+import com.typewritermc.engine.paper.content.ContentContext
+import com.typewritermc.engine.paper.content.ContentMode
+import com.typewritermc.engine.paper.content.entryId
+import com.typewritermc.engine.paper.content.fieldPath
+import com.typewritermc.engine.paper.entry.stagedEntry
+import com.typewritermc.region.data.buildShapeOrNull
+import org.bukkit.entity.Player
+import java.time.Duration
+
+/**
+ * The editor of an inline region definition.
+ *
+ * A definition entry carries its shape in its type, so the panel knows which editor to ask
+ * for. An inline definition carries it in its data, so the editor can only be picked once
+ * the entry is read. This mode is that indirection: it resolves the shape the user chose and
+ * runs the very editor the matching definition entry would have opened, writing through the
+ * paths the inline definition lives behind.
+ */
+class InlineRegionContentMode(context: ContentContext, player: Player) : ContentMode(context, player) {
+    private var editor: RegionContentMode? = null
+
+    override val components: MutableList<ContentComponent>
+        get() = editor?.components ?: mutableListOf()
+
+    override suspend fun setup(): Result<Unit> {
+        val entryId = context.entryId
+            ?: return failure("No entryId found for ${this::class.simpleName}. This is a bug. Please report it.")
+        val fieldPath = context.fieldPath
+            ?: return failure("No fieldPath found for ${this::class.simpleName}. This is a bug. Please report it.")
+
+        val ref = Ref(entryId, Entry::class)
+        val entry = ref.stagedEntry() ?: ref.get()
+            ?: return failure("Could not find the entry $entryId to edit.")
+        val target = regionEditTarget(entry, fieldPath)
+            ?: return failure("$fieldPath on $entryId holds no region to edit. This is a bug. Please report it.")
+        val definition = target.definitionOf(entry)
+            ?: return failure("This region points at a definition entry. Open the editor on that entry instead.")
+
+        val shape = definition.buildShapeOrNull()
+            ?: return failure("This region's shape fields do not describe a shape. Fix them on the web panel first.")
+        val editor = regionEditorMode(shape, context, player)
+            ?: return failure("The inline region's shape has no in-game editor.")
+        this.editor = editor
+        return editor.setup()
+    }
+
+    override suspend fun initialize() {
+        editor?.initialize()
+    }
+
+    override suspend fun tick(deltaTime: Duration) {
+        editor?.tick(deltaTime)
+    }
+
+    override suspend fun dispose() {
+        editor?.dispose()
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/OutlinePieces.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/OutlinePieces.kt
@@ -1,0 +1,142 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.region.shape.Shape
+import com.typewritermc.region.shape.outlinePolylines
+import org.joml.Quaternionf
+import org.joml.Vector3f
+import kotlin.math.ceil
+import kotlin.math.max
+
+internal const val OUTLINE_CIRCLE_SEGMENTS = 16
+internal const val MAX_CIRCLE_SEGMENTS = 128
+internal const val PIECE_LENGTH = 4.0
+internal const val MAX_LINE_DISPLAYS = 96
+
+/**
+ * How many segments this shape's outline circles need: enough that the arc chords stay
+ * near [PIECE_LENGTH], so a big sphere reads as round instead of a hexadecagon, clamped
+ * between the classic [OUTLINE_CIRCLE_SEGMENTS] and [MAX_CIRCLE_SEGMENTS].
+ */
+internal fun adaptiveCircleSegments(shape: Shape, pieceLength: Double = PIECE_LENGTH): Int {
+    val bounds = shape.localBounds
+    val diameter = maxOf(
+        bounds.maxX - bounds.minX,
+        bounds.maxY - bounds.minY,
+        bounds.maxZ - bounds.minZ,
+    )
+    return ceil(Math.PI * diameter / pieceLength).toInt()
+        .coerceIn(OUTLINE_CIRCLE_SEGMENTS, MAX_CIRCLE_SEGMENTS)
+}
+
+/**
+ * One drawable stretch of a region's outline.
+ *
+ * [anchorOffset] is where the piece's display entity sits and [midOffset] is its unscaled
+ * midpoint used for distance culling; both are offsets from the region anchor already rotated
+ * into the world frame. Anchoring each piece where it is drawn is required for a big region's
+ * outline to arrive at all: a display entity is only sent to a client near the entity itself, so
+ * lines anchored on a distant region anchor are never sent.
+ *
+ * [from] and [to] are the line the entity draws, in the region's local (unrotated) frame: the
+ * entity's own rotation carries them into the world, via the `rotation` argument of
+ * [RegionOutline.lineTransformation]. They carry the workspace pulse's scale, while
+ * [anchorOffset] and [midOffset] stay unscaled, so the pulse rewrites transformations only,
+ * never teleporting a display, and the culling in [visibleOutlinePieces] does not churn while a
+ * region pulses.
+ */
+internal data class OutlinePiece(
+    val anchorOffset: Vector,
+    val from: Vector,
+    val to: Vector,
+    val midOffset: Vector,
+)
+
+/** The most pieces one outline may be cut into, however large the region is. */
+private const val MAX_OUTLINE_PIECES = 20_000
+
+/**
+ * [preferred], or longer when the outline at that length would exceed [MAX_OUTLINE_PIECES].
+ */
+private fun pieceLengthFor(shape: Shape, preferred: Double, circleSegments: Int): Double {
+    var total = 0.0
+    for (polyline in shape.outlinePolylines(circleSegments)) {
+        for ((from, to) in polyline.segments()) total += (to - from).length
+    }
+    if (total <= 0.0) return preferred
+    return max(preferred, total / MAX_OUTLINE_PIECES)
+}
+
+/**
+ * The region's outline cut into pieces of at most [pieceLength] blocks. Each piece's anchor and
+ * midpoint are offset from the region anchor and rotated into the world frame; its line stays
+ * in the region's local frame, for [RegionOutline] to rotate along with the entity itself.
+ */
+internal fun buildOutlinePieces(
+    shape: Shape,
+    yawDegrees: Float,
+    pitchDegrees: Float,
+    rollDegrees: Float,
+    scale: Float,
+    circleSegments: Int = OUTLINE_CIRCLE_SEGMENTS,
+    pieceLength: Double = PIECE_LENGTH,
+): List<OutlinePiece> {
+    val rotation = RegionOutline.regionRotation(yawDegrees, pitchDegrees, rollDegrees)
+    val stretch = scale.toDouble()
+    val pieces = mutableListOf<OutlinePiece>()
+
+    // The piece length adapts to the region's size instead of being fixed. A stray zero in a
+    // radius makes the outline millions of pieces long at a fixed length, all built on the main
+    // thread before the display cap ever sees them, and a large enough one never finishes.
+    val length = pieceLengthFor(shape, pieceLength, circleSegments)
+
+    for (polyline in shape.outlinePolylines(circleSegments)) {
+        for ((localFrom, localTo) in polyline.segments()) {
+            val count = ceil((localTo - localFrom).length / length).toInt().coerceAtLeast(1)
+            for (index in 0 until count) {
+                val a = lerp(localFrom, localTo, index.toDouble() / count)
+                val b = lerp(localFrom, localTo, (index + 1).toDouble() / count)
+                pieces += OutlinePiece(
+                    anchorOffset = rotate(rotation, a),
+                    from = a * stretch - a,
+                    to = b * stretch - a,
+                    midOffset = rotate(rotation, lerp(a, b, 0.5)),
+                )
+            }
+        }
+    }
+    return pieces
+}
+
+/**
+ * The pieces to draw for a player, paired with their index in the full list so a piece keeps
+ * the same display entity while the player walks along the border.
+ *
+ * An outline that fits within [budget] is drawn whole, whatever the distance, so a normal sized
+ * region behaves exactly as it always has. A larger one is cut down to the pieces within
+ * [renderDistance] of the player, nearest first.
+ */
+internal fun visibleOutlinePieces(
+    pieces: List<OutlinePiece>,
+    anchor: Vector,
+    viewer: Vector,
+    renderDistance: Double,
+    budget: Int,
+): List<IndexedValue<OutlinePiece>> {
+    if (pieces.size <= budget) return pieces.withIndex().toList()
+
+    val limit = renderDistance * renderDistance
+    return pieces.withIndex()
+        .map { it to (anchor + it.value.midOffset - viewer).lengthSquared }
+        .filter { (_, distance) -> distance <= limit }
+        .sortedBy { (_, distance) -> distance }
+        .take(budget)
+        .map { (piece, _) -> piece }
+}
+
+private fun rotate(rotation: Quaternionf, vector: Vector): Vector {
+    val rotated = Vector3f(vector.x.toFloat(), vector.y.toFloat(), vector.z.toFloat()).rotate(rotation)
+    return Vector(rotated.x.toDouble(), rotated.y.toDouble(), rotated.z.toDouble())
+}
+
+private fun lerp(from: Vector, to: Vector, fraction: Double): Vector = from + (to - from) * fraction

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/PolygonRegionContentMode.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/PolygonRegionContentMode.kt
@@ -1,0 +1,942 @@
+package com.typewritermc.region.content
+
+import com.google.gson.reflect.TypeToken
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.core.utils.point.World
+import com.typewritermc.core.utils.switchContext
+import com.typewritermc.engine.paper.content.ContentContext
+import com.typewritermc.engine.paper.content.components.ItemComponent
+import com.typewritermc.engine.paper.content.components.ItemInteractionType
+import com.typewritermc.engine.paper.utils.Sync
+import com.typewritermc.engine.paper.utils.asMini
+import com.typewritermc.engine.paper.utils.round
+import com.typewritermc.region.data.ResolvedTransform
+import com.typewritermc.region.shape.PolygonShape
+import kotlinx.coroutines.Dispatchers
+import org.bukkit.FluidCollisionMode
+import org.bukkit.GameMode
+import org.bukkit.Location
+import org.bukkit.Material
+import org.bukkit.Sound
+import org.bukkit.entity.Player
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * The player walks the outline and marks blocks along it. The moment three marks exist,
+ * the outline derives into the working model (the centroid becomes `origin`, the prism
+ * bottom sits at the lowest mark) and the marks turn into corner handles: from then on the
+ * vertex list is the only outline model, shared with the resize tool's wall drags, so
+ * nothing ever snaps back to the original marks.
+ *
+ * From then on each click keeps one meaning: left click adds a corner on the nearest
+ * wall, right click removes the corner under the crosshair, and F turns the hovered
+ * corner into an explicit selection. The selected corner shows a glowing push axis that
+ * follows the way the player faces: left click pushes it along the axis, right click
+ * pulls it back, sneak scroll slides it finely, sneak right click picks it up into a
+ * carry that follows the crosshair, and F lets go. A spectator only has right click, so
+ * it adds at the occupied block and sneak right click removes the hovered corner, while
+ * the locked keys nudge the hovered or pinned corner the way the resize tool drives
+ * faces.
+ */
+class PolygonRegionContentMode(context: ContentContext, player: Player) : RegionContentMode(context, player) {
+    private val points = CopyOnWriteArrayList<CapturedBlock>()
+
+    @Volatile
+    private var hoveredIndex: Int? = null
+
+    @Volatile
+    private var selectedIndex: Int? = null
+
+    @Volatile
+    private var carriedIndex: Int? = null
+
+    @Volatile
+    private var pinnedCornerIndex: Int? = null
+
+    @Volatile
+    private var carryPointDistance = 8.0
+    private var carryPointBase: Map<String, Any?>? = null
+
+    private val handles = HandleDisplay(player)
+    private val edgeHighlight = GuideDisplay(player)
+    private val pointAxis = GuideDisplay(player)
+
+    private val working by lazy {
+        val shape = editedShape<PolygonShape>()
+        // Seeded exactly as the entry holds it. A prism thinner than the resize step is a legal
+        // thing to build on the panel, and rounding it up here would show the builder a region
+        // that is not theirs and save that back the moment they applied anything.
+        PolygonWorking(CopyOnWriteArrayList(shape?.points.orEmpty()), shape?.halfHeight ?: DEFAULT_HALF_HEIGHT)
+    }
+
+    private fun captured(): Boolean = working.points.size >= MIN_POINTS
+
+    override fun workingShape(): PolygonShape? {
+        if (!captured()) return null
+        return PolygonShape(working.points.toList(), working.halfHeight)
+    }
+
+    override fun hologramSizeLine(): String {
+        val count = if (captured()) working.points.size else points.size
+        return "<#A9B2C3><white>$count</white> points <#A9B2C3>half height <white>${working.halfHeight}"
+    }
+
+    override fun faceSpec() = object : FaceSpec {
+        override fun faces(localEye: Vector): List<RegionFace> {
+            if (!captured()) return emptyList()
+            val halfHeight = working.halfHeight
+            val outline = working.points
+            val boundsX = outline.maxOf { kotlin.math.abs(it.x) }
+            val boundsZ = outline.maxOf { kotlin.math.abs(it.z) }
+            val shape = PolygonShape(outline.toList(), halfHeight)
+
+            val faces = mutableListOf(
+                RegionFace(
+                    "+y",
+                    "top face",
+                    Vector(0.0, halfHeight, 0.0),
+                    Vector(0, 1, 0),
+                    Vector(0, 0, 1),
+                    Vector(1, 0, 0),
+                    boundsZ * 0.6,
+                    boundsX * 0.6
+                ),
+                RegionFace(
+                    "-y",
+                    "bottom face",
+                    Vector(0.0, -halfHeight, 0.0),
+                    Vector(0, -1, 0),
+                    Vector(1, 0, 0),
+                    Vector(0, 0, 1),
+                    boundsX * 0.6,
+                    boundsZ * 0.6
+                ),
+            )
+            for (index in outline.indices) {
+                val a = outline[index]
+                val b = outline[(index + 1) % outline.size]
+                val edge = Vector(b.x - a.x, 0.0, b.z - a.z)
+                if (edge.length < Vector.EPSILON) continue
+                val mid = Vector((a.x + b.x) / 2, 0.0, (a.z + b.z) / 2)
+                val candidate = Vector(edge.z, 0.0, -edge.x).normalize()
+                val probe = mid - candidate * PROBE_DISTANCE
+                val normal = if (shape.contains(Vector(probe.x, 0.0, probe.z))) candidate else candidate * -1.0
+                faces += RegionFace(
+                    "edge$index",
+                    "wall ${index + 1}",
+                    mid,
+                    normal,
+                    Vector(0, 1, 0).cross(normal),
+                    Vector(0, 1, 0),
+                    edge.length / 2,
+                    halfHeight,
+                )
+            }
+            return faces
+        }
+
+        override fun moveFace(face: RegionFace, delta: Double): ResizeResult {
+            if (face.id == "+y" || face.id == "-y") {
+                val current = working.halfHeight
+                val newHalf = (current + delta / 2).coerceAtLeast(MIN_HALF_HEIGHT).round(2)
+                val applied = (newHalf - current) * 2
+                // A region already thinner than the tool's own minimum would otherwise answer a
+                // pull inward by jumping outward to that minimum, anchor and all.
+                if (applied == 0.0 || applied * delta < 0.0) {
+                    return ResizeResult("<red>The ${face.label} cannot move further.", changed = false)
+                }
+                if (!shiftResizeAnchor(face.normal, applied / 2)) {
+                    return ResizeResult(
+                        "<red>The origin is bound to a variable, the face cannot move.",
+                        changed = false
+                    )
+                }
+                working.halfHeight = newHalf
+                restageSizeFields()
+                return ResizeResult("<gold>${face.label} <white>half height $newHalf")
+            }
+
+            val index = face.id.removePrefix("edge").toIntOrNull()
+                ?: return ResizeResult("<red>Unknown face.", changed = false)
+            if (index >= working.points.size) return ResizeResult("<red>The wall no longer exists.", changed = false)
+            val next = (index + 1) % working.points.size
+            val shift = face.normal * delta
+            working.points[index] = (working.points[index] + shift).rounded()
+            working.points[next] = (working.points[next] + shift).rounded()
+            stagePoints()
+            return ResizeResult(
+                "<gold>${face.label} <white>moved ${if (delta >= 0) "out" else "in"} ${
+                    kotlin.math.abs(
+                        delta
+                    ).round(2)
+                }"
+            )
+        }
+    }
+
+    override fun wandComponent(): ItemComponent = RegionWandComponent(
+        title = "<gold><bold>Polygon Wand",
+        loreText = """
+            |
+            |<line> <gray>Walk the outline left-clicking blocks for the first $MIN_POINTS points.
+            |<line> <gray>Then left-click adds a corner on the nearest wall,
+            |<line> <gray>right-click removes the corner you aim at.
+            |<line> <gray><white>F</white> selects the aimed corner: left-click pushes it $MOVE_STEP,
+            |<line> <gray>right-click pulls it back, sneak scroll slides it $MOVE_FINE_STEP,
+            |<line> <gray>sneak right-click picks it up to carry, <white>F</white> lets go.
+            |<line> <gray>Press <white>Q</white> to undo, sneak <white>Q</white> to redo.
+        """.trimMargin(),
+        onDrop = ::dropOrCancelGrab,
+        onSwap = ::toggleSelection,
+    ) { interaction, block ->
+        val spectator = player.gameMode == GameMode.SPECTATOR
+        when (interaction.type) {
+            ItemInteractionType.LEFT_CLICK, ItemInteractionType.SHIFT_LEFT_CLICK ->
+                if (!spectator) primaryAction(block)
+
+            ItemInteractionType.RIGHT_CLICK, ItemInteractionType.SHIFT_RIGHT_CLICK -> {
+                val sneak = interaction.type == ItemInteractionType.SHIFT_RIGHT_CLICK
+                if (spectator) spectatorClick(block, sneak) else secondaryAction(sneak)
+            }
+
+            else -> return@RegionWandComponent
+        }
+    }
+
+    private fun primaryAction(block: CapturedBlock) {
+        if (carriedIndex != null) {
+            cancelPointCarry()
+            return
+        }
+        if (!captured()) {
+            addPoint(block)
+            return
+        }
+        val selected = selectedIndex
+        if (selected != null) {
+            nudgePoint(selected, MOVE_STEP)
+            return
+        }
+        insertVertex(block)
+    }
+
+    private fun toggleSelection() {
+        if (carriedIndex != null) {
+            refuse(modeGestureRefusal())
+            return
+        }
+        val hovered = hoveredIndex
+        val selected = selectedIndex
+        when {
+            hovered != null && hovered != selected -> {
+                selectedIndex = hovered
+                player.playSound(player.location, Sound.UI_BUTTON_CLICK, 0.5f, 1.4f)
+                player.sendActionBar(
+                    ("<gold>Selected point <white>${hovered + 1}</white>. <gray>Left-click pushes, right-click pulls, " +
+                            "sneak right-click carries, <white>F</white> lets go.").asMini(),
+                )
+            }
+
+            selected != null -> {
+                selectedIndex = null
+                player.playSound(player.location, Sound.UI_BUTTON_CLICK, 0.3f, 1.0f)
+                player.sendActionBar("<gray>Deselected.".asMini())
+            }
+
+            else -> player.sendActionBar("<gray>Aim at a corner and press <white>F</white> to select it.".asMini())
+        }
+    }
+
+    private fun secondaryAction(sneak: Boolean) {
+        if (carriedIndex != null) {
+            placePointCarry()
+            return
+        }
+        if (!captured()) {
+            removeLastPoint()
+            return
+        }
+        val selected = selectedIndex
+        if (selected != null) {
+            if (sneak) grabPoint(selected) else nudgePoint(selected, -MOVE_STEP)
+            return
+        }
+        val hovered = hoveredIndex
+        if (hovered == null) {
+            player.sendActionBar("<gray>Aim at a corner to remove it, or press <white>F</white> to select one.".asMini())
+            return
+        }
+        removePointAt(hovered)
+    }
+
+    /**
+     * The spectator wand click, the only button a spectator client sends: right click adds
+     * at the occupied block, sneak right click removes the hovered corner, mirroring the
+     * resize tool's aim driven targeting.
+     */
+    private fun spectatorClick(block: CapturedBlock, sneak: Boolean) {
+        // Putting a carried corner down comes first, exactly as on foot. A spectator has no other
+        // button to end the carry with: left click, drop and swap are never sent, so without this
+        // the corner stays glued to the crosshair and every other tool refuses to run.
+        if (carriedIndex != null) {
+            placePointCarry()
+            return
+        }
+        if (!sneak) {
+            addPoint(block)
+            return
+        }
+        if (!captured()) {
+            removeLastPoint()
+            return
+        }
+        val hovered = hoveredIndex
+        if (hovered == null) {
+            player.sendActionBar("<gray>Aim at a corner to remove it.".asMini())
+            return
+        }
+        removePointAt(hovered)
+    }
+
+    /** The sprint and sneak chord does nothing here; the hint names the gesture that does. */
+    override fun spectatorSecondary(block: CapturedBlock) {
+        player.sendActionBar("<gray>Sneak <white>right-click</white> removes the aimed corner.".asMini())
+    }
+
+    override fun spectatorHint(): String =
+        "<white>right-click</white> adds a corner at your block, sneak <white>right-click</white> " +
+                "removes the aimed one, <white>jump + sneak</white> locks for key nudging"
+
+    override fun lockedWandHint(): String =
+        "aim at a corner: <white>WASD</white> nudge it $MOVE_STEP, <white>space</white> pins it, " +
+                "<white>jump + sneak</white> releases"
+
+    override fun usesSelectionCube(): Boolean = false
+
+    override fun onSpectatorLockReleased() {
+        pinnedCornerIndex = null
+    }
+
+    /**
+     * The locked spectator keys drive corners the way the resize tool drives faces: the
+     * aim picks the corner, WASD nudge it along the yaw cardinals, and space pins it so
+     * aim slip cannot switch targets mid adjustment.
+     */
+    override fun wandSpectatorKey(key: SpectatorKey) {
+        if (!captured()) {
+            player.sendActionBar("<gray>Fly onto a spot and <white>right-click</white> to add outline points.".asMini())
+            return
+        }
+        if (key == SpectatorKey.UP) {
+            toggleCornerPin()
+            return
+        }
+        val direction = spectatorKeyDirection(key, player.location.yaw)
+        if (direction == null || direction.y != 0.0) {
+            player.sendActionBar("<gray>WASD nudge the aimed corner, <white>space</white> pins it.".asMini())
+            return
+        }
+        val target = spectatorTargetCorner() ?: run {
+            refuse("<red>Aim at a corner to nudge it, or pin one with <white>space</white>.")
+            return
+        }
+        slidePointAlong(target, direction, MOVE_STEP, "Point ${target + 1} nudge", coalesce = false)
+    }
+
+    /** The corner the locked keys drive: the pinned one, or whichever the aim hovers. */
+    private fun spectatorTargetCorner(): Int? =
+        retainedIndex(pinnedCornerIndex, working.points.size) ?: hoveredIndex
+
+    private fun toggleCornerPin() {
+        if (pinnedCornerIndex != null) {
+            pinnedCornerIndex = null
+            player.playSound(player.location, Sound.UI_BUTTON_CLICK, 0.3f, 1.2f)
+            player.sendActionBar("<gray>Corner released. The aim picks corners again.".asMini())
+            return
+        }
+        val hovered = hoveredIndex ?: run {
+            refuse("<red>Aim at a corner to pin it first.")
+            return
+        }
+        pinnedCornerIndex = hovered
+        player.playSound(player.location, Sound.UI_BUTTON_CLICK, 0.3f, 1.6f)
+        player.sendActionBar(
+            "<gold>Pinned point <white>${hovered + 1}</white>. <gray>WASD keep driving it; <white>space</white> releases.".asMini(),
+        )
+    }
+
+    private fun dropOrCancelGrab() {
+        if (carriedIndex != null) {
+            cancelPointCarry()
+            return
+        }
+        undoOrRedoHeldTool()
+    }
+
+    override fun modeGestureActive(): Boolean = carriedIndex != null
+
+    override fun cancelModeGesture() = cancelPointCarry()
+
+    override fun finishModeGesture() = placePointCarry()
+
+    override fun modeGestureRefusal(): String = "<red>Place the point down first."
+
+    override fun modeGestureActivity(): String = "is moving a point"
+
+    private fun addPoint(block: CapturedBlock) {
+        if (captured()) {
+            insertVertex(block)
+            return
+        }
+        // The refusal comes before the mark is taken, not after the third one derives the outline: the
+        // capture clears the marks either way, so a refusal there throws away everything the
+        // builder walked out.
+        if (!placementWritable(rotation = true)) return
+        var collinear = false
+        val allowed = recorded(EditTool.WAND, "Outline point") {
+            if (points.firstOrNull()?.world != block.world) points.clear()
+            points.add(block)
+            if (points.size < MIN_POINTS) return@recorded true
+            // Three marks in a line enclose nothing. Deriving them anyway hands the builder an
+            // outline the hologram is happy with and a published region that contains nobody,
+            // which the console only mentions after the next publish. The earlier marks are kept,
+            // so one more point off the line finishes the capture.
+            if (!encloses(capture())) {
+                refuse("<red>Those points lie in a straight line. Mark one off the line.")
+                points.removeAt(points.lastIndex)
+                collinear = true
+                return@recorded false
+            }
+            deriveOutline()
+            points.clear()
+            true
+        }
+        if (!allowed || collinear) return
+        if (captured()) {
+            captureFeedback("<gold>Outline captured with <white>${working.points.size}</white> corners.", 1.4f)
+            return
+        }
+        val pitch = (0.7f + points.size * 0.05f).coerceAtMost(1.8f)
+        captureFeedback(
+            "<gold>Point <white>${points.size}</white> added <white>(${block.x}, ${block.y}, ${block.z})",
+            pitch
+        )
+    }
+
+    private fun insertVertex(block: CapturedBlock) {
+        val transform = workingTransform() ?: run {
+            refuse("<red>The origin is bound to a variable, the outline cannot be edited here.")
+            return
+        }
+        if (block.world.identifier != transform.world.identifier) {
+            refuse("<red>The outline lives in another world.")
+            return
+        }
+        val local = transform.toLocal(block.center)
+        val point = Vector(local.x.round(2), 0.0, local.z.round(2))
+        val index = insertionIndexFor(working.points, point)
+        val allowed = recorded(EditTool.WAND, "Point ${index + 1} added") {
+            working.points.add(index, point)
+            // Every index at or above the insertion shifts up, and a pin or selection left
+            // pointing at the old number would silently drive the neighbouring corner.
+            if (pinnedCornerIndex?.let { it >= index } == true) pinnedCornerIndex = null
+            if (selectedIndex?.let { it >= index } == true) selectedIndex = null
+            stagePoints()
+            true
+        }
+        if (!allowed) return
+        captureFeedback(
+            "<gold>Point <white>${index + 1}</white> added on the nearest wall, <white>${working.points.size}</white> corners",
+            1.2f,
+        )
+    }
+
+    private fun nudgePoint(index: Int, distance: Double) {
+        slidePoint(index, distance, "Point ${index + 1} nudge", coalesce = false)
+    }
+
+    private fun slidePoint(index: Int, distance: Double, label: String, coalesce: Boolean) =
+        slidePointAlong(index, cardinalFromYaw(player.location.yaw), distance, label, coalesce)
+
+    private fun slidePointAlong(index: Int, direction: Vector, distance: Double, label: String, coalesce: Boolean) {
+        val transform = workingTransform() ?: return
+        if (index >= working.points.size) return
+        val localShift = transform.toLocal(transform.worldOrigin + direction * distance) -
+                transform.toLocal(transform.worldOrigin)
+        recorded(EditTool.WAND, label, if (coalesce) SCROLL_COALESCE_MILLIS else 0) {
+            val current = working.points[index]
+            working.points[index] = Vector(
+                (current.x + localShift.x).round(2),
+                0.0,
+                (current.z + localShift.z).round(2),
+            )
+            stagePoints()
+            val world = transform.toWorld(working.points[index])
+            toolFeedback(
+                "<gold>Point ${index + 1} <white>${world.x.round(2)}, ${world.z.round(2)}",
+                distance >= 0,
+            )
+            true
+        }
+    }
+
+    private fun grabPoint(index: Int) {
+        if (isFaceGrabbed()) {
+            refuse("<red>Keep or put back the grabbed face first.")
+            return
+        }
+        if (isCarryingRegion()) {
+            refuse("<red>Place the region down first.")
+            return
+        }
+        val transform = workingTransform() ?: run {
+            refuse("<red>The origin is bound to a variable, the outline cannot be edited here.")
+            return
+        }
+        if (index >= working.points.size) return
+
+        carryPointBase = mapOf(KEY_POINTS to working.points.toList())
+        carriedIndex = index
+        val world = transform.toWorld(working.points[index])
+        carryPointDistance = player.eyeLocation
+            .distance(Location(player.world, world.x, world.y, world.z))
+            .coerceIn(CARRY_MIN_DISTANCE, CARRY_MAX_DISTANCE)
+        player.playSound(player.location, Sound.ENTITY_ITEM_FRAME_REMOVE_ITEM, 0.8f, 1.2f)
+        player.sendActionBar(
+            "<gold>Picked up point <white>${index + 1}</white>. <gray>It follows your crosshair; <white>right-click</white> places it.".asMini(),
+        )
+    }
+
+    private fun placePointCarry() {
+        val index = carriedIndex ?: return
+        carriedIndex = null
+        val base = carryPointBase
+        carryPointBase = null
+        val after = mapOf(KEY_POINTS to working.points.toList())
+        base?.let { recordGestureEntry(EditTool.WAND, "Point ${index + 1} carry", it, after) }
+        stagePoints()
+        val world = workingTransform()?.toWorld(working.points.getOrNull(index) ?: Vector.ZERO)
+        player.playSound(player.location, Sound.ENTITY_ITEM_FRAME_ADD_ITEM, 0.8f, 1.0f)
+        val at = world?.let { " at <white>${it.x.round(2)}, ${it.z.round(2)}</white>" } ?: ""
+        player.sendActionBar("<gold>Placed point <white>${index + 1}</white>$at.".asMini())
+    }
+
+    private fun cancelPointCarry() {
+        if (carriedIndex == null) return
+        carriedIndex = null
+        carryPointBase?.let(::restoreGestureBase)
+        carryPointBase = null
+        player.playSound(player.location, Sound.ENTITY_ITEM_FRAME_ROTATE_ITEM, 0.8f, 0.8f)
+        player.sendActionBar("<gray>Put the point back where it was.".asMini())
+    }
+
+    /**
+     * While carried, the point hangs on the player's crosshair: its XZ follows the first
+     * block the view ray hits, or floats at the carry distance the scroll adjusts,
+     * half grid snapped unless sneaking. Main thread only.
+     */
+    override fun tickModeGesture() {
+        val index = carriedIndex ?: return
+        if (index >= working.points.size) {
+            carriedIndex = null
+            carryPointBase = null
+            return
+        }
+        val transform = workingTransform() ?: return
+        if (transform.world.identifier != player.world.uid.toString()) {
+            cancelPointCarry()
+            return
+        }
+
+        val eye = player.eyeLocation
+        val direction = eye.direction
+        val hit = player.world
+            .rayTraceBlocks(eye, direction, carryPointDistance, FluidCollisionMode.NEVER, true)
+            ?.hitPosition
+        val targetX = hit?.x ?: (eye.x + direction.x * carryPointDistance)
+        val targetZ = hit?.z ?: (eye.z + direction.z * carryPointDistance)
+        val snap = !player.isSneaking
+        fun settle(value: Double): Double = if (snap) snapToHalfGrid(value) else value.round(2)
+        val local = transform.toLocal(Vector(settle(targetX), transform.worldOrigin.y, settle(targetZ)))
+        working.points[index] = Vector(local.x.round(2), 0.0, local.z.round(2))
+        stagePoints()
+    }
+
+    override fun onWandScroll(steps: Int): Boolean {
+        if (carriedIndex != null) {
+            carryPointDistance = (carryPointDistance + steps * CARRY_SCROLL_STEP)
+                .coerceIn(CARRY_MIN_DISTANCE, CARRY_MAX_DISTANCE)
+            return true
+        }
+        if (!player.isSneaking) return false
+        val selected = selectedIndex ?: return false
+        slidePoint(selected, steps * MOVE_FINE_STEP, "Point ${selected + 1} slide", coalesce = true)
+        return true
+    }
+
+    private fun removePointAt(index: Int) {
+        if (working.points.size <= MIN_POINTS) {
+            refuse("<red>A polygon needs at least $MIN_POINTS points.")
+            return
+        }
+        val allowed = recorded(EditTool.WAND, "Point ${index + 1} removed") {
+            if (index >= working.points.size) return@recorded false
+            working.points.removeAt(index)
+            stagePoints()
+            true
+        }
+        if (!allowed) return
+        selectedIndex = null
+        pinnedCornerIndex = null
+        captureFeedback("<gold>Removed point <white>${index + 1}</white>, <white>${working.points.size}</white> left", 0.6f)
+    }
+
+    private fun removeLastPoint() {
+        if (captured()) {
+            removePointAt(working.points.size - 1)
+            return
+        }
+        if (points.isEmpty()) {
+            refuse("<red>No outline points to remove.")
+            return
+        }
+        val allowed = recorded(EditTool.WAND, "Outline point") {
+            points.removeLastOrNull() != null
+        }
+        if (!allowed) return
+        captureFeedback("<gold>Removed the last point, <white>${points.size}</white> left", 0.6f)
+    }
+
+    override fun hasCapturedGeometry(): Boolean = captured()
+
+    override fun instruction(): String {
+        val carried = carriedIndex
+        if (carried != null) {
+            return "Carrying point <white>${carried + 1}</white>: it follows your aim, scroll sets the distance, " +
+                    "<green>right-click</green> places it, <red>left-click</red> puts it back"
+        }
+        val selected = selectedIndex
+        if (selected != null) {
+            return "Point <white>${selected + 1}</white> selected: <red>left-click</red> pushes, " +
+                    "<green>right-click</green> pulls, sneak <green>right-click</green> carries, " +
+                    "<white>F</white> lets go"
+        }
+        if (!captured()) {
+            return "Walk the outline: <red>left-click</red> blocks to add points (${points.size} of $MIN_POINTS minimum)"
+        }
+        return "${working.points.size} corners. <red>Left-click</red> adds on the nearest wall, " +
+                "<green>right-click</green> removes the aimed corner, <white>F</white> selects it"
+    }
+
+    /**
+     * Aim based corner hover plus the handle rendering. The whole vertical corner edge
+     * hovers, straight through terrain, because outline corners usually sit inside walls.
+     * F turns the hover into the sticky selection the click gestures act on; a spectator
+     * has no F, so the locked keys act on the hover or the pinned corner directly.
+     */
+    override fun updateModeOverlays() {
+        val previous = hoveredIndex
+        val hovered = pickHovered()
+        hoveredIndex = hovered
+        if (player.gameMode == GameMode.SPECTATOR) {
+            selectedIndex = null
+        } else {
+            pinnedCornerIndex = null
+            if (player.inventory.heldItemSlot != WAND_SLOT) selectedIndex = null
+        }
+        if (hovered != null && hovered != previous) {
+            player.playSound(player.location, Sound.UI_BUTTON_CLICK, 0.3f, 1.7f)
+        }
+        renderHandles()
+    }
+
+    private fun pickHovered(): Int? {
+        if (carriedIndex != null) return null
+        if (isCarryingRegion() || isFaceGrabbed()) return null
+        if (!captured()) return null
+        val spectator = player.gameMode == GameMode.SPECTATOR
+        if (!spectator && player.inventory.heldItemSlot != WAND_SLOT) return null
+        val transform = workingTransform() ?: return null
+        if (transform.world.identifier != player.world.uid.toString()) return null
+        val eye = player.eyeLocation
+        val direction = eye.direction
+        return pickVertexEdge(
+            vertexEdges(transform),
+            Vector(eye.x, eye.y, eye.z),
+            Vector(direction.x, direction.y, direction.z),
+            PICK_RANGE,
+            hoveredIndex,
+        )
+    }
+
+    /** Each corner's vertical edge in the world frame, bottom ring point to top ring point. */
+    private fun vertexEdges(transform: ResolvedTransform): List<Pair<Vector, Vector>> =
+        working.points.map { point ->
+            transform.toWorld(Vector(point.x, -working.halfHeight, point.z)) to
+                    transform.toWorld(Vector(point.x, working.halfHeight, point.z))
+        }
+
+    private fun renderHandles() {
+        val playerWorldId = player.world.uid.toString()
+        if (!captured()) {
+            val marks = points.filter { it.world.identifier == playerWorldId }
+            handles.update(player.world, marks.map { HandleSpec(it.center, normalMaterial(), normalGlow(), HANDLE_SIZE) })
+            edgeHighlight.despawn()
+            pointAxis.despawn()
+            return
+        }
+        val transform = workingTransform()
+        if (transform == null || transform.world.identifier != playerWorldId) {
+            handles.despawn()
+            edgeHighlight.despawn()
+            pointAxis.despawn()
+            return
+        }
+        val edges = vertexEdges(transform)
+        val specs = buildList {
+            for ((index, edge) in edges.withIndex()) {
+                val (material, glow, size) = handleAppearance(index)
+                add(HandleSpec(edge.first, material, glow, size))
+                add(HandleSpec(edge.second, material, glow, size))
+            }
+        }
+        handles.update(player.world, specs)
+        renderPointAxis(edges)
+
+        val highlighted = carriedIndex ?: selectedIndex ?: retainedIndex(pinnedCornerIndex, edges.size)
+        if (highlighted == null || highlighted >= edges.size) {
+            edgeHighlight.despawn()
+            return
+        }
+        val edge = edges[highlighted]
+        edgeHighlight.update(
+            Location(player.world, edge.first.x, edge.first.y, edge.first.z),
+            listOf(Vector.ZERO to edge.second - edge.first),
+            Material.YELLOW_CONCRETE,
+            SELECTED_GLOW,
+            EDGE_HIGHLIGHT_THICKNESS,
+        )
+    }
+
+    /**
+     * The glowing push axis through the corner the gestures would move: the selection on
+     * foot, the hovered or pinned corner for a locked spectator. It follows the way the
+     * player faces, colored per world axis like the move guide, with the arrowhead
+     * marking the push direction so a step's effect is visible before it happens.
+     */
+    private fun renderPointAxis(edges: List<Pair<Vector, Vector>>) {
+        val spectator = player.gameMode == GameMode.SPECTATOR
+        val target = when {
+            carriedIndex != null -> null
+            spectator -> if (isSpectatorLocked()) spectatorTargetCorner() else null
+            player.inventory.heldItemSlot != WAND_SLOT -> null
+            else -> selectedIndex
+        }
+        if (target == null || target >= edges.size) {
+            pointAxis.despawn()
+            return
+        }
+        val direction = cardinalFromYaw(player.location.yaw)
+        val edge = edges[target]
+        val mid = (edge.first + edge.second) * 0.5
+        val eye = player.eyeLocation
+        val view = (mid + direction * PUSH_AXIS_REACH - Vector(eye.x, eye.y, eye.z))
+            .takeIf { it.length > Vector.EPSILON }?.normalize() ?: direction
+        val (material, glow) = axisAppearance(direction)
+        pointAxis.update(
+            Location(player.world, mid.x, mid.y, mid.z),
+            pushAxisSegments(direction, view),
+            material,
+            glow,
+        )
+    }
+
+    private fun handleAppearance(index: Int): Triple<Material, org.bukkit.Color, Float> = when (index) {
+        carriedIndex -> Triple(Material.YELLOW_CONCRETE, SELECTED_GLOW, HANDLE_SELECTED_SIZE)
+        selectedIndex -> Triple(Material.YELLOW_CONCRETE, SELECTED_GLOW, HANDLE_SELECTED_SIZE)
+        pinnedCornerIndex -> Triple(Material.YELLOW_CONCRETE, SELECTED_GLOW, HANDLE_SELECTED_SIZE)
+        hoveredIndex -> Triple(Material.WHITE_CONCRETE, org.bukkit.Color.WHITE, hoverPulseSize())
+        else -> Triple(normalMaterial(), normalGlow(), HANDLE_SIZE)
+    }
+
+    /**
+     * The hovered handle pulses: the size swings on a short sine so the corner the aim
+     * would select stands out from the still ones without needing yet another color.
+     */
+    private fun hoverPulseSize(): Float {
+        val phase = System.currentTimeMillis() % HOVER_PULSE_MILLIS / HOVER_PULSE_MILLIS.toDouble()
+        return HANDLE_HOVER_SIZE + HOVER_PULSE_AMPLITUDE * kotlin.math.sin(phase * 2.0 * Math.PI).toFloat()
+    }
+
+    private fun normalMaterial(): Material = RegionOutline.nearestConcrete(editColor())
+
+    private fun normalGlow(): org.bukkit.Color {
+        val color = editColor()
+        return org.bukkit.Color.fromRGB(color.red, color.green, color.blue)
+    }
+
+    override suspend fun dispose() {
+        carriedIndex = null
+        carryPointBase = null
+        pinnedCornerIndex = null
+        super.dispose()
+        Dispatchers.Sync.switchContext {
+            handles.despawn()
+            edgeHighlight.despawn()
+            pointAxis.despawn()
+        }
+    }
+
+    override fun collectState(state: MutableMap<String, Any?>) {
+        state[KEY_MARKED] = points.toList()
+        state[KEY_POINTS] = working.points.toList()
+        state[KEY_HALF_HEIGHT] = working.halfHeight
+    }
+
+    override fun restoreStateValue(key: String, value: Any?) {
+        when (key) {
+            KEY_MARKED -> {
+                points.clear()
+                (value as? List<*>)?.filterIsInstance<CapturedBlock>()?.let(points::addAll)
+            }
+
+            KEY_POINTS -> {
+                working.points.clear()
+                (value as? List<*>)?.filterIsInstance<Vector>()?.let(working.points::addAll)
+                selectedIndex = retainedIndex(selectedIndex, working.points.size)
+                pinnedCornerIndex = retainedIndex(pinnedCornerIndex, working.points.size)
+                if (retainedIndex(carriedIndex, working.points.size) == null) {
+                    carriedIndex = null
+                    carryPointBase = null
+                }
+            }
+
+            KEY_HALF_HEIGHT -> working.halfHeight = value as? Double ?: working.halfHeight
+        }
+    }
+
+    override fun restageSizeFields() {
+        val shape = editedShape<PolygonShape>()
+        restageShapeField("points", working.points.toList(), shape?.points, object : TypeToken<List<Vector>>() {}.type)
+        restageShapeField("halfHeight", working.halfHeight, shape?.halfHeight)
+    }
+
+    private fun stagePoints() {
+        restageSizeFields()
+    }
+
+    /**
+     * The one shot capture transition: the marks become the vertex model. Never runs again
+     * after that, so resize edits can never be derived away again.
+     */
+    private fun deriveOutline() {
+        val capture = capture() ?: return
+        if (!placementWritable(rotation = true)) return
+        resetResizeShift()
+        // The captured vertices are world axis offsets from the centroid, and the working
+        // transform would rotate them again by the entry's stored yaw. The box captures reset
+        // the rotation for the same reason.
+        resetWorkingRotation()
+        updateWorkingOrigin(originMovedTo(capture.world, capture.origin.x, capture.origin.y, capture.origin.z))
+        working.points.clear()
+        working.points.addAll(capture.relativePoints)
+        stagePoints()
+    }
+
+    /**
+     * Whether [capture] describes a floor rather than a line or a single point.
+     *
+     * The height is deliberately not part of the question. A prism with no height is unusable
+     * too, but that is a number the builder can see and change, while an outline that encloses
+     * nothing fails with nothing visible to correct.
+     */
+    private fun encloses(capture: PolygonCapture?): Boolean {
+        val points = capture?.relativePoints ?: return false
+        return PolygonShape(points, halfHeight = 1.0).usable
+    }
+
+    private fun capture(): PolygonCapture? {
+        val outline = points.toList()
+        if (outline.size < MIN_POINTS) return null
+
+        val world = outline.first().world
+        val centroidX = (outline.sumOf { it.center.x } / outline.size).round(2)
+        val centroidZ = (outline.sumOf { it.center.z } / outline.size).round(2)
+        val bottomY = outline.minOf { it.y }.toDouble()
+        val halfHeight = working.halfHeight
+
+        val origin = Vector(centroidX, bottomY + halfHeight, centroidZ)
+        val relativePoints = outline.map {
+            Vector((it.center.x - centroidX).round(2), 0.0, (it.center.z - centroidZ).round(2))
+        }
+        return PolygonCapture(world, origin, relativePoints, halfHeight)
+    }
+
+    private fun Vector.rounded(): Vector = Vector(x.round(2), y.round(2), z.round(2))
+
+    private data class PolygonCapture(
+        val world: World,
+        val origin: Vector,
+        val relativePoints: List<Vector>,
+        val halfHeight: Double,
+    )
+
+    private class PolygonWorking(val points: MutableList<Vector>, var halfHeight: Double)
+
+    companion object {
+        private const val MIN_POINTS = 3
+        private const val DEFAULT_HALF_HEIGHT = 2.0
+        private const val MIN_HALF_HEIGHT = 0.5
+        private const val PROBE_DISTANCE = 0.05
+        private const val PICK_RANGE = 32.0
+        private const val HANDLE_SIZE = 0.22f
+        private const val HANDLE_HOVER_SIZE = 0.28f
+        private const val HANDLE_SELECTED_SIZE = 0.32f
+        private const val HOVER_PULSE_AMPLITUDE = 0.06f
+        private const val HOVER_PULSE_MILLIS = 700L
+        private val SELECTED_GLOW = org.bukkit.Color.fromRGB(255, 200, 0)
+        private const val EDGE_HIGHLIGHT_THICKNESS = 0.08f
+    }
+}
+
+private const val KEY_MARKED = "poly.marked"
+private const val KEY_POINTS = "poly.points"
+private const val KEY_HALF_HEIGHT = "poly.halfHeight"
+
+/** The XZ distance from [point] to the segment [a] to [b], all in the polygon's local frame. */
+internal fun pointSegmentDistanceXZ(point: Vector, a: Vector, b: Vector): Double {
+    val abx = b.x - a.x
+    val abz = b.z - a.z
+    val apx = point.x - a.x
+    val apz = point.z - a.z
+    val lengthSquared = abx * abx + abz * abz
+    val s = if (lengthSquared < 1e-12) 0.0 else ((apx * abx + apz * abz) / lengthSquared).coerceIn(0.0, 1.0)
+    val dx = apx - abx * s
+    val dz = apz - abz * s
+    return kotlin.math.sqrt(dx * dx + dz * dz)
+}
+
+/**
+ * Where a new outline point belongs: after the start vertex of the nearest wall, so a
+ * click extends the wall the builder is looking at instead of appending at the end and
+ * crossing the polygon.
+ */
+internal fun insertionIndexFor(points: List<Vector>, point: Vector): Int {
+    if (points.size < 2) return points.size
+    var bestIndex = points.size
+    var bestDistance = Double.MAX_VALUE
+    for (index in points.indices) {
+        val a = points[index]
+        val b = points[(index + 1) % points.size]
+        val distance = pointSegmentDistanceXZ(point, a, b)
+        if (distance < bestDistance) {
+            bestDistance = distance
+            bestIndex = index + 1
+        }
+    }
+    return bestIndex
+}
+
+/** [index] when it still points into a list of [size] entries, else `null`. */
+internal fun retainedIndex(index: Int?, size: Int): Int? = index?.takeIf { it in 0 until size }

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/RegionContentMode.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/RegionContentMode.kt
@@ -1,0 +1,2195 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.core.entries.Entry
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.interaction.context
+import com.typewritermc.core.utils.failure
+import com.typewritermc.core.utils.ok
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.core.utils.point.World
+import com.typewritermc.core.utils.switchContext
+import com.typewritermc.engine.paper.content.*
+import com.typewritermc.engine.paper.content.components.*
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.writeFieldValue
+import com.typewritermc.engine.paper.entry.stagedEntry
+import com.typewritermc.engine.paper.entry.triggerFor
+import com.typewritermc.engine.paper.plugin
+import com.typewritermc.engine.paper.utils.*
+import com.typewritermc.engine.paper.utils.Color
+import com.typewritermc.region.data.RegionDefinition
+import com.typewritermc.region.data.buildShapeOrNull
+import com.typewritermc.region.data.ResolvedTransform
+import com.typewritermc.region.data.displayColor
+import com.typewritermc.region.data.tiltDegrees
+import com.typewritermc.region.shape.LocalBounds
+import com.typewritermc.region.shape.Shape
+import com.typewritermc.region.shape.nearestBoundaryPoint
+import kotlinx.coroutines.Dispatchers
+import lirand.api.extensions.events.unregister
+import lirand.api.extensions.server.registerEvents
+import net.kyori.adventure.bossbar.BossBar
+import org.bukkit.*
+import org.bukkit.Sound
+import org.bukkit.entity.Player
+import org.bukkit.inventory.ItemStack
+import org.koin.java.KoinJavaComponent
+import java.lang.reflect.Type
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.math.*
+
+/** A block a player marked with the region wand. */
+data class CapturedBlock(val world: World, val x: Int, val y: Int, val z: Int) {
+    val center: Vector get() = Vector(x + 0.5, y + 0.5, z + 0.5)
+}
+
+/**
+ * The region the working model currently describes. The preview renders it with the same
+ * [Shape] math the runtime uses.
+ */
+data class PendingRegion(val transform: ResolvedTransform, val shape: Shape)
+
+/**
+ * The block aligned box spanned by two marked blocks. The upper bounds are exclusive so
+ * both blocks are fully covered.
+ */
+data class BlockBox(
+    val minX: Double, val minY: Double, val minZ: Double,
+    val maxX: Double, val maxY: Double, val maxZ: Double,
+) {
+    val center: Vector get() = Vector((minX + maxX) / 2, (minY + maxY) / 2, (minZ + maxZ) / 2)
+    val halfX: Double get() = (maxX - minX) / 2
+    val halfY: Double get() = (maxY - minY) / 2
+    val halfZ: Double get() = (maxZ - minZ) / 2
+
+    companion object {
+        fun spanning(a: CapturedBlock, b: CapturedBlock): BlockBox = BlockBox(
+            minX = min(a.x, b.x).toDouble(),
+            minY = min(a.y, b.y).toDouble(),
+            minZ = min(a.z, b.z).toDouble(),
+            maxX = max(a.x, b.x) + 1.0,
+            maxY = max(a.y, b.y) + 1.0,
+            maxZ = max(a.z, b.z) + 1.0,
+        )
+    }
+}
+
+/**
+ * Base for the in game region capture editors. Everything edits one working model: wand
+ * captures derive placement and size into it the moment they complete, the transform tools
+ * nudge it, and the preview always renders it. Nothing touches the entry until the player
+ * clicks Apply; leaving discards the session.
+ *
+ * The shape renders as glowing display entity edge lines in the region's color, with dust
+ * on the surface between them, so the silhouette reads through terrain. A text display
+ * above the region reads out the live placement, size and unsaved change count.
+ *
+ * Every change lands in a tool aware undo history: the drop key undoes the held tool's
+ * last change (sneaking redoes it), the arrow item walks the whole session, and
+ * sneak clicking the arrow undoes or redoes everything.
+ *
+ * The move tool can pick the region up and carry it on the crosshair. The resize tool aims
+ * at faces: click to step the face, or grab it and drag it along its normal by looking.
+ */
+abstract class RegionContentMode(context: ContentContext, player: Player) : ContentMode(context, player) {
+    private val editRegistry: RegionEditRegistry by KoinJavaComponent.inject(RegionEditRegistry::class.java)
+    private var entryRef: Ref<Entry>? = null
+    private var target: RegionEditTarget? = null
+
+    private var stagedEntryResolved = false
+    private var stagedEntry: Entry? = null
+
+    private var placementSeeded = false
+    private var entryHadPlacement = false
+
+    @Volatile
+    private var disposed = false
+
+    @Volatile
+    private var workingOrigin: Position? = null
+
+    @Volatile
+    private var workingOffset: Vector = Vector.ZERO
+
+    @Volatile
+    private var workingYaw: Float? = null
+
+    @Volatile
+    private var workingPitch: Float? = null
+
+    @Volatile
+    private var workingRoll: Float? = null
+
+    @Volatile
+    private var resizeShift: Vector = Vector.ZERO
+
+    private val stagedWrites = ConcurrentHashMap<String, StagedWrite>()
+    private val history = EditHistory()
+    private val hologram = EditorHologram(player)
+    private val outline = RegionOutline(player)
+    private val guide = GuideDisplay(player)
+    private val ghostMarker = GuideDisplay(player)
+    private var scrollListener: ScrollListener? = null
+    private var displacementListener: DisplacementListener? = null
+    private var spectatorListener: SpectatorInputListener? = null
+
+    @Volatile
+    private var spectatorLock: SpectatorLockState? = null
+
+    private var restoreEpoch = 0
+    private var renderedRestoreEpoch = 0
+
+    @Volatile
+    private var moveAxisLock = AxisLock.Auto
+
+    @Volatile
+    private var autoMoveMemory: Vector? = null
+
+    @Volatile
+    private var rotatePitchMode = false
+
+    @Volatile
+    private var carrying = false
+
+    @Volatile
+    private var carryDistance = 8.0
+    private var carryBaseState: Map<String, Any?>? = null
+
+    @Volatile
+    private var targetedFace: RegionFace? = null
+
+    @Volatile
+    private var pinnedFaceId: String? = null
+
+    @Volatile
+    private var grabbedFace: RegionFace? = null
+    private var dragBaseState: Map<String, Any?>? = null
+    private var dragTransform: ResolvedTransform? = null
+    private var dragLocalEye: Vector? = null
+    private var lastDragDelta = 0.0
+
+    private var returnLocation: Location? = null
+
+    private var session: RegionEditSession? = null
+    private var awaitingPublish = false
+
+    private var rotateSlot = -1
+    private var resizeSlot = -1
+
+    final override suspend fun setup(): Result<Unit> {
+        val entryId = context.entryId
+            ?: return failure("No entryId found for ${this::class.simpleName}. This is a bug. Please report it.")
+        val fieldPath = context.fieldPath
+            ?: return failure("No fieldPath found for ${this::class.simpleName}. This is a bug. Please report it.")
+        val ref = Ref(entryId, Entry::class)
+        val entry = ref.stagedEntry() ?: ref.get()
+            ?: return failure("Could not find the entry $entryId to edit.")
+        entryRef = ref
+        stagedEntry = entry
+        stagedEntryResolved = true
+        target = regionEditTarget(entry, fieldPath)
+            ?: return failure("$fieldPath on $entryId holds no region to edit. This is a bug. Please report it.")
+
+        rotateSlot = if (supportsRotation()) ROTATE_SLOT else -1
+        resizeSlot = if (faceSpec() != null) RESIZE_SLOT else -1
+
+        bossBar {
+            title = bossBarTitle()
+            color = when {
+                carrying || grabbedFace != null || modeGestureActive() -> BossBar.Color.BLUE
+                canApply() -> BossBar.Color.GREEN
+                else -> BossBar.Color.YELLOW
+            }
+        }
+        // No double shift exit: sneaking is a core editor input (large steps, fine scrolls,
+        // border teleport), so two quick shifts must never throw the player out of the mode.
+        exit { canApply() }
+        +wandComponent()
+        +moveTool()
+        if (rotateSlot >= 0) +rotateTool()
+        if (resizeSlot >= 0) +resizeTool()
+        +TeleportToolComponent(TELEPORT_SLOT, ::teleportToRegion, ::teleportToBorder, ::teleportBack, ::undoOrRedoHeldTool)
+        +UndoItemComponent(
+            { history.undoCount },
+            { history.redoCount },
+            { all -> if (all) undoEverything() else undoLastChange() },
+            { all -> if (all) redoEverything() else redoLastChange() },
+        )
+        +ApplyItemComponent(::canApply, { stagedWrites.size }, ::applyIfReady)
+
+        return ok(Unit)
+    }
+
+    override suspend fun initialize() {
+        // The engine initializes the mode underneath again whenever a mode pushed on top of it is
+        // popped, so the flag has to be armed again here. Left set, the returning editor keeps
+        // its tools and its boss bar and renders nothing at all.
+        disposed = false
+        val entryId = entryRef?.id
+        if (entryId != null) {
+            session = editRegistry.tryStartEditing(player.uniqueId, player.name, entryId)
+            if (session == null) {
+                val holder = editRegistry.sessionOf(entryId)?.editorName ?: "Another player"
+                Dispatchers.Sync.switchContext { refuse("<red>$holder is editing this region right now.") }
+                ContentPopTrigger.triggerFor(player, context())
+                return
+            }
+            awaitingPublish = target?.let(::hasUnpublishedRegionChanges) == true
+        }
+        editRegistry.enterMode(player.uniqueId, RegionModeKind.Editor)
+        seedWorkingPlacement()
+        // A mode pushed on top of this one disposed it, which discarded the staged writes, but the
+        // working model and the whole edit history survived in memory and are about to be drawn
+        // again. Staging them back matches what the builder sees; leaving it would show an edited
+        // region that Apply refuses to save and that exiting throws away without asking.
+        restageWorkingFields()
+        val listener = ScrollListener(player, ::onScroll)
+        scrollListener = listener
+        plugin.registerEvents(listener)
+        val inputListener = SpectatorInputListener(
+            player,
+            anchor = { spectatorLock?.anchor },
+            onLockChord = ::toggleSpectatorLock,
+            onSecondaryChord = ::markSpectatorSecondary,
+            onKey = ::onSpectatorKey,
+            onForcedRelease = ::releaseSpectatorLock,
+        )
+        spectatorListener = inputListener
+        plugin.registerEvents(inputListener)
+        val displacementListener = DisplacementListener(
+            player,
+            anchor = { spectatorLock?.anchor },
+            onDisplaced = ::releaseGestures,
+        )
+        this.displacementListener = displacementListener
+        plugin.registerEvents(displacementListener)
+        super.initialize()
+    }
+
+    override suspend fun dispose() {
+        disposed = true
+        carrying = false
+        carryBaseState = null
+        grabbedFace = null
+        dragBaseState = null
+        dragTransform = null
+        dragLocalEye = null
+        scrollListener?.unregister()
+        scrollListener = null
+        spectatorListener?.unregister()
+        spectatorListener = null
+        displacementListener?.unregister()
+        displacementListener = null
+        try {
+            Dispatchers.Sync.switchContext {
+                releaseSpectatorLock(quiet = true)
+                hologram.despawn()
+                outline.despawn()
+                guide.despawn()
+                ghostMarker.despawn()
+            }
+        } finally {
+            // The lock goes back whatever the despawns did. Nothing else ever reclaims it: there is
+            // no quit handler on the registry, so a throw on the way out would leave the region
+            // unopenable by anyone until the server restarts.
+            session?.let { editRegistry.stopEditing(player.uniqueId, it.entryId) }
+            session = null
+            editRegistry.exitMode(player.uniqueId, RegionModeKind.Editor)
+        }
+        if (stagedWrites.isNotEmpty()) {
+            stagedWrites.clear()
+            player.sendActionBar("<gray>Discarded the unsaved region changes.".asMini())
+        }
+        super.dispose()
+    }
+
+    /** Boss bar text for the current capture state, shown while holding the wand. */
+    protected abstract fun instruction(): String
+
+    protected abstract fun wandComponent(): ItemComponent
+
+    /** Whether the rotate tool makes sense for this shape. A sphere has nothing to rotate. */
+    protected open fun supportsRotation(): Boolean = true
+
+    /** The faces the resize tool can aim at, or `null` when the shape has no size fields. */
+    protected open fun faceSpec(): FaceSpec? = null
+
+    /** Called every tick to render markers for the captured points. */
+    protected open fun renderMarkers(eye: Location) {}
+
+    /** Called every tick on the main thread, for mode owned displays beyond the shared ones. */
+    protected open fun updateModeOverlays() {}
+
+    /**
+     * Scroll input while the wand is held. Return `true` to consume the notches. Runs
+     * before the sneak gate, so a wand gesture can consume plain scrolls the way the
+     * region carry does.
+     */
+    protected open fun onWandScroll(steps: Int): Boolean = false
+
+    /** Whether a mode owned gesture, like the polygon's point carry, is in progress. */
+    protected open fun modeGestureActive(): Boolean = false
+
+    /** Puts a mode owned gesture back without keeping it. */
+    protected open fun cancelModeGesture() {}
+
+    /** Confirms a mode owned gesture, recording it, like placing a carried region. */
+    protected open fun finishModeGesture() {}
+
+    /** The refusal shown while a mode owned gesture blocks other tools. */
+    protected open fun modeGestureRefusal(): String = "<red>Finish the current gesture first."
+
+    /** The spectate label while a mode owned gesture runs, like "is moving a point". */
+    protected open fun modeGestureActivity(): String? = null
+
+    /** Called every tick on the main thread before the outline update, for mode gestures. */
+    protected open fun tickModeGesture() {}
+
+    /** The boss bar instruction while the player is a free flying spectator. */
+    protected open fun spectatorHint(): String =
+        "fly to the spot and press <white>jump + sneak</white> to lock in"
+
+    /** The tool the spectator drives: the held slot froze when the hotbar keys stopped reaching the server. */
+    private fun spectatorToolName(): String = when (player.inventory.heldItemSlot) {
+        WAND_SLOT -> "Wand"
+        MOVE_SLOT -> "Move"
+        rotateSlot -> "Rotate"
+        resizeSlot -> "Resize"
+        else -> "Capture"
+    }
+
+    /** The boss bar instruction while the spectator lock drives the wand. */
+    protected open fun lockedWandHint(): String =
+        "<white>WASD</white>, <white>space</white> and <white>shift</white> move the cube, " +
+                "<white>ctrl</white> marks it, <white>jump + sneak</white> releases"
+
+    private fun lockedSpectatorHint(): String = when (player.inventory.heldItemSlot) {
+        WAND_SLOT -> lockedWandHint()
+
+        MOVE_SLOT ->
+            "<white>WASD</white>, <white>space</white> and <white>shift</white> nudge the region $MOVE_STEP, " +
+                    "<white>jump + sneak</white> releases"
+
+        rotateSlot ->
+            "<white>A/D</white> turn the yaw, <white>W/S</white> tilt it away or toward you $ROTATE_STEP°, " +
+                    "<white>jump + sneak</white> releases"
+
+        resizeSlot ->
+            if (pinnedFaceId != null) {
+                "<white>${targetedFace?.label ?: "face"}</white> pinned: <white>W/S</white> keep driving it, " +
+                        "<white>space</white> releases it, <white>jump + sneak</white> unlocks"
+            } else {
+                "aim at a face: <white>W</white> pushes it away, <white>S</white> pulls it toward you, " +
+                        "<white>space</white> pins the face, <white>jump + sneak</white> releases"
+            }
+
+        else -> "no ghost controls on this slot, <white>jump + sneak</white> releases"
+    }
+
+    /**
+     * The entry as the editor should see it: the staged copy when the page has unpublished
+     * edits, so reopening the editor after an Apply shows the applied values instead of the
+     * still published ones. Falls back to the published runtime entry. Resolved once, since a
+     * session's own Apply closes the mode and nothing else changes this entry mid session.
+     */
+    @PublishedApi
+    internal fun editedEntryRaw(): Entry? {
+        if (!stagedEntryResolved) {
+            val ref = entryRef
+            stagedEntry = ref?.stagedEntry() ?: ref?.get()
+            stagedEntryResolved = true
+        }
+        return stagedEntry
+    }
+
+    /**
+     * The region being edited: the entry itself when it is a definition entry, or the inline
+     * definition the entry holds.
+     */
+    @PublishedApi
+    internal fun definition(): RegionDefinition? = editedEntryRaw()?.let { target?.definitionOf(it) }
+
+    /**
+     * The shape the entry currently holds, when it is the shape this editor edits. Reading
+     * the size through the shape rather than the entry's own fields lets one editor serve
+     * both a definition entry and an inline definition: the field names are the same,
+     * only the path to them differs.
+     */
+    protected inline fun <reified S : Shape> editedShape(): S? = definition()?.buildShapeOrNull() as? S
+
+    private fun stageWrite(path: String, value: Any, type: Type) {
+        stagedWrites[path] = StagedWrite(value, type)
+    }
+
+    private fun placementPath(): String = target?.placementPath ?: ""
+
+    private fun shapePath(): String = target?.shapePath ?: ""
+
+    /**
+     * The placement the entry's origin field would receive: the working origin plus the
+     * accumulated single sided resize shift.
+     */
+    private fun effectiveOrigin(): Position? {
+        val origin = workingOrigin ?: return null
+        val shift = resizeShift
+        if (shift == Vector.ZERO) return origin
+        return Position(
+            origin.world,
+            origin.x + shift.x,
+            origin.y + shift.y,
+            origin.z + shift.z,
+            origin.yaw,
+            origin.pitch
+        )
+    }
+
+    /**
+     * The placement fields this mode may write. A field bound to a variable on the panel has
+     * no working value, and staging a raw one in its place replaces the binding with a
+     * constant that the builder cannot restore from in game.
+     */
+    protected fun placementWritable(rotation: Boolean = false): Boolean {
+        if (workingOrigin == null) {
+            notifyVariableBound("origin")
+            return false
+        }
+        if (rotation && (workingYaw == null || workingPitch == null)) {
+            notifyVariableBound("rotation")
+            return false
+        }
+        return true
+    }
+
+    protected fun updateWorkingOrigin(position: Position) {
+        workingOrigin = position
+        restageWorkingFields()
+    }
+
+    /**
+     * An origin at [x], [y], [z] in [world], facing nowhere.
+     *
+     * A capture describes where the region sits in the world, and the marks already carry its
+     * whole orientation. A region with `Rotate With Origin` set adds the origin's own facing on
+     * top of that, so a facing left over from wherever the origin was captured before would turn
+     * the published region away from the blocks that were just marked. Nothing else reads a
+     * constant origin's facing, so clearing it here costs nothing.
+     */
+    protected fun originMovedTo(world: World, x: Double, y: Double, z: Double): Position =
+        Position(world, x, y, z, 0f, 0f)
+
+    protected fun updateWorkingYaw(yaw: Float) {
+        workingYaw = yaw
+        restageWorkingFields()
+    }
+
+    /** Rotates the working pitch and stages it. */
+    protected fun updateWorkingPitch(pitch: Float) {
+        workingPitch = pitch
+        restageWorkingFields()
+    }
+
+    /** Rotates the working roll and stages it. */
+    protected fun updateWorkingRoll(roll: Float) {
+        workingRoll = roll
+        restageWorkingFields()
+    }
+
+    /**
+     * Stages an axis aligned rotation when the working model is rotated. Box based
+     * captures call it, since their marks describe a world aligned shape. Variable bound
+     * rotations are left alone.
+     */
+    protected fun resetWorkingRotation() {
+        workingYaw?.takeIf { it != 0f }?.let { updateWorkingYaw(0f) }
+        workingPitch?.takeIf { it != 0f }?.let { updateWorkingPitch(0f) }
+        workingRoll?.takeIf { it != 0f }?.let { updateWorkingRoll(0f) }
+    }
+
+    /**
+     * Accumulates a placement shift along a local frame direction, rotated by the working
+     * yaw and pitch. Single sided face moves use this to keep the opposite face in place.
+     * The shift lives next to the size values instead of in the working origin, so the
+     * resize tool and the move tool never write the same undo history key and tool scoped
+     * undo cannot conflict between them. Returns `false` when the origin is variable bound.
+     */
+    protected fun shiftResizeAnchor(localDirection: Vector, distance: Double): Boolean {
+        val origin = workingOrigin ?: return false
+        val rotated = ResolvedTransform(origin.world, Vector.ZERO, workingYaw ?: 0f, workingPitch ?: 0f, workingRoll ?: 0f)
+            .rotateLocalToWorld(localDirection)
+        resizeShift = Vector(
+            (resizeShift.x + rotated.x * distance).round(3),
+            (resizeShift.y + rotated.y * distance).round(3),
+            (resizeShift.z + rotated.z * distance).round(3),
+        )
+        restageWorkingFields()
+        return true
+    }
+
+    /**
+     * Folds the resize shift away for a fresh placement. Wand captures call this before
+     * setting the origin, so the captured anchor is exactly where the marks put it.
+     */
+    protected fun resetResizeShift() {
+        resizeShift = Vector.ZERO
+    }
+
+    /** Extra state a subclass wants captured in undo history, like marked points. */
+    protected open fun collectState(state: MutableMap<String, Any?>) {}
+
+    /** Restores one subclass state value captured by [collectState]. */
+    protected open fun restoreStateValue(key: String, value: Any?) {}
+
+    /**
+     * Stages the subclass's size fields from the working model again after a history restore,
+     * through [restageField]. Staged writes are derived state: they follow the working
+     * values instead of living in the undo history themselves.
+     */
+    protected open fun restageSizeFields() {}
+
+    /**
+     * Stages [working] for a placement [field], or drops the staged write when it matches
+     * what the entry already holds, so a fully undone editor reads as having nothing to save.
+     */
+    protected fun restageField(field: String, working: Any?, entryValue: Any?, type: Type? = null) {
+        restage(placementPath() + field, working, entryValue, type)
+    }
+
+    /** [restageField] for one of the shape's own fields. */
+    protected fun restageShapeField(field: String, working: Any?, entryValue: Any?, type: Type? = null) {
+        restage(shapePath() + field, working, entryValue, type)
+    }
+
+    private fun restage(path: String, working: Any?, entryValue: Any?, type: Type?) {
+        if (working == null) return
+        if (working == entryValue) {
+            stagedWrites.remove(path)
+            return
+        }
+        stageWrite(path, working, type ?: working.javaClass)
+    }
+
+    private fun editorState(): Map<String, Any?> {
+        val state = mutableMapOf(
+            KEY_ORIGIN to workingOrigin,
+            KEY_OFFSET to workingOffset,
+            KEY_YAW to workingYaw,
+            KEY_PITCH to workingPitch,
+            KEY_ROLL to workingRoll,
+            KEY_RESIZE_SHIFT to resizeShift,
+        )
+        collectState(state)
+        return state
+    }
+
+    private fun applyValues(values: Map<String, Any?>) {
+        for ((key, value) in values) {
+            when (key) {
+                KEY_ORIGIN -> workingOrigin = value as? Position
+                KEY_OFFSET -> workingOffset = value as? Vector ?: Vector.ZERO
+                KEY_YAW -> workingYaw = value as? Float
+                KEY_PITCH -> workingPitch = value as? Float
+                KEY_ROLL -> workingRoll = value as? Float
+                KEY_RESIZE_SHIFT -> resizeShift = value as? Vector ?: Vector.ZERO
+                else -> restoreStateValue(key, value)
+            }
+        }
+        restageWorkingFields()
+    }
+
+    private fun restageWorkingFields() {
+        val definition = definition() ?: return
+        restageField(ORIGIN_FIELD, effectiveOrigin(), (definition.origin as? ConstVar)?.value, Position::class.java)
+        restageField("yaw", workingYaw, (definition.yaw as? ConstVar)?.value)
+        restageField("pitch", workingPitch, (definition.pitch as? ConstVar)?.value)
+        restageField("roll", workingRoll, (definition.roll as? ConstVar)?.value)
+        restageSizeFields()
+    }
+
+    /**
+     * Applies a history restore. The restore is a discrete jump, so the next outline
+     * update snaps into place instead of interpolating across it. The rotate readout
+     * follows the axis the restore touched, so undoing a pitch change does not read as
+     * nothing happening while the boss bar is still showing yaw.
+     */
+    private fun restoreValues(values: Map<String, Any?>) {
+        applyValues(values)
+        restoreEpoch++
+        when {
+            values.containsKey(KEY_ROLL) -> rotatePitchMode = true
+            values.containsKey(KEY_PITCH) && !values.containsKey(KEY_YAW) -> rotatePitchMode = true
+            values.containsKey(KEY_YAW) -> rotatePitchMode = false
+        }
+    }
+
+    /** A short readout of the fields a restore moved, for the undo and redo feedback. */
+    private fun describeRestore(values: Map<String, Any?>): String? {
+        val parts = mutableListOf<String>()
+        (values[KEY_ORIGIN] as? Position)?.let {
+            parts += "origin ${it.x.round(2)}, ${it.y.round(2)}, ${it.z.round(2)}"
+        }
+        (values[KEY_YAW] as? Float)?.let { parts += "yaw ${it.toDouble().round(1)}°" }
+        (values[KEY_PITCH] as? Float)?.let { parts += "pitch ${it.toDouble().round(1)}°" }
+        (values[KEY_ROLL] as? Float)?.let { parts += "roll ${it.toDouble().round(1)}°" }
+        for ((key, value) in values) {
+            if (!key.startsWith("size.") || key == KEY_RESIZE_SHIFT) continue
+            val shown = (value as? Double)?.round(2) ?: value ?: continue
+            parts += "${key.removePrefix("size.")} $shown"
+        }
+        return parts.takeIf { it.isNotEmpty() }?.joinToString(", ")
+    }
+
+    /**
+     * Runs [change] and records the state difference under [tool] when it reports
+     * something actually changed. Bursts with the same [label] within [coalesceMillis]
+     * collapse into one undo step.
+     *
+     * While a face is grabbed, and for every tool but rotate while the region is carried,
+     * the gesture is refused and `false` comes back: a change recorded in the middle of a
+     * gesture would capture a base state the gesture's own entry also spans, and undoing
+     * one would silently revert the other. Rotation is safe mid carry because the carry
+     * entry only ever holds the origin. A mode owned gesture refuses every tool, rotation
+     * included: the base cannot know which keys the gesture's entry will span, so no tool
+     * is provably safe to interleave.
+     */
+    protected fun recorded(tool: String, label: String, coalesceMillis: Long = 0, change: () -> Boolean): Boolean {
+        if (grabbedFace != null) {
+            refuse("<red>Keep or put back the grabbed face first.")
+            return false
+        }
+        if (carrying && tool != EditTool.ROTATE) {
+            refuse("<red>Place the region down first.")
+            return false
+        }
+        if (modeGestureActive()) {
+            refuse(modeGestureRefusal())
+            return false
+        }
+        val before = editorState()
+        if (!change()) return true
+        history.record(tool, label, before, editorState(), coalesceMillis)
+        return true
+    }
+
+    /**
+     * The drop key on a tool: undoes the held tool's last gesture, or redoes the last
+     * undone one while sneaking. Puts a carried region or a grabbed face back first.
+     */
+    protected fun undoOrRedoHeldTool() {
+        if (modeGestureActive()) {
+            cancelModeGesture()
+            return
+        }
+        if (carrying) {
+            cancelCarry()
+            return
+        }
+        if (grabbedFace != null) {
+            cancelFaceDrag()
+            return
+        }
+        val redo = player.isSneaking
+        val tool = toolForSlot(player.inventory.heldItemSlot) ?: run {
+            // A non editing slot like the teleport shard: its drop key owns no history, so it
+            // stays quiet instead of reaching for a global undo the way the arrow item does.
+            nothingLeftForTool(null, redo)
+            return
+        }
+        applyToolResult(tool, if (redo) history.redoTool(tool) else history.undoTool(tool), redo)
+    }
+
+    /** Restores a moved entry's values with feedback, or explains the quiet refusal. */
+    private fun applyToolResult(tool: String, result: ToolHistoryResult, redo: Boolean) {
+        when (result) {
+            is ToolHistoryResult.Restored -> {
+                restoreValues(result.change.values)
+                undoFeedback(
+                    if (redo) "Redid" else "Undid",
+                    result.change.label,
+                    result.change.values,
+                    pitch = if (redo) 1.3f else 0.7f,
+                )
+            }
+
+            is ToolHistoryResult.Entangled -> entangledHint(result.blockingTool, redo)
+            ToolHistoryResult.NothingLeft -> nothingLeftForTool(tool, redo)
+        }
+    }
+
+    /**
+     * The held tool has nothing of its own left to undo or redo. An empty stack is a
+     * normal resting state, not an error, so this is deliberately quiet: a soft hint and
+     * no sound, never the page turn that reads as success or the refusal buzz of a failure.
+     */
+    private fun nothingLeftForTool(tool: String?, redo: Boolean) {
+        val what = tool?.let { "the ${it.replaceFirstChar(Char::uppercase)} tool" } ?: "this tool"
+        player.sendActionBar("<dark_gray>Nothing left to ${if (redo) "redo" else "undo"} for $what.".asMini())
+    }
+
+    /**
+     * A newer change by another tool overlaps the keys this undo or redo would move, so
+     * moving it out of order would corrupt that change. The history stays intact and the
+     * arrow can unwind it in order. A soft hint, no refusal buzz: nothing went wrong.
+     */
+    private fun entangledHint(blockingTool: String, redo: Boolean) {
+        val blocker = blockingTool.replaceFirstChar(Char::uppercase)
+        player.sendActionBar(
+            "<gray>Later $blocker changes overlap this. <white>Use the arrow</white> to ${if (redo) "redo" else "undo"} in order.".asMini(),
+        )
+    }
+
+    /** The arrow item's global undo or redo with an empty stack. Quiet, like [nothingLeftForTool]. */
+    private fun nothingLeft(redo: Boolean) {
+        player.sendActionBar("<dark_gray>Nothing left to ${if (redo) "redo" else "undo"}.".asMini())
+    }
+
+    private fun toolForSlot(slot: Int): String? = when (slot) {
+        WAND_SLOT -> EditTool.WAND
+        MOVE_SLOT -> EditTool.MOVE
+        rotateSlot -> EditTool.ROTATE
+        resizeSlot -> EditTool.RESIZE
+        else -> null
+    }
+
+    private fun undoLastChange() {
+        if (modeGestureActive()) {
+            cancelModeGesture()
+            return
+        }
+        if (carrying) {
+            cancelCarry()
+            return
+        }
+        if (grabbedFace != null) {
+            cancelFaceDrag()
+            return
+        }
+        val restored = history.undoLast() ?: run {
+            nothingLeft(redo = false)
+            return
+        }
+        restoreValues(restored.values)
+        undoFeedback("Undid", restored.label, restored.values)
+    }
+
+    private fun redoLastChange() {
+        // The gesture is cancelled, not committed, the same way undo does it. Committing records the
+        // gesture, and recording clears the redo stack, so the redo the builder asked for would be
+        // gone by the time it was looked up and they would be told there was nothing to redo.
+        if (modeGestureActive()) cancelModeGesture()
+        if (carrying) cancelCarry()
+        if (grabbedFace != null) cancelFaceDrag()
+        val restored = history.redoLast() ?: run {
+            nothingLeft(redo = true)
+            return
+        }
+        restoreValues(restored.values)
+        undoFeedback("Redid", restored.label, restored.values, pitch = 1.3f)
+    }
+
+    private fun undoEverything() {
+        if (modeGestureActive()) cancelModeGesture()
+        if (carrying) cancelCarry()
+        if (grabbedFace != null) cancelFaceDrag()
+        val restored = history.undoAll() ?: run {
+            nothingLeft(redo = false)
+            return
+        }
+        restoreValues(restored.values)
+        undoFeedback("Undid", restored.label, emptyMap())
+    }
+
+    private fun redoEverything() {
+        if (modeGestureActive()) cancelModeGesture()
+        if (carrying) cancelCarry()
+        if (grabbedFace != null) cancelFaceDrag()
+        val restored = history.redoAll() ?: run {
+            nothingLeft(redo = true)
+            return
+        }
+        restoreValues(restored.values)
+        undoFeedback("Redid", restored.label, emptyMap(), pitch = 1.3f)
+    }
+
+    private fun undoFeedback(verb: String, label: String, values: Map<String, Any?>, pitch: Float = 0.7f) {
+        val detail = describeRestore(values)?.let { " <gray>→ <white>$it</white>" } ?: ""
+        player.playSound(player.location, Sound.ITEM_BOOK_PAGE_TURN, 0.7f, pitch)
+        player.sendActionBar(
+            "<gray>$verb <white>$label</white>$detail <gray>(${history.undoCount} undo, ${history.redoCount} redo left).".asMini(),
+        )
+    }
+
+    private fun canApply(): Boolean =
+        carrying || grabbedFace != null || modeGestureActive() || stagedWrites.isNotEmpty()
+
+    private fun applyIfReady() {
+        if (modeGestureActive()) finishModeGesture()
+        if (carrying) placeCarry()
+        if (grabbedFace != null) confirmFaceDrag()
+        if (stagedWrites.isEmpty()) {
+            refuse("<red>Nothing to apply yet. Capture the region or nudge it with the tools first.")
+            return
+        }
+
+        val ref = entryRef
+        if (ref == null) {
+            refuse("<red>This region is not attached to an entry, so there is nothing to save it to.")
+            return
+        }
+
+        val count = stagedWrites.size
+        // The writes are kept when one fails, so a builder can fix the cause (usually the entry
+        // moved page or was deleted on the web) and apply again without redoing the edit.
+        val failure = stagedWrites.entries.firstNotNullOfOrNull { (path, write) ->
+            ref.writeFieldValue(path, write.value, write.type).exceptionOrNull()?.let { path to it }
+        }
+        if (failure != null) {
+            val (path, cause) = failure
+            refuse("<red>Could not save <white>$path</white>: ${cause.message ?: "the entry could not be written"}")
+            return
+        }
+
+        stagedWrites.clear()
+        stagedEntryResolved = false
+
+        player.playSound(player.location, Sound.ENTITY_PLAYER_LEVELUP, 0.5f, 1.6f)
+        player.sendActionBar(
+            "<green>Saved <white>$count</white> field${if (count == 1) "" else "s"}. <gray>Publish on the web to go live.".asMini(),
+        )
+        ContentPopTrigger.triggerFor(player, context())
+    }
+
+    final override suspend fun tick(deltaTime: Duration) {
+        super.tick(deltaTime)
+        Dispatchers.Sync.switchContext {
+            // The hop is already queued when the session is torn down, and the scheduler runs it
+            // anyway. Without this it respawns the outline and the hologram into a mode nobody
+            // holds any more, leaving displays only a chunk unload can clear.
+            if (disposed) return@switchContext
+            tickCarry()
+            tickFaceDrag()
+            tickModeGesture()
+            updateOutline()
+            updateToolGuides()
+            updateGhostMarker()
+            updateModeOverlays()
+            hologram.update(hologramAnchor(), hologramText())
+        }
+        if (disposed) return
+        renderMarkers(player.location)
+        visibleRegion()?.let { renderSurfacePreview(player, it.transform, it.shape, editColor()) }
+        session?.let { it.preview = visibleRegion()?.let(::sessionPreview) }
+    }
+
+    /** The live snapshot the spectator renderer draws for other players near the region. */
+    private fun sessionPreview(region: PendingRegion): SessionPreview = SessionPreview(
+        regionName = editedEntryRaw()?.name ?: "Region",
+        transform = region.transform,
+        shape = region.shape,
+        color = editColor(),
+        activity = when {
+            carrying -> "is carrying the region"
+            grabbedFace != null -> "is dragging the ${grabbedFace?.label}"
+            modeGestureActive() -> modeGestureActivity() ?: "is editing"
+            else -> "is editing"
+        },
+    )
+
+    protected fun emitMarker(block: CapturedBlock, particle: Particle, eye: Location) {
+        if (block.world.identifier != player.world.uid.toString()) return
+
+        val marker = Vector(block.x + 0.5, block.y + 1.2, block.z + 0.5)
+        if (!withinPreviewDistance(marker, eye)) return
+        emitPreviewParticle(player, marker, particle)
+    }
+
+    /** The color this region draws with, from the definition's color property. */
+    protected fun editColor(): Color = definition()?.displayColor(entryRef?.id ?: "") ?: Color.WHITE
+
+    /**
+     * The shape the working model currently describes. Modes with a resize tool track the
+     * sizes themselves, because staged writes are not visible through the entry.
+     */
+    protected open fun workingShape(): Shape? = definition()?.buildShapeOrNull()
+
+    /** An extra hologram line describing the working size, like `half 5.0 × 3.0 × 5.0`. */
+    protected open fun hologramSizeLine(): String? = null
+
+    /**
+     * The live preview of the working model. `null` when the origin is variable bound,
+     * since it cannot resolve at edit time. Regions using `rotateWithOrigin` preview with
+     * the raw yaw and pitch.
+     */
+    private fun workingRegion(): PendingRegion? {
+        val transform = workingTransform() ?: return null
+        val shape = workingShape() ?: return null
+        return PendingRegion(transform, shape)
+    }
+
+    protected fun workingTransform(): ResolvedTransform? {
+        val origin = effectiveOrigin() ?: return null
+        return ResolvedTransform.fromOriginAndOffset(
+            origin,
+            workingOffset,
+            workingYaw ?: 0f,
+            workingPitch ?: 0f,
+            workingRoll ?: 0f,
+        )
+    }
+
+    protected fun isCarryingRegion(): Boolean = carrying
+
+    /** Whether the resize tool holds a grabbed face. */
+    protected fun isFaceGrabbed(): Boolean = grabbedFace != null
+
+    /** Records a grab to place gesture as one history entry, like the region carry. */
+    protected fun recordGestureEntry(
+        tool: String,
+        label: String,
+        before: Map<String, Any?>,
+        after: Map<String, Any?>,
+    ): Boolean = history.record(tool, label, before, after)
+
+    /** Applies a gesture's base state back, snapping the next render. */
+    protected fun restoreGestureBase(values: Map<String, Any?>) = restoreValues(values)
+
+    /** Whether the spectator lock currently freezes the player for key driven editing. */
+    protected fun isSpectatorLocked(): Boolean = spectatorLock != null
+
+    /**
+     * Copies the constant placement fields out of the entry, once. Staged tool writes are
+     * not visible through the entry, so this working copy is the editing truth until the
+     * mode closes. Variable bound fields stay `null` and their tools refuse with a hint.
+     */
+    private fun seedWorkingPlacement() {
+        if (placementSeeded) return
+        placementSeeded = true
+
+        val definition = definition() ?: return
+        (definition.origin as? ConstVar)?.let { workingOrigin = it.value }
+        (definition.offset as? ConstVar)?.let { workingOffset = it.value }
+        (definition.yaw as? ConstVar)?.let { workingYaw = it.value }
+        (definition.pitch as? ConstVar)?.let { workingPitch = it.value }
+        (definition.roll as? ConstVar)?.let { workingRoll = it.value }
+        entryHadPlacement = workingOrigin?.world?.identifier?.isNotBlank() == true
+    }
+
+    /**
+     * Whether the session itself captured enough geometry to describe the region. Modes
+     * with a capture flow override this; a fresh region shows no outline, hologram or tool
+     * guides until either the entry already had a placement or the capture completes.
+     */
+    protected open fun hasCapturedGeometry(): Boolean = true
+
+    private fun regionDefined(): Boolean {
+        val origin = workingOrigin ?: return false
+        if (origin.world.identifier.isBlank()) return false
+        return entryHadPlacement || hasCapturedGeometry()
+    }
+
+    /** The working region, but only once it is actually defined enough to visualize. */
+    private fun visibleRegion(): PendingRegion? = if (regionDefined()) workingRegion() else null
+
+    private fun bossBarTitle(): String {
+        val staged = stagedWrites.size
+        val suffix = if (staged > 0) " <gray>· <yellow>$staged</yellow> unsaved" else ""
+        if (player.gameMode == GameMode.SPECTATOR) {
+            val toolName = spectatorToolName()
+            if (spectatorLock == null) {
+                return "<gold><bold>Ghost $toolName</bold> <gray>${spectatorHint()}$suffix"
+            }
+            return "<gold><bold>Ghost $toolName <yellow>[locked]</yellow></bold> <gray>${lockedSpectatorHint()}$suffix"
+        }
+        if (modeGestureActive()) {
+            return instruction() + suffix
+        }
+        if (carrying) {
+            return "<gold><bold>Carrying</bold> <gray>scroll to push or pull, <white>right-click</white> places, <white>left-click</white> puts back"
+        }
+        grabbedFace?.let {
+            return "<gold><bold>Dragging ${it.label}</bold> <gray>aim to move it, <white>right-click</white> keeps, <white>left-click</white> cancels"
+        }
+        return when (player.inventory.heldItemSlot) {
+            MOVE_SLOT ->
+                "<gold><bold>Move</bold> <gray><white>right-click</white> carries, <white>left-click</white> nudges, " +
+                        "<white>F</white> axis <yellow>[${moveAxisLock.display}]</yellow>$suffix"
+
+            rotateSlot -> {
+                val shown = if (rotatePitchMode) {
+                    val pitch = workingPitch
+                    val roll = workingRoll
+                    if (pitch == null || roll == null) "variable" else "${tiltDegrees(pitch, roll).round(1)}°"
+                } else {
+                    workingYaw?.let { "${it.toDouble().round(1)}°" } ?: "variable"
+                }
+                "<gold><bold>Rotate ${if (rotatePitchMode) "Tilt" else "Yaw"}</bold> <gray>now <white>$shown</white>, " +
+                        "clicks step, <white>F</white> switches axis$suffix"
+            }
+
+            resizeSlot -> {
+                val face = targetedFace
+                if (face == null) {
+                    "<gold><bold>Resize</bold> <gray>aim at a face of the region$suffix"
+                } else {
+                    "<gold><bold>Resize</bold> <gray>aiming at <white>${face.label}</white>: <white>right-click</white> grabs, " +
+                            "<white>left-click</white> pushes away, sneak pulls toward you$suffix"
+                }
+            }
+
+            TELEPORT_SLOT ->
+                "<gold><bold>Teleport</bold> <gray><white>right-click</white> region, " +
+                        "<white>sneak right-click</white> border, <white>left-click</white> back$suffix"
+            UNDO_SLOT ->
+                "<gold><bold>History</bold> <gray><white>${history.undoCount}</white> to undo, <white>${history.redoCount}</white> to redo, " +
+                        "sneak-click for all$suffix"
+
+            APPLY_SLOT ->
+                if (canApply()) "<green><bold>Apply</bold> <gray>saves to the entry; publish on the web to go live$suffix"
+                else "<gray><bold>Apply</bold> nothing to save yet"
+
+            else -> instruction() + suffix
+        }
+    }
+
+    private fun moveTool(): ItemComponent = TransformToolComponent(
+        slot = MOVE_SLOT,
+        material = Material.PISTON,
+        title = {
+            when {
+                carrying -> "<gold><bold>Move Region</bold> <yellow>(carrying)"
+                moveAxisLock != AxisLock.Auto -> "<gold><bold>Move Region</bold> <yellow>[${moveAxisLock.display}]"
+                else -> "<gold><bold>Move Region"
+            }
+        },
+        loreText = {
+            if (carrying) {
+                """
+                    |
+                    |<line> <gray>The region follows your crosshair.
+                    |<line> <gray>Scroll to push or pull, sneak for free placement.
+                    |<line> <gray>Right-click to place it, left-click to put it back.
+                """.trimMargin()
+            } else {
+                """
+                    |
+                    |<line> <gray>Right-click to pick the region up and carry it.
+                    |<line> <gray>Left-click to nudge $MOVE_STEP the way you look (sneak: $MOVE_STEP_LARGE).
+                    |<line> <gray>Sneak and scroll to slide in $MOVE_FINE_STEP steps.
+                    |<line> <gray><white>F</white> locks the axis, <white>Q</white> undoes, sneak <white>Q</white> redoes.
+                """.trimMargin()
+            }
+        },
+        glint = { carrying },
+        onSwap = ::cycleMoveAxis,
+        onDrop = ::undoOrRedoHeldTool,
+    ) { click ->
+        if (click.grow) {
+            if (carrying) placeCarry() else grabRegion()
+            return@TransformToolComponent
+        }
+        if (carrying) {
+            cancelCarry()
+            return@TransformToolComponent
+        }
+        nudgeOrigin(
+            currentMoveDirection(),
+            if (click.large) MOVE_STEP_LARGE else MOVE_STEP,
+            "Origin nudge",
+        )
+    }
+
+    private fun rotateTool(): ItemComponent = TransformToolComponent(
+        slot = rotateSlot,
+        material = Material.CLOCK,
+        title = { "<gold><bold>Rotate Region</bold> <yellow>[${if (rotatePitchMode) "Tilt" else "Yaw"}]" },
+        loreText = {
+            """
+                |
+                |<line> <gray>Yaw: right-click and left-click turn it either way.
+                |<line> <gray>Tilt: left-click tips the top away from you,
+                |<line> <gray>right-click pulls it back, a clean pitch or roll.
+                |<line> <gray>Steps of $ROTATE_STEP°, sneak-click for $ROTATE_STEP_LARGE°.
+                |<line> <gray>Sneak and scroll for $ROTATE_FINE_STEP° steps.
+                |<line> <gray><white>F</white> switches yaw and tilt, <white>Q</white> undoes, sneak <white>Q</white> redoes.
+            """.trimMargin()
+        },
+        onSwap = ::toggleRotateMode,
+        onDrop = ::undoOrRedoHeldTool,
+    ) { click ->
+        val step = if (click.large) ROTATE_STEP_LARGE else ROTATE_STEP
+        // In tilt mode left click applies the positive, tipping away step, matching how
+        // left click pushes faces and corners on the other tools.
+        val positive = if (rotatePitchMode) !click.grow else click.grow
+        applyRotation(if (positive) step else -step, coalesce = false)
+    }
+
+    private fun resizeTool(): ItemComponent = TransformToolComponent(
+        slot = resizeSlot,
+        material = Material.SLIME_BLOCK,
+        title = {
+            when {
+                grabbedFace != null -> "<gold><bold>Resize Region</bold> <yellow>(dragging ${grabbedFace?.label})"
+                targetedFace != null -> "<gold><bold>Resize Region</bold> <yellow>[${targetedFace?.label}]"
+                else -> "<gold><bold>Resize Region"
+            }
+        },
+        loreText = {
+            if (grabbedFace != null) {
+                """
+                    |
+                    |<line> <gray>The face follows where you look, along its normal.
+                    |<line> <gray>Sneak to snap to $RESIZE_FINE_STEP steps.
+                    |<line> <gray>Right-click to keep it, left-click to put it back.
+                """.trimMargin()
+            } else {
+                """
+                    |
+                    |<line> <gray>Aim at a face; the glowing panel shows the pick.
+                    |<line> <gray>Right-click to grab it and drag it by looking.
+                    |<line> <gray>Left-click pushes it away from you $RESIZE_STEP,
+                    |<line> <gray>sneak-click pulls it toward you.
+                    |<line> <gray>Sneak and scroll for $RESIZE_FINE_STEP steps.
+                    |<line> <gray><white>Q</white> undoes, sneak <white>Q</white> redoes.
+                """.trimMargin()
+            }
+        },
+        glint = { grabbedFace != null },
+        onDrop = ::undoOrRedoHeldTool,
+    ) { click ->
+        if (grabbedFace != null) {
+            if (click.grow) confirmFaceDrag() else cancelFaceDrag()
+            return@TransformToolComponent
+        }
+        if (click.grow) {
+            grabFace()
+            return@TransformToolComponent
+        }
+        // The click follows the view: pushing moves the aimed face the way the player
+        // looks, whichever side of the region they stand on, and sneaking pulls it back.
+        val along = viewFollowSign()
+        stepTargetedFace((if (click.large) -RESIZE_STEP else RESIZE_STEP) * along, coalesce = false)
+    }
+
+    private fun onScroll(heldSlot: Int, steps: Int): Boolean {
+        if (carrying) {
+            if (heldSlot != MOVE_SLOT) return false
+            carryDistance = (carryDistance + steps * CARRY_SCROLL_STEP)
+                .coerceIn(CARRY_MIN_DISTANCE, CARRY_MAX_DISTANCE)
+            return true
+        }
+        if (heldSlot == WAND_SLOT && onWandScroll(steps)) return true
+        if (grabbedFace != null && heldSlot == resizeSlot) return true
+        if (!player.isSneaking) return false
+        return when (heldSlot) {
+            MOVE_SLOT -> {
+                nudgeOrigin(
+                    currentMoveDirection(),
+                    steps * MOVE_FINE_STEP,
+                    "Origin slide",
+                    coalesce = true
+                )
+                true
+            }
+
+            rotateSlot -> {
+                applyRotation(steps * ROTATE_FINE_STEP, coalesce = true)
+                true
+            }
+
+            resizeSlot -> {
+                stepTargetedFace(steps * RESIZE_FINE_STEP, coalesce = true)
+                true
+            }
+
+            else -> false
+        }
+    }
+
+    private fun nudgeOrigin(direction: Vector, distance: Double, label: String, coalesce: Boolean = false) {
+        val origin = workingOrigin ?: run {
+            notifyVariableBound("origin")
+            return
+        }
+        recorded(EditTool.MOVE, label, if (coalesce) SCROLL_COALESCE_MILLIS else 0) {
+            val moved = Position(
+                origin.world,
+                (origin.x + direction.x * distance).round(2),
+                (origin.y + direction.y * distance).round(2),
+                (origin.z + direction.z * distance).round(2),
+                origin.yaw,
+                origin.pitch,
+            )
+            updateWorkingOrigin(moved)
+            val shown = effectiveOrigin() ?: moved
+            toolFeedback(
+                "<gold>Origin <white>${shown.x.round(2)}, ${shown.y.round(2)}, ${shown.z.round(2)}",
+                distance >= 0
+            )
+            true
+        }
+    }
+
+    private fun applyRotation(delta: Float, coalesce: Boolean) {
+        val window = if (coalesce) SCROLL_COALESCE_MILLIS else 0L
+        if (rotatePitchMode) {
+            val yaw = workingYaw
+            val pitch = workingPitch
+            val roll = workingRoll
+            if (yaw == null || pitch == null || roll == null) {
+                notifyVariableBound("rotation")
+                return
+            }
+            recorded(EditTool.ROTATE, "Tilt", window) {
+                val (newPitch, newRoll) = steppedTilt(pitch, roll, tiltFacing(), yaw, delta)
+                updateWorkingPitch(newPitch)
+                updateWorkingRoll(newRoll)
+                toolFeedback("<gold>Tilt <white>${tiltDegrees(newPitch, newRoll).round(1)}°", delta >= 0)
+                true
+            }
+            return
+        }
+
+        val yaw = workingYaw ?: run {
+            notifyVariableBound("yaw")
+            return
+        }
+        recorded(EditTool.ROTATE, "Yaw", window) {
+            val rotated = normalizeDegrees(yaw + delta)
+            updateWorkingYaw(rotated)
+            toolFeedback("<gold>Yaw <white>${rotated.toDouble().round(1)}°", delta >= 0)
+            true
+        }
+    }
+
+    /**
+     * The quantized direction from the viewer toward the region's visual center, the same
+     * one the displayed tilt dial uses, so the tilt gesture rotates exactly the way the
+     * dial says: a clean pitch or roll, whichever side the player looks from.
+     */
+    private fun tiltFacing(): Vector {
+        val transform = workingTransform() ?: return Vector(0.0, 0.0, 1.0)
+        val anchor = transform.worldOrigin
+        val center = boundsCenter(guideBounds(transform))
+        val eye = eyeVector()
+        return quantizedTiltFacing(
+            anchor.x + center.x - eye.x,
+            anchor.z + center.z - eye.z,
+            transform.yawDegrees,
+        )
+    }
+
+    private fun stepTargetedFace(delta: Double, coalesce: Boolean) {
+        val spec = faceSpec() ?: return
+        val face = targetedFace ?: run {
+            refuse("<red>Aim at a face of the region first.")
+            return
+        }
+        recorded(EditTool.RESIZE, face.label, if (coalesce) SCROLL_COALESCE_MILLIS else 0) {
+            val result = spec.moveFace(face, delta)
+            if (result.changed) toolFeedback(result.message, delta >= 0) else refuse(result.message)
+            result.changed
+        }
+    }
+
+    private fun grabFace() {
+        faceSpec() ?: return
+        if (modeGestureActive()) {
+            refuse(modeGestureRefusal())
+            return
+        }
+        val face = targetedFace ?: run {
+            refuse("<red>Aim at a face of the region first.")
+            return
+        }
+        val transform = workingTransform() ?: run {
+            notifyVariableBound("origin")
+            return
+        }
+
+        val eye = player.eyeLocation
+        dragBaseState = editorState()
+        dragTransform = transform
+        // The eye position at grab time, in the region's local frame. View dependent faces
+        // (a sphere's surface, a capsule's side) rebuild their bases from the eye; frozen at
+        // the grab, the highlight panel keeps its orientation for the whole drag.
+        dragLocalEye = transform.toLocal(Vector(eye.x, eye.y, eye.z))
+        grabbedFace = face
+        lastDragDelta = 0.0
+        player.playSound(player.location, Sound.BLOCK_PISTON_EXTEND, 0.5f, 1.4f)
+        player.sendActionBar(
+            "<gold>Grabbed ${face.label}. <gray>Look to drag it, right-click to keep it, left-click to put it back.".asMini(),
+        )
+    }
+
+    /**
+     * While a face is grabbed it tracks the view ray: the drag distance is where the ray
+     * passes closest to the face's normal line. The base state is restored before every
+     * application, so the drag is absolute from the grab and never accumulates error.
+     */
+    private fun tickFaceDrag() {
+        val face = grabbedFace ?: return
+        val spec = faceSpec() ?: return
+        val base = dragTransform ?: return
+        // The drag is a view ray measured against the face, so a player who left the world is
+        // measuring against coordinates that mean nothing here. It would keep resizing the
+        // region from the far side of a portal, out of sight of the outline.
+        if (base.world.identifier != player.world.uid.toString()) {
+            cancelFaceDrag()
+            return
+        }
+
+        val eye = player.eyeLocation
+        val eyeVec = Vector(eye.x, eye.y, eye.z)
+        val direction = eye.direction
+        val directionVec = Vector(direction.x, direction.y, direction.z)
+        val center = base.toWorld(face.center)
+        val normal = base.rotateLocalToWorld(face.normal)
+
+        var delta = dragDelta(eyeVec, directionVec, center, normal)
+        delta = delta.coerceIn(-MAX_FACE_DRAG, MAX_FACE_DRAG)
+        delta = if (player.isSneaking) snapToQuarterGrid(delta) else delta.round(2)
+        if (delta == lastDragDelta) return
+        lastDragDelta = delta
+
+        dragBaseState?.let(::applyValues)
+        val result = spec.moveFace(face, delta)
+        if (result.changed) {
+            player.sendActionBar("${result.message} <gray>(${if (delta >= 0) "+" else ""}${delta.round(2)})".asMini())
+        }
+    }
+
+    private fun confirmFaceDrag() {
+        val face = grabbedFace ?: return
+        grabbedFace = null
+        dragTransform = null
+        dragLocalEye = null
+        val base = dragBaseState ?: return
+        dragBaseState = null
+
+        if (!history.record(EditTool.RESIZE, face.label, base, editorState())) {
+            player.sendActionBar("<gray>The ${face.label} ended up where it started.".asMini())
+            return
+        }
+        player.playSound(player.location, Sound.BLOCK_PISTON_CONTRACT, 0.5f, 1.1f)
+        player.sendActionBar("<gold>Kept the ${face.label}.".asMini())
+        flashHeldItem()
+    }
+
+    private fun cancelFaceDrag() {
+        if (grabbedFace == null) return
+        grabbedFace = null
+        dragTransform = null
+        dragLocalEye = null
+        dragBaseState?.let(::restoreValues)
+        dragBaseState = null
+        player.playSound(player.location, Sound.BLOCK_PISTON_CONTRACT, 0.5f, 0.8f)
+        player.sendActionBar("<gray>Put the face back where it was.".asMini())
+    }
+
+    private fun grabRegion() {
+        if (grabbedFace != null) {
+            refuse("<red>Keep or put back the grabbed face first.")
+            return
+        }
+        if (modeGestureActive()) {
+            refuse(modeGestureRefusal())
+            return
+        }
+        val origin = workingOrigin ?: run {
+            notifyVariableBound("origin")
+            return
+        }
+        if (origin.world.identifier != player.world.uid.toString()) {
+            refuse("<red>The region is in another world. Teleport to it first.")
+            return
+        }
+
+        // The carry only ever moves the origin, so its base state holds only the origin:
+        // a rotation dialed in mid carry stays its own history entry, and neither placing
+        // nor cancelling the carry touches it.
+        carryBaseState = mapOf(KEY_ORIGIN to workingOrigin)
+        carrying = true
+        val anchor = workingTransform()?.worldOrigin ?: Vector(origin.x, origin.y, origin.z)
+        carryDistance = player.eyeLocation.distance(Location(player.world, anchor.x, anchor.y, anchor.z))
+            .coerceIn(CARRY_MIN_DISTANCE, CARRY_MAX_DISTANCE)
+        player.playSound(player.location, Sound.ENTITY_ITEM_FRAME_REMOVE_ITEM, 0.8f, 1.1f)
+        player.sendActionBar(
+            "<gold>Carrying the region. <gray>Scroll to push or pull, right-click to place, left-click to put it back.".asMini(),
+        )
+    }
+
+    private fun placeCarry() {
+        if (!carrying) return
+        carrying = false
+        val origin = workingOrigin ?: return
+        val placed = Position(
+            origin.world,
+            origin.x.round(3),
+            origin.y.round(3),
+            origin.z.round(3),
+            origin.yaw,
+            origin.pitch,
+        )
+        updateWorkingOrigin(placed)
+        carryBaseState?.let { history.record(EditTool.MOVE, "Region carry", it, mapOf(KEY_ORIGIN to workingOrigin)) }
+        carryBaseState = null
+        player.playSound(player.location, Sound.ENTITY_ITEM_FRAME_ADD_ITEM, 0.8f, 1.0f)
+        player.sendActionBar("<gold>Placed at <white>${placed.x}, ${placed.y}, ${placed.z}</white>.".asMini())
+        flashHeldItem()
+    }
+
+    /**
+     * Puts back whatever the player is holding, wherever they ended up.
+     *
+     * Every one of these gestures is measured from the eye, so a player moved by anything other
+     * than walking takes the region, the face or the corner with them. The editor refuses its own
+     * teleport tool mid gesture; this covers the ways out it does not own, like a command, a
+     * portal, or dying.
+     */
+    private fun releaseGestures() {
+        cancelModeGesture()
+        cancelCarry()
+        cancelFaceDrag()
+    }
+
+    private fun cancelCarry() {
+        if (!carrying) return
+        carrying = false
+        carryBaseState?.let(::restoreValues)
+        carryBaseState = null
+        player.playSound(player.location, Sound.ENTITY_ITEM_FRAME_ROTATE_ITEM, 0.8f, 0.8f)
+        player.sendActionBar("<gray>Put the region back where it was.".asMini())
+    }
+
+    /**
+     * While carried, the region hangs on the player's crosshair: on the first block the
+     * view ray hits, or floating at the carry distance. Runs on the main thread because
+     * the ray trace reads world state.
+     */
+    private fun tickCarry() {
+        if (!carrying) return
+        val origin = workingOrigin ?: run {
+            carrying = false
+            return
+        }
+        if (origin.world.identifier != player.world.uid.toString()) {
+            cancelCarry()
+            return
+        }
+
+        val eye = player.eyeLocation
+        val direction = eye.direction
+        val hit = player.world
+            .rayTraceBlocks(eye, direction, carryDistance, FluidCollisionMode.NEVER, true)
+            ?.hitPosition
+        val target = Vector(
+            hit?.x ?: (eye.x + direction.x * carryDistance),
+            hit?.y ?: (eye.y + direction.y * carryDistance),
+            hit?.z ?: (eye.z + direction.z * carryDistance),
+        )
+        // The crosshair carries the effective anchor, so the resize shift is subtracted
+        // back out of the raw working origin.
+        val shift = resizeShift
+        val snap = !player.isSneaking
+        fun settle(value: Double): Double = if (snap) snapToHalfGrid(value) else value.round(2)
+        workingOrigin = Position(
+            origin.world,
+            settle(target.x) - shift.x,
+            settle(target.y) - shift.y,
+            settle(target.z) - shift.z,
+            origin.yaw,
+            origin.pitch,
+        )
+    }
+
+    /**
+     * Keeps the display entity outline, the face highlight and the face targeting in sync
+     * with the working model. Main thread only.
+     */
+    private fun updateOutline() {
+        val region = visibleRegion()
+        if (region == null || region.transform.world.identifier != player.world.uid.toString()) {
+            targetedFace = null
+            outline.despawn()
+            return
+        }
+
+        val snap = restoreEpoch != renderedRestoreEpoch
+        renderedRestoreEpoch = restoreEpoch
+        val anchor = region.transform.worldOrigin
+        val color = editColor()
+        outline.update(
+            Location(player.world, anchor.x, anchor.y, anchor.z),
+            region.transform.yawDegrees,
+            region.transform.pitchDegrees,
+            region.shape,
+            color,
+            snap = snap,
+            rollDegrees = region.transform.rollDegrees,
+        )
+
+        val spec = faceSpec()
+        if (spec == null || player.inventory.heldItemSlot != resizeSlot || carrying || modeGestureActive()) {
+            targetedFace = null
+            pinnedFaceId = null
+            outline.updateHighlight(null, color)
+            return
+        }
+
+        val eye = player.eyeLocation
+        val eyeVec = Vector(eye.x, eye.y, eye.z)
+        val localEye = region.transform.toLocal(eyeVec)
+        val grabbed = grabbedFace
+        val face = if (grabbed == null) {
+            val pinned = pinnedFaceId?.let { id -> spec.faces(localEye).firstOrNull { it.id == id } }
+            if (pinnedFaceId != null && pinned == null) pinnedFaceId = null
+            if (pinned != null) {
+                targetedFace = pinned
+                pinned
+            } else {
+                val direction = eye.direction
+                val ahead = Vector(eye.x + direction.x, eye.y + direction.y, eye.z + direction.z)
+                val localDirection = (region.transform.toLocal(ahead) - localEye).normalize()
+                pickFace(spec.faces(localEye), localEye, localDirection, targetedFace?.id).also { targetedFace = it }
+            }
+        } else {
+            spec.faces(dragLocalEye ?: localEye).firstOrNull { it.id == grabbed.id } ?: grabbed
+        }
+
+        val held = grabbed != null || pinnedFaceId != null
+        val rotation = RegionOutline.regionRotation(
+            region.transform.yawDegrees,
+            region.transform.pitchDegrees,
+            region.transform.rollDegrees,
+        )
+        outline.updateHighlight(
+            face?.let {
+                RegionOutline.panelTransformation(
+                    rotation,
+                    it.center,
+                    it.uBasis,
+                    it.vBasis,
+                    it.normal,
+                    it.halfU,
+                    it.halfV
+                )
+            },
+            if (held) Color(0xFFFFD54A.toInt()) else color,
+            // The restore epoch and the held state join the key: a history restore snaps
+            // the panel, and so does grabbing, pinning or releasing a face, where the
+            // panel switches its basis or must apply the held color again.
+            face?.let { "${it.id}#$restoreEpoch#$held" },
+        )
+    }
+
+    private fun teleportToRegion() {
+        // The hotbar is frozen mid gesture, but the shard is still reachable through the
+        // inventory screen, and teleporting away with the region on the crosshair drags it to
+        // wherever the builder lands.
+        if (carrying || grabbedFace != null || modeGestureActive()) {
+            refuse("<red>Finish what you are holding before teleporting.")
+            return
+        }
+        val transform = workingTransform() ?: run {
+            refuse("<red>The origin is bound to a variable, there is nowhere to teleport.")
+            return
+        }
+        val world = resolveBukkitWorld(transform.world.identifier) ?: run {
+            refuse("<red>The region's world is not loaded.")
+            return
+        }
+
+        val anchor = transform.worldOrigin
+        val target =
+            liftToPassable(Location(world, anchor.x, anchor.y, anchor.z, player.location.yaw, player.location.pitch))
+        returnLocation = player.location
+        player.teleport(target)
+        player.playSound(target, Sound.ENTITY_ENDERMAN_TELEPORT, 0.7f, 1f)
+        player.sendActionBar("<gold>Teleported to the region. <gray>Left-click to go back.".asMini())
+    }
+
+    /**
+     * Teleports to the boundary the player is looking at. Aiming works from inside the region
+     * too: the view ray still leaves through the stretch of border the player faces, which is
+     * the case this exists for, since a region too big to see the outline of is exactly the one
+     * whose border is hard to reach. A ray that never crosses the boundary falls back to the
+     * nearest point on it.
+     */
+    private fun teleportToBorder() {
+        if (carrying || grabbedFace != null || modeGestureActive()) {
+            refuse("<red>Finish what you are holding before teleporting.")
+            return
+        }
+        if (!regionDefined()) {
+            refuse("<red>The region has no shape yet. Capture it with the wand first.")
+            return
+        }
+        val region = workingRegion() ?: run {
+            refuse("<red>The origin is bound to a variable, there is nowhere to teleport.")
+            return
+        }
+        val world = resolveBukkitWorld(region.transform.world.identifier) ?: run {
+            refuse("<red>The region's world is not loaded.")
+            return
+        }
+
+        val result = borderTeleport(world, region.transform, region.shape, player.eyeLocation) ?: run {
+            refuse("<red>Could not find a border to teleport to.")
+            return
+        }
+
+        returnLocation = player.location
+        player.teleport(result.destination)
+        player.playSound(result.destination, Sound.ENTITY_ENDERMAN_TELEPORT, 0.7f, 1.2f)
+        val hint = if (result.usedFallback) " <gray>Nothing in your aim, so this is the nearest edge." else ""
+        player.sendActionBar("<gold>Teleported to the border.$hint <gray>Left-click to go back.".asMini())
+    }
+
+    private fun teleportBack() {
+        val back = returnLocation ?: run {
+            refuse("<red>No previous spot to return to yet.")
+            return
+        }
+        returnLocation = player.location
+        player.teleport(back)
+        player.playSound(back, Sound.ENTITY_ENDERMAN_TELEPORT, 0.7f, 0.8f)
+        player.sendActionBar("<gold>Teleported back. <gray>Left-click again to bounce between the two.".asMini())
+    }
+
+    private fun cycleMoveAxis() {
+        moveAxisLock = moveAxisLock.next()
+        autoMoveMemory = null
+        modeFeedback("<gold>Move axis <white>${moveAxisLock.display}")
+    }
+
+    /** [moveDirection] with the auto axis kept steady across ticks by its hysteresis. */
+    private fun currentMoveDirection(): Vector {
+        val direction = moveDirection(player, moveAxisLock, autoMoveMemory)
+        autoMoveMemory = if (moveAxisLock == AxisLock.Auto) direction else null
+        return direction
+    }
+
+    private fun toggleRotateMode() {
+        rotatePitchMode = !rotatePitchMode
+        modeFeedback("<gold>Rotating <white>${if (rotatePitchMode) "tilt" else "yaw"}")
+    }
+
+    private fun modeFeedback(message: String) {
+        player.sendActionBar(message.asMini())
+        player.playSound(player.location, Sound.BLOCK_LEVER_CLICK, 0.6f, 1.3f)
+    }
+
+    /** Action bar value readout, a click sound pitched up when growing, and an item flash. */
+    protected fun toolFeedback(message: String, grow: Boolean) {
+        player.sendActionBar(message.asMini())
+        player.playSound(player.location, Sound.BLOCK_NOTE_BLOCK_HAT, 0.5f, if (grow) 1.25f else 0.75f)
+        flashHeldItem()
+    }
+
+    protected fun captureFeedback(message: String, pitch: Float = 1f) {
+        player.sendActionBar(message.asMini())
+        player.playSound(player.location, Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 0.5f, pitch)
+        flashHeldItem()
+    }
+
+    protected fun refuse(message: String) {
+        player.sendActionBar(message.asMini())
+        player.playSound(player.location, Sound.ENTITY_VILLAGER_NO, 0.6f, 1f)
+    }
+
+    /**
+     * The vanilla cooldown sweep over the held item, as visual confirmation the click
+     * registered. Only safe on the main thread, where all interaction handlers run.
+     */
+    private fun flashHeldItem() {
+        val held = player.inventory.itemInMainHand
+        if (!held.isEmpty) player.setCooldown(held.type, FLASH_TICKS)
+    }
+
+    protected fun notifyVariableBound(field: String) {
+        refuse("<red>The $field is bound to a variable and cannot be changed here.")
+    }
+
+    private fun hologramAnchor(): Location? {
+        val region = visibleRegion() ?: return null
+        if (region.transform.world.identifier != player.world.uid.toString()) return null
+
+        val bounds = region.shape.localBounds.rotated(
+            region.transform.yawDegrees,
+            region.transform.pitchDegrees,
+            region.transform.rollDegrees,
+        )
+        val anchor = region.transform.worldOrigin
+        return Location(player.world, anchor.x, anchor.y + bounds.maxY + HOLOGRAM_LIFT, anchor.z)
+    }
+
+    private fun hologramText(): String {
+        val color = editColor()
+        val hex = String.format("#%02X%02X%02X", color.red, color.green, color.blue)
+        val lines = mutableListOf<String>()
+        editedEntryRaw()?.name?.let { lines += "<$hex>■</$hex> <white><bold>$it</bold></white> <$hex>■</$hex>" }
+        effectiveOrigin()?.let { origin ->
+            lines += "<#A9B2C3>origin <white>${origin.x.round(2)}, ${origin.y.round(2)}, ${origin.z.round(2)}"
+        }
+
+        val rotationParts = mutableListOf<String>()
+        workingYaw?.let { rotationParts += "yaw <white>${it.toDouble().round(1)}°</white>" }
+        val pitch = workingPitch
+        val roll = workingRoll
+        if (pitch != null && roll != null && (pitch != 0f || roll != 0f)) {
+            rotationParts += "tilt <white>${tiltDegrees(pitch, roll).round(1)}°</white>"
+        }
+        if (rotationParts.isNotEmpty()) lines += "<#A9B2C3>${rotationParts.joinToString(" ")}"
+
+        hologramSizeLine()?.let { lines += it }
+
+        val staged = stagedWrites.size
+        lines += when {
+            carrying -> "<gold>carrying"
+            grabbedFace != null -> "<gold>dragging ${grabbedFace?.label}"
+            staged > 0 -> "<yellow>$staged unsaved change${if (staged == 1) "" else "s"}"
+            awaitingPublish -> "<yellow>saved, awaiting publish on the web"
+            else -> "<#7E8695>no unsaved changes"
+        }
+        return lines.joinToString("\n")
+    }
+
+    /**
+     * While the player holds the move or rotate tool, a glowing guide line shows what a
+     * click would do: the move direction colored per world axis (X red, Y green, Z blue),
+     * or a gold ring in the rotation plane. The resize tool highlights faces instead.
+     *
+     * When the region origin is farther than [GUIDE_NEAR_RANGE], the guides come to the
+     * player instead: the move arrow anchors on the stretch of boundary nearest to them,
+     * and the rotation ring widens to pass through where they stand, drawing only the
+     * nearby arc. Main thread only.
+     */
+    private fun updateToolGuides() {
+        val transform = if (carrying || grabbedFace != null || modeGestureActive()) null else workingTransform()
+        if (transform == null || !regionDefined() || transform.world.identifier != player.world.uid.toString()) {
+            guide.despawn()
+            return
+        }
+        // The held slot froze when the player entered spectator, which makes it exactly
+        // the active ghost tool, so the guides render for spectators too.
+        when (player.inventory.heldItemSlot) {
+            MOVE_SLOT -> updateMoveGuide(transform)
+            rotateSlot -> updateRotateGuide(transform)
+            else -> guide.despawn()
+        }
+    }
+
+    private fun eyeVector(): Vector {
+        val eye = player.eyeLocation
+        return Vector(eye.x, eye.y, eye.z)
+    }
+
+    /**
+     * Where a guide hangs: the region origin while the player is near it, otherwise the
+     * boundary point nearest to the player, so the guide stays in view on a huge region.
+     */
+    private fun guideAnchor(transform: ResolvedTransform): Pair<Vector, Boolean> {
+        val anchor = transform.worldOrigin
+        val eye = eyeVector()
+        if ((anchor - eye).lengthSquared <= GUIDE_NEAR_RANGE * GUIDE_NEAR_RANGE) return anchor to true
+        val boundary = workingShape()?.nearestBoundaryPoint(transform.toLocal(eye)) ?: return anchor to true
+        return transform.toWorld(boundary) to false
+    }
+
+    /** The offset from the anchor to the boundary point nearest the player, in world axes. */
+    private fun nearestBoundaryOffset(transform: ResolvedTransform, eye: Vector): Vector? {
+        val local = workingShape()?.nearestBoundaryPoint(transform.toLocal(eye)) ?: return null
+        return transform.toWorld(local) - transform.worldOrigin
+    }
+
+    private fun updateMoveGuide(transform: ResolvedTransform) {
+        val direction = currentMoveDirection()
+        val (material, glow) = axisAppearance(direction)
+        val (anchor, nearOrigin) = guideAnchor(transform)
+        val bounds = guideBounds(transform)
+        val length = if (nearOrigin) moveAxisLength(bounds, direction) else FAR_ANCHOR_AXIS_LENGTH
+        val view = (anchor + direction * length - eyeVector()).takeIf { it.length > Vector.EPSILON }
+            ?.normalize() ?: direction
+        guide.update(
+            Location(player.world, anchor.x, anchor.y, anchor.z),
+            moveGuideSegments(bounds, direction, view, length),
+            material,
+            glow,
+        )
+    }
+
+    private fun updateRotateGuide(transform: ResolvedTransform) {
+        val anchor = transform.worldOrigin
+        val eye = eyeVector()
+        val nearOrigin = (anchor - eye).lengthSquared <= GUIDE_NEAR_RANGE * GUIDE_NEAR_RANGE
+        val bounds = guideBounds(transform)
+        // The rings hang on the bounds center, not the anchor: a polygon's outline is not
+        // symmetric around its origin, and vertex edits drift the two further apart.
+        val center = boundsCenter(bounds)
+
+        // Far from the origin, the guide hangs on the boundary point nearest the player:
+        // it sits on the region the way the far move arrow does, instead of floating
+        // around the player.
+        val boundary = if (nearOrigin) null else nearestBoundaryOffset(transform, eye)
+
+        val segments = if (rotatePitchMode) {
+            // The tilt dial stands face on to the viewer's quantized side. The rotation
+            // axis is the level line through its middle: the region tips toward or away
+            // through the dial, as a clean pitch or roll of the region.
+            val facing = quantizedTiltFacing(
+                anchor.x + center.x - eye.x,
+                anchor.z + center.z - eye.z,
+                transform.yawDegrees,
+            )
+            val side = Vector(facing.z, 0.0, -facing.x)
+            val radius = rotationRingRadius(bounds, pitchPlane = true)
+            if (boundary == null) {
+                ringSegments(radius, center, Vector(0.0, 1.0, 0.0), side)
+            } else {
+                val offset = Vector(boundary.x.round(1), boundary.y.round(1), boundary.z.round(1))
+                ringSegments(radius, offset, Vector(0.0, 1.0, 0.0), side)
+            }
+        } else {
+            if (boundary == null) {
+                val radius = rotationRingRadius(bounds, pitchPlane = false)
+                ringSegments(radius, center, Vector(1.0, 0.0, 0.0), Vector(0.0, 0.0, 1.0))
+            } else {
+                val radius = farRingRadius(
+                    bounds,
+                    sqrt(boundary.x * boundary.x + boundary.z * boundary.z).round(1),
+                    pitchPlane = false,
+                )
+                ringSegments(radius, Vector(0.0, boundary.y.round(1), 0.0), Vector(1.0, 0.0, 0.0), Vector(0.0, 0.0, 1.0))
+            }
+        }
+        val visible = if (boundary == null) segments else cullSegmentsNear(segments, eye - anchor)
+
+        guide.update(
+            Location(player.world, anchor.x, anchor.y, anchor.z),
+            visible,
+            Material.YELLOW_CONCRETE,
+            org.bukkit.Color.fromRGB(255, 200, 0),
+        )
+    }
+
+    /**
+     * A spectator flies through walls, so the wand works on the wireframe cube instead of
+     * a clicked block: the occupied block while flying, the key nudged selection while
+     * locked. Main thread only.
+     */
+    private fun updateGhostMarker() {
+        if (player.gameMode != GameMode.SPECTATOR) {
+            ghostMarker.despawn()
+            return
+        }
+        val lock = spectatorLock
+        val cube = when {
+            lock == null -> occupiedBlock()
+            player.inventory.heldItemSlot == WAND_SLOT && usesSelectionCube() -> lock.cube
+            else -> null
+        }
+        if (cube == null) {
+            ghostMarker.despawn()
+            return
+        }
+        ghostMarker.update(
+            Location(player.world, cube.x.toDouble(), cube.y.toDouble(), cube.z.toDouble()),
+            BLOCK_OUTLINE_SEGMENTS,
+            Material.YELLOW_CONCRETE,
+            org.bukkit.Color.fromRGB(255, 200, 0),
+            GHOST_MARKER_THICKNESS,
+        )
+    }
+
+    private fun markSpectatorSecondary() {
+        spectatorSecondary(occupiedBlock())
+    }
+
+    private fun occupiedBlock(): CapturedBlock {
+        val block = player.location.block
+        return CapturedBlock(World(block.world.uid.toString()), block.x, block.y, block.z)
+    }
+
+    /**
+     * The wand's left click from the locked spectator state, fired on the selection cube.
+     * Capture modes override this with their marking behavior.
+     */
+    protected open fun spectatorMark(block: CapturedBlock) {}
+
+    /**
+     * The free flight secondary gesture, sprint and sneak pressed together. Modes with a
+     * wand right click behavior override this with it.
+     */
+    protected open fun spectatorSecondary(block: CapturedBlock) {}
+
+    /**
+     * Whether the locked wand drives the ghost selection cube. Corner based modes return
+     * `false` and target by aim instead, the way the resize tool targets faces.
+     */
+    protected open fun usesSelectionCube(): Boolean = true
+
+    /** Called when the spectator lock releases, so modes can drop lock scoped state. */
+    protected open fun onSpectatorLockReleased() {}
+
+    /**
+     * Locks the spectator in place for key driven editing, or releases them. The camera
+     * stays free so the player can still aim; only movement freezes, by zeroing the fly
+     * speed, with the listener's move pin guarding the client side scroll speed override.
+     */
+    private fun toggleSpectatorLock() {
+        val lock = spectatorLock
+        if (lock != null) {
+            releaseSpectatorLock()
+            return
+        }
+        spectatorLock = SpectatorLockState(player.location.clone(), occupiedBlock(), player.flySpeed)
+        player.flySpeed = 0f
+        player.playSound(player.location, Sound.BLOCK_BEACON_ACTIVATE, 0.4f, 1.6f)
+        player.sendActionBar("<gold>Locked in place. <gray>The keys now drive the tool; <white>jump + sneak</white> releases.".asMini())
+    }
+
+    private fun releaseSpectatorLock() = releaseSpectatorLock(quiet = false)
+
+    private fun releaseSpectatorLock(quiet: Boolean) {
+        val lock = spectatorLock ?: return
+        spectatorLock = null
+        pinnedFaceId = null
+        onSpectatorLockReleased()
+        player.flySpeed = lock.previousFlySpeed
+        if (quiet) return
+        player.playSound(player.location, Sound.BLOCK_BEACON_DEACTIVATE, 0.4f, 1.6f)
+        player.sendActionBar("<gray>Released. Fly freely again.".asMini())
+    }
+
+    private fun onSpectatorKey(key: SpectatorKey) {
+        if (spectatorLock == null) return
+        when (player.inventory.heldItemSlot) {
+            WAND_SLOT -> wandSpectatorKey(key)
+            MOVE_SLOT -> moveSpectatorKey(key)
+            rotateSlot -> rotateSpectatorKey(key)
+            resizeSlot -> resizeSpectatorKey(key)
+            else -> player.sendActionBar(
+                "<gray>No ghost controls on this slot. Hold a tool before entering spectator.".asMini(),
+            )
+        }
+    }
+
+    /** The locked wand keys: the base nudges and marks the ghost selection cube. */
+    internal open fun wandSpectatorKey(key: SpectatorKey) {
+        val lock = spectatorLock ?: return
+        if (key == SpectatorKey.MARK) {
+            spectatorMark(lock.cube)
+            return
+        }
+        val direction = spectatorKeyDirection(key, player.location.yaw) ?: return
+        val cube = lock.cube
+        lock.cube = CapturedBlock(
+            cube.world,
+            cube.x + direction.x.roundToInt(),
+            cube.y + direction.y.roundToInt(),
+            cube.z + direction.z.roundToInt(),
+        )
+        player.playSound(player.location, Sound.UI_BUTTON_CLICK, 0.2f, 1.8f)
+        player.sendActionBar(
+            "<gray>Selection at <white>${lock.cube.x}, ${lock.cube.y}, ${lock.cube.z}</white>. <white>Ctrl</white> marks it.".asMini(),
+        )
+    }
+
+    private fun moveSpectatorKey(key: SpectatorKey) {
+        val direction = spectatorKeyDirection(key, player.location.yaw) ?: run {
+            player.sendActionBar("<gray>WASD, space and shift nudge the region.".asMini())
+            return
+        }
+        nudgeOrigin(direction, MOVE_STEP, "Origin nudge")
+    }
+
+    private fun rotateSpectatorKey(key: SpectatorKey) {
+        when (key) {
+            SpectatorKey.LEFT, SpectatorKey.RIGHT -> {
+                rotatePitchMode = false
+                applyRotation(if (key == SpectatorKey.RIGHT) ROTATE_STEP else -ROTATE_STEP, coalesce = false)
+            }
+
+            SpectatorKey.FORWARD, SpectatorKey.BACKWARD -> {
+                rotatePitchMode = true
+                // W tips the region's top away from the player, S pulls it back, matching
+                // how W pushes and S pulls on the resize tool.
+                applyRotation(if (key == SpectatorKey.FORWARD) ROTATE_STEP else -ROTATE_STEP, coalesce = false)
+            }
+
+            else -> player.sendActionBar("<gray>A/D turn the yaw, W/S tilt it away or toward you.".asMini())
+        }
+    }
+
+    private fun resizeSpectatorKey(key: SpectatorKey) {
+        when (key) {
+            SpectatorKey.FORWARD -> stepTargetedFace(RESIZE_STEP * viewFollowSign(), coalesce = false)
+            SpectatorKey.BACKWARD -> stepTargetedFace(-RESIZE_STEP * viewFollowSign(), coalesce = false)
+            SpectatorKey.UP -> toggleFacePin()
+            else -> player.sendActionBar(
+                "<gray>Aim at a face; W pushes it away, S pulls it toward you, <white>space</white> pins it.".asMini(),
+            )
+        }
+    }
+
+    /**
+     * Pins the aimed face for the locked spectator, so the keys keep driving it even when
+     * another face of the region slides in front of the view, which pushing a face far
+     * enough does all by itself.
+     */
+    private fun toggleFacePin() {
+        if (pinnedFaceId != null) {
+            pinnedFaceId = null
+            player.playSound(player.location, Sound.UI_BUTTON_CLICK, 0.3f, 1.2f)
+            player.sendActionBar("<gray>Face released. The aim picks faces again.".asMini())
+            return
+        }
+        val face = targetedFace ?: run {
+            refuse("<red>Aim at a face to pin it first.")
+            return
+        }
+        pinnedFaceId = face.id
+        player.playSound(player.location, Sound.UI_BUTTON_CLICK, 0.3f, 1.6f)
+        player.sendActionBar(
+            "<gold>Pinned the ${face.label}. <gray>W and S keep driving it; <white>space</white> releases.".asMini(),
+        )
+    }
+
+    /**
+     * Whether stepping the aimed face outward moves it away from the player: `1.0` when
+     * its outward normal points along the view, `-1.0` when the face looks back at the
+     * player, so pushing always moves the face the way the player is looking.
+     */
+    private fun viewFollowSign(): Double {
+        val face = targetedFace ?: return 1.0
+        val transform = workingTransform() ?: return 1.0
+        val direction = player.eyeLocation.direction
+        val normal = transform.rotateLocalToWorld(face.normal)
+        return pushPullSign(Vector(direction.x, direction.y, direction.z), normal)
+    }
+
+    private class SpectatorLockState(val anchor: Location, var cube: CapturedBlock, val previousFlySpeed: Float)
+
+    /** The region's world aligned extents, which the tool guides size themselves from. */
+    private fun guideBounds(transform: ResolvedTransform): LocalBounds =
+        workingShape()?.localBounds?.rotated(transform.yawDegrees, transform.pitchDegrees, transform.rollDegrees)
+            ?: LocalBounds(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+    protected fun axisAppearance(direction: Vector): Pair<Material, org.bukkit.Color> = when {
+        abs(direction.y) > abs(direction.x) && abs(direction.y) > abs(direction.z) ->
+            Material.LIME_CONCRETE to org.bukkit.Color.fromRGB(85, 255, 85)
+
+        abs(direction.x) >= abs(direction.z) ->
+            Material.RED_CONCRETE to org.bukkit.Color.fromRGB(255, 85, 85)
+
+        else -> Material.LIGHT_BLUE_CONCRETE to org.bukkit.Color.fromRGB(85, 170, 255)
+    }
+
+    protected data class StagedWrite(val value: Any, val type: Type)
+
+    companion object {
+        internal const val ORIGIN_FIELD = "origin"
+
+        private const val KEY_ORIGIN = "work.origin"
+        private const val KEY_OFFSET = "work.offset"
+        private const val KEY_YAW = "work.yaw"
+        private const val KEY_PITCH = "work.pitch"
+        private const val KEY_ROLL = "work.roll"
+        private const val KEY_RESIZE_SHIFT = "size.shift"
+
+        internal const val CARRY_SCROLL_STEP = 1.0
+        internal const val CARRY_MIN_DISTANCE = 2.0
+        internal const val CARRY_MAX_DISTANCE = 48.0
+        private const val MAX_FACE_DRAG = 64.0
+        internal const val SCROLL_COALESCE_MILLIS = 1200L
+
+        private const val HOLOGRAM_LIFT = 1.0
+        private const val FLASH_TICKS = 5
+        private const val GHOST_MARKER_THICKNESS = 0.08f
+    }
+}
+
+/** The wand item. A click in the air marks the block the player stands on. */
+internal class RegionWandComponent(
+    private val title: String,
+    private val loreText: String,
+    private val onDrop: () -> Unit,
+    private val onSwap: (() -> Unit)? = null,
+    private val onSelect: (ItemInteraction, CapturedBlock) -> Unit,
+) : ItemComponent {
+    override fun item(player: Player): Pair<Int, IntractableItem> {
+        val item = ItemStack(Material.GOLDEN_AXE).apply {
+            editMeta { meta ->
+                meta.name = title
+                meta.loreString = loreText
+            }
+        }
+        return WAND_SLOT to (item onInteract { interaction ->
+            if (interaction.type == ItemInteractionType.DROP) {
+                onDrop()
+                return@onInteract
+            }
+            if (interaction.type == ItemInteractionType.SWAP) {
+                onSwap?.invoke()
+                return@onInteract
+            }
+            if (!interaction.type.isClick) return@onInteract
+            val block = interaction.clickedBlock ?: player.location.block
+            onSelect(interaction, CapturedBlock(World(block.world.uid.toString()), block.x, block.y, block.z))
+        })
+    }
+}
+
+/**
+ * The apply item. The content mode sends the inventory again every tick, so the dye swaps
+ * color as soon as there is something to save.
+ */
+internal class ApplyItemComponent(
+    private val ready: () -> Boolean,
+    private val stagedCount: () -> Int,
+    private val onApply: () -> Unit,
+) : ItemComponent {
+    override fun item(player: Player): Pair<Int, IntractableItem> {
+        val item = if (ready()) readyItem() else notReadyItem()
+        return APPLY_SLOT to (item onInteract { interaction ->
+            if (!interaction.type.isActivation) return@onInteract
+            onApply()
+        })
+    }
+
+    private fun readyItem(): ItemStack = ItemStack(Material.LIME_DYE).apply {
+        val staged = stagedCount()
+        editMeta { meta ->
+            meta.name = "<green><bold>Apply"
+            meta.loreString = """
+                |
+                |<line> <gray>Click to save the region to its entry.
+                |<line> <gray>Leaving without applying discards the changes.
+                |<line> <gray>Publish on the web afterwards to make it live.
+                |${if (staged > 0) "<line> <yellow>$staged</yellow> <gray>staged change${if (staged == 1) "" else "s"} waiting." else ""}
+            """.trimMargin()
+        }
+    }
+
+    private fun notReadyItem(): ItemStack = ItemStack(Material.GRAY_DYE).apply {
+        editMeta { meta ->
+            meta.name = "<gray><bold>Apply <dark_gray>(nothing to save)"
+            meta.loreString = """
+                |
+                |<line> <gray>Capture the region with the wand or nudge it
+                |<line> <gray>with the tools, then click here to save.
+            """.trimMargin()
+        }
+    }
+}
+
+/**
+ * `true` when the interaction is a way of pressing the item like a button: a click in the world or
+ * a click on it in the inventory, which is how a builder with the inventory open reaches it.
+ *
+ * Dropping and swapping are excluded. Both would otherwise activate whatever the item does, and a
+ * stray Q over the Apply dye would save and end the session on the builder's behalf.
+ */
+internal val ItemInteractionType.isActivation: Boolean
+    get() = isClick || this == ItemInteractionType.INVENTORY_CLICK

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/RegionDebugContentMode.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/RegionDebugContentMode.kt
@@ -1,0 +1,256 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.entries.ref
+import com.typewritermc.core.utils.failure
+import com.typewritermc.core.utils.ok
+import com.typewritermc.core.utils.switchContext
+import com.typewritermc.engine.paper.content.ContentContext
+import com.typewritermc.engine.paper.content.ContentMode
+import com.typewritermc.engine.paper.content.components.*
+import com.typewritermc.engine.paper.content.entryId
+import com.typewritermc.engine.paper.utils.*
+import com.typewritermc.region.RegionEngine
+import com.typewritermc.region.data.DistanceMode
+import com.typewritermc.region.data.RegionDefinitionEntry
+import com.typewritermc.region.data.RegionReferenceData
+import com.typewritermc.region.data.displayColor
+import com.typewritermc.region.tracker.RegionTracker
+import kotlinx.coroutines.Dispatchers
+import net.kyori.adventure.bossbar.BossBar
+import org.bukkit.Location
+import org.bukkit.Material
+import org.bukkit.Sound
+import org.bukkit.entity.Player
+import org.bukkit.inventory.ItemStack
+import org.koin.java.KoinJavaComponent
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * The in game debugger for one region definition. Instead of chat spam, the live state
+ * renders on the HUD: the boss bar answers "am I inside and did the events see it", and the
+ * region draws itself as a glowing outline in its color. The action bar can additionally
+ * stream the exact distance numbers, off by default to keep the HUD calm.
+ *
+ * When a region "does not trigger", this shows which link of the chain is broken.
+ */
+class RegionDebugContentMode(context: ContentContext, player: Player) : ContentMode(context, player) {
+    private val engine: RegionEngine by KoinJavaComponent.inject(RegionEngine::class.java)
+    private val editRegistry: RegionEditRegistry by KoinJavaComponent.inject(RegionEditRegistry::class.java)
+    private var definitionRef: Ref<RegionDefinitionEntry>? = null
+    private val channels = ConcurrentHashMap(
+        mapOf(
+            DebugChannel.OVERVIEW to true,
+            DebugChannel.DISTANCES to false,
+            DebugChannel.PREVIEW to true,
+        ),
+    )
+    private val outline = RegionOutline(player)
+
+    @Volatile
+    private var lastSample: DebugSample? = null
+
+    @Volatile
+    private var disposed = false
+
+    override suspend fun setup(): Result<Unit> {
+        val entryId = context.entryId
+            ?: return failure("No entryId found for ${this::class.simpleName}. This is a bug. Please report it.")
+        definitionRef = Ref(entryId, RegionDefinitionEntry::class)
+
+        bossBar {
+            val sample = lastSample
+            title = when {
+                sample == null -> "<gray>Waiting for the region to resolve…"
+                !channels.getValue(DebugChannel.OVERVIEW) -> "<white><bold>${sample.name}</bold> <gray>(overview off)"
+                sample.transformResolved -> "<white><bold>${sample.name}</bold> <gray>· ${sample.membershipLine}"
+                else -> "<white><bold>${sample.name}</bold> <red>transform unresolved: a placement variable returned nothing"
+            }
+            color = when {
+                sample == null || !sample.transformResolved -> BossBar.Color.PURPLE
+                sample.inside && sample.entered -> BossBar.Color.GREEN
+                sample.inside && sample.enterMissed -> BossBar.Color.RED
+                else -> BossBar.Color.YELLOW
+            }
+        }
+        exit(doubleShiftExits = true)
+        +toggleItem(
+            0,
+            DebugChannel.OVERVIEW,
+            Material.ENDER_EYE,
+            "Overview",
+            "Membership and event state on the boss bar."
+        )
+        +toggleItem(
+            1,
+            DebugChannel.DISTANCES,
+            Material.BLAZE_ROD,
+            "Distances",
+            "Hitbox, point and XZ distances on the action bar."
+        )
+        +toggleItem(
+            2,
+            DebugChannel.PREVIEW,
+            Material.GLOWSTONE_DUST,
+            "Boundary",
+            "Draw the region's outline in its color."
+        )
+
+        return ok(Unit)
+    }
+
+    override suspend fun initialize() {
+        // Armed again here as well as set in dispose: this mode is initialized again whenever a mode
+        // pushed on top of it is popped, and left set it would render nothing ever after.
+        disposed = false
+        editRegistry.enterMode(player.uniqueId, RegionModeKind.Debug)
+        super.initialize()
+    }
+
+    override suspend fun tick(deltaTime: Duration) {
+        super.tick(deltaTime)
+        val definition = definitionRef?.get() ?: return
+        val sample = sample(definition)
+        lastSample = sample
+
+        if (channels.getValue(DebugChannel.DISTANCES)) {
+            player.sendActionBar(sample.distanceLine.asMini())
+        }
+
+        // Disposal is checked again on the main thread: sampling takes long enough for a publish
+        // or a disconnect to dispose this mode while it runs, and an outline spawned after the
+        // despawn is one nothing despawns again.
+        Dispatchers.Sync.switchContext { if (!disposed) updateOutline(sample) }
+    }
+
+    override suspend fun dispose() {
+        disposed = true
+        editRegistry.exitMode(player.uniqueId, RegionModeKind.Debug)
+        Dispatchers.Sync.switchContext { outline.despawn() }
+        super.dispose()
+    }
+
+    private fun updateOutline(sample: DebugSample) {
+        if (!channels.getValue(DebugChannel.PREVIEW)) {
+            outline.despawn()
+            return
+        }
+        val tracker = sample.tracker
+        val transform = tracker?.lastTransform
+        val world = transform?.let { resolveBukkitWorld(it.world.identifier) }
+        if (transform == null || world == null) {
+            outline.despawn()
+            return
+        }
+        val anchor = transform.worldOrigin
+        outline.update(
+            Location(world, anchor.x, anchor.y, anchor.z),
+            transform.yawDegrees,
+            transform.pitchDegrees,
+            tracker.shape,
+            sample.color,
+            rollDegrees = transform.rollDegrees,
+        )
+    }
+
+    private fun sample(definition: RegionDefinitionEntry): DebugSample {
+        val data = RegionReferenceData(definition.ref())
+        val registered = engine.registeredTracker(data, player)
+        val tracker = registered ?: engine.query(data, player)
+        val color = definition.displayColor(definition.id)
+        if (tracker == null) {
+            return DebugSample(
+                name = definition.name,
+                color = color,
+                tracker = null,
+                transformResolved = false,
+                inside = false,
+                entered = false,
+                enterMissed = false,
+                membershipLine = "<red>the region reference does not resolve",
+                distanceLine = "<red>The region reference does not resolve to a definition.",
+            )
+        }
+
+        val snapshot = tracker.debugSnapshot()
+        val transform = snapshot.transform
+        val hitbox = tracker.hitboxDistance(player)
+        val point = tracker.signedDistance(player.position)
+        val horizontal = tracker.signedDistance(player.position, DistanceMode.HORIZONTAL)
+        val inside = hitbox != null && hitbox <= 0.0
+        val entered = tracker.countsAsEntered(player)
+        val observed = registered != null && snapshot.enterExitHandlers > 0
+        val enterMissed = observed && inside && !entered
+
+        val membership = if (inside) "<green>inside</green>" else "<gray>outside</gray>"
+        val events = when {
+            !observed -> "<red>no enter/exit observers</red>"
+            entered -> "<green>events entered</green>"
+            inside -> "<red>enter did not fire</red>"
+            else -> "<white>events not entered</white>"
+        }
+
+        return DebugSample(
+            name = definition.name,
+            color = color,
+            tracker = tracker,
+            transformResolved = transform != null,
+            inside = inside,
+            entered = entered,
+            enterMissed = enterMissed,
+            membershipLine = "$membership <gray>· $events",
+            distanceLine = "<gray>hitbox <white>${hitbox.formatted()}</white> <gray>· point <white>${point.formatted()}</white>" +
+                    " <gray>· xz <white>${horizontal.formatted()}</white> <dark_gray>(negative = inside)",
+        )
+    }
+
+    private fun toggleItem(
+        slot: Int,
+        channel: DebugChannel,
+        material: Material,
+        title: String,
+        description: String,
+    ): ItemComponent = object : ItemComponent {
+        override fun item(player: Player): Pair<Int, IntractableItem> {
+            val enabled = channels.getValue(channel)
+            val item = ItemStack(material).apply {
+                editMeta { meta ->
+                    meta.name = if (enabled) "<gold><bold>$title <green>(on)" else "<gray><bold>$title <dark_gray>(off)"
+                    meta.loreString = """
+                        |
+                        |<line> <gray>$description
+                        |<line> <gray>Click to turn it ${if (enabled) "off" else "on"}.
+                    """.trimMargin()
+                    @Suppress("UsePropertyAccessSyntax") // Getter and setter signatures differ in nullability, so property syntax doesn't compile
+                    if (enabled) meta.setEnchantmentGlintOverride(true)
+                }
+            }
+            return slot to (item onInteract { interaction ->
+                if (!interaction.type.isClick) return@onInteract
+                val nowEnabled = !channels.getValue(channel)
+                channels[channel] = nowEnabled
+                player.playSound(player.location, Sound.BLOCK_LEVER_CLICK, 0.6f, if (nowEnabled) 1.4f else 0.8f)
+                player.sendActionBar(
+                    "<gray>$title ${if (nowEnabled) "<green>enabled" else "<red>disabled"}".asMini(),
+                )
+            })
+        }
+    }
+
+    private fun Double?.formatted(): String = this?.round(2)?.toString() ?: "n/a"
+
+    private data class DebugSample(
+        val name: String,
+        val color: Color,
+        val tracker: RegionTracker?,
+        val transformResolved: Boolean,
+        val inside: Boolean,
+        val entered: Boolean,
+        val enterMissed: Boolean,
+        val membershipLine: String,
+        val distanceLine: String,
+    )
+
+    private enum class DebugChannel { OVERVIEW, DISTANCES, PREVIEW }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/RegionEditRegistry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/RegionEditRegistry.kt
@@ -1,0 +1,127 @@
+package com.typewritermc.region.content
+
+import com.google.common.collect.Sets
+import com.typewritermc.core.extension.Initializable
+import com.typewritermc.core.extension.annotations.Singleton
+import com.typewritermc.engine.paper.utils.Color
+import com.typewritermc.region.data.RegionData
+import com.typewritermc.region.data.RegionReferenceData
+import com.typewritermc.region.data.ResolvedTransform
+import com.typewritermc.region.shape.Shape
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * A live snapshot of an edit session's working model, published every tick. Nothing in it is
+ * authoritative entry state; it is what the editor currently sees.
+ */
+data class SessionPreview(
+    val regionName: String,
+    val transform: ResolvedTransform,
+    val shape: Shape,
+    val color: Color,
+    val activity: String,
+)
+
+/**
+ * One open editor on a region entry: the edit lock (one session per entry), the live
+ * [preview] of the working model, and the [spectators] currently watching it.
+ */
+class RegionEditSession(
+    val entryId: String,
+    val editorId: UUID,
+    val editorName: String,
+) {
+    @Volatile
+    var preview: SessionPreview? = null
+
+    /** The players the spectator renderer currently shows this session to. */
+    val spectators: MutableSet<UUID> = Sets.newConcurrentHashSet()
+}
+
+/** Which region content mode a player currently has open. */
+enum class RegionModeKind {
+    Workspace,
+    Editor,
+    Debug,
+}
+
+/**
+ * Tracks the open region edit sessions. It is the edit lock (one editor per entry at a
+ * time), the source of the live previews the spectator renderer draws for bystanders, and
+ * the authority on which players already see a live editor preview of a region, so
+ * boundary displays and the visualizer can hide their own rendering for those players.
+ *
+ * It also tracks which region content mode each player has open. The engine only exposes
+ * whether a player is in some content interaction, so the region modes report themselves:
+ * the edit command uses it to stop stacking modes, and the barrier audience to leave
+ * editing players alone.
+ */
+@Singleton
+class RegionEditRegistry : Initializable {
+    private val sessions = ConcurrentHashMap<String, RegionEditSession>()
+    private val activeModes = ConcurrentHashMap<UUID, RegionModeKind>()
+
+    override suspend fun initialize() {}
+
+    override suspend fun shutdown() {
+        sessions.clear()
+        activeModes.clear()
+    }
+
+    /**
+     * Reports a region content mode as the player's active one. The engine initializes a
+     * mode only while it is on top of the stack, so one slot per player is enough.
+     */
+    fun enterMode(playerId: UUID, kind: RegionModeKind) {
+        activeModes[playerId] = kind
+    }
+
+    /** Withdraws a mode registration; only [kind] itself, so teardown order cannot misfire. */
+    fun exitMode(playerId: UUID, kind: RegionModeKind) {
+        activeModes.remove(playerId, kind)
+    }
+
+    fun activeMode(playerId: UUID): RegionModeKind? = activeModes[playerId]
+
+    fun inRegionMode(playerId: UUID): Boolean = activeModes.containsKey(playerId)
+
+    /**
+     * Claims the edit lock on [entryId] for [playerId]. Returns the session on success,
+     * including when the player already holds it, or `null` while another player does.
+     */
+    fun tryStartEditing(playerId: UUID, playerName: String, entryId: String): RegionEditSession? {
+        val session = sessions.computeIfAbsent(entryId) { RegionEditSession(entryId, playerId, playerName) }
+        return session.takeIf { it.editorId == playerId }
+    }
+
+    /** Releases the edit lock, if [playerId] is the one holding it. */
+    fun stopEditing(playerId: UUID, entryId: String) {
+        val session = sessions[entryId] ?: return
+        if (session.editorId != playerId) return
+        sessions.remove(entryId, session)
+    }
+
+    fun sessionOf(entryId: String): RegionEditSession? = sessions[entryId]
+
+    fun sessions(): Collection<RegionEditSession> = sessions.values
+
+    fun isEditing(playerId: UUID, entryId: String): Boolean = sessions[entryId]?.editorId == playerId
+
+    /** `true` when [playerId] sees a live preview of [entryId], as its editor or a spectator. */
+    fun hasLiveView(playerId: UUID, entryId: String): Boolean {
+        val session = sessions[entryId] ?: return false
+        return session.editorId == playerId || playerId in session.spectators
+    }
+
+    /**
+     * `true` when [playerId] already sees a live editor preview covering [region]: their
+     * own editor, or another player's session they are spectating. Also checks the entry
+     * the consumer itself lives on ([ownerEntryId]), which covers inline definitions.
+     */
+    fun isSuppressed(playerId: UUID, ownerEntryId: String?, region: RegionData): Boolean {
+        if (ownerEntryId != null && hasLiveView(playerId, ownerEntryId)) return true
+        val reference = region as? RegionReferenceData ?: return false
+        return hasLiveView(playerId, reference.definition.id)
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/RegionEditSpectators.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/RegionEditSpectators.kt
@@ -1,0 +1,139 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.core.extension.Initializable
+import com.typewritermc.core.extension.annotations.Singleton
+import com.typewritermc.core.utils.UntickedAsync
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.core.utils.switchContext
+import com.typewritermc.engine.paper.content.isInContentInteraction
+import com.typewritermc.engine.paper.utils.Sync
+import com.typewritermc.engine.paper.utils.TICK_MS
+import com.typewritermc.region.cancelAndJoinBounded
+import kotlinx.coroutines.*
+import org.bukkit.Bukkit
+import org.bukkit.Location
+import org.bukkit.entity.Player
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import java.util.*
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Renders the live working preview of every open edit session to nearby players who are
+ * not the session's editor: the outline follows the editor's carries, drags and undos in
+ * real time, with a name tag saying who is working on the region. Only players who hold
+ * the region edit permission and are inside a content editor themselves see it; everyone
+ * else keeps seeing the published boundary.
+ *
+ * The renderer is participant agnostic: it draws whatever [RegionEditSession.preview]
+ * holds for whoever is near. A future collaborative mode reuses it unchanged by
+ * publishing its shared working model as the preview.
+ */
+@Singleton
+class RegionEditSpectators : Initializable, KoinComponent {
+    private val registry: RegionEditRegistry by inject()
+    private val views = mutableMapOf<ViewKey, SpectatorView>()
+    private var scope: CoroutineScope? = null
+
+    override suspend fun initialize() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.UntickedAsync)
+        this.scope = scope
+        scope.launch {
+            try {
+                while (isActive) {
+                    Dispatchers.Sync.switchContext { render() }
+                    delay(TICK_MS.milliseconds)
+                }
+            } finally {
+                withContext(NonCancellable) {
+                    Dispatchers.Sync.switchContext {
+                        views.values.forEach(SpectatorView::despawn)
+                        views.clear()
+                    }
+                }
+            }
+        }
+    }
+
+    override suspend fun shutdown() {
+        val scope = this.scope ?: return
+        this.scope = null
+        scope.coroutineContext.job.cancelAndJoinBounded()
+    }
+
+    /** Main thread only: reconciles one view per session and eligible nearby player. */
+    private fun render() {
+        val active = registry.sessions()
+        val desired = mutableSetOf<ViewKey>()
+
+        for (session in active) {
+            val preview = session.preview ?: continue
+            for (viewer in Bukkit.getOnlinePlayers()) {
+                if (!canSpectate(viewer, session, preview)) continue
+                val key = ViewKey(session.entryId, viewer.uniqueId)
+                desired += key
+                views.getOrPut(key) { SpectatorView(viewer) }.update(preview, session.editorName)
+            }
+        }
+
+        val stale = views.keys - desired
+        for (key in stale) views.remove(key)?.despawn()
+
+        for (session in active) {
+            val watching = desired.filter { it.entryId == session.entryId }.mapTo(mutableSetOf()) { it.viewerId }
+            session.spectators.retainAll(watching)
+            session.spectators.addAll(watching)
+        }
+    }
+
+    private fun canSpectate(viewer: Player, session: RegionEditSession, preview: SessionPreview): Boolean {
+        if (viewer.uniqueId == session.editorId) return false
+        if (!viewer.hasPermission(SPECTATE_PERMISSION)) return false
+        if (!viewer.isInContentInteraction) return false
+        if (preview.transform.world.identifier != viewer.world.uid.toString()) return false
+        // Distance to the boundary, not the anchor: a viewer at the edge of a huge region
+        // is close to the edit even when its center is far away.
+        val location = viewer.location
+        val local = preview.transform.toLocal(Vector(location.x, location.y, location.z))
+        return preview.shape.signedDistance(local) <= RANGE
+    }
+
+    private data class ViewKey(val entryId: String, val viewerId: UUID)
+
+    private class SpectatorView(private val viewer: Player) {
+        private val outline = RegionOutline(viewer)
+        private val hologram = EditorHologram(viewer)
+
+        fun update(preview: SessionPreview, editorName: String) {
+            val anchor = preview.transform.worldOrigin
+            outline.update(
+                Location(viewer.world, anchor.x, anchor.y, anchor.z),
+                preview.transform.yawDegrees,
+                preview.transform.pitchDegrees,
+                preview.shape,
+                preview.color,
+                rollDegrees = preview.transform.rollDegrees,
+            )
+            val top = preview.shape.localBounds
+                .rotated(preview.transform.yawDegrees, preview.transform.pitchDegrees, preview.transform.rollDegrees)
+                .maxY
+            val hex = String.format("#%02X%02X%02X", preview.color.red, preview.color.green, preview.color.blue)
+            hologram.update(
+                Location(viewer.world, anchor.x, anchor.y + top + NAME_LIFT, anchor.z),
+                "<$hex>■</$hex> <white><bold>${preview.regionName}</bold></white> <$hex>■</$hex>\n" +
+                        "<yellow>✎ $editorName ${preview.activity}</yellow>",
+            )
+        }
+
+        fun despawn() {
+            outline.despawn()
+            hologram.despawn()
+        }
+    }
+
+    companion object {
+        private const val RANGE = 64.0
+        private const val NAME_LIFT = 1.0
+        internal const val SPECTATE_PERMISSION = "typewriter.region.edit"
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/RegionEditTarget.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/RegionEditTarget.kt
@@ -1,0 +1,92 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.core.entries.Entry
+import com.typewritermc.region.data.RegionData
+import com.typewritermc.region.data.RegionDefinition
+import com.typewritermc.region.data.RegionDefinitionData
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.isSubclassOf
+import kotlin.reflect.full.memberProperties
+
+/**
+ * Where the geometry an editor writes to lives inside its entry.
+ *
+ * A definition entry *is* the region: its placement and shape fields sit at the top level. A
+ * consumer entry holds an inline definition inside one of its own fields, so the same fields
+ * sit behind a prefix, and the shape sits one algebraic hop deeper again.
+ *
+ * The paths are the ones the staging manager writes with, so they carry the `value` hops the
+ * panel serializes algebraic types with and the Kotlin object graph does not have.
+ */
+class RegionEditTarget(
+    val entryId: String,
+    private val inlineField: String?,
+) {
+    /** Prefix of the placement fields: `origin`, `offset`, `yaw` and `pitch`. */
+    val placementPath: String = inlineField?.let { "$it.$VALUE." } ?: ""
+
+    /** Prefix of the shape's own fields, like a sphere's `radius` or a cuboid's `halfX`. */
+    val shapePath: String = inlineField?.let { "$it.$VALUE.$SHAPE.$VALUE." } ?: ""
+
+    /**
+     * The definition [entry] holds, or `null` when the field that should hold it points at a
+     * definition entry instead of inlining one. Those are edited on the entry they live on.
+     */
+    fun definitionOf(entry: Entry): RegionDefinition? {
+        val field = inlineField ?: return entry as? RegionDefinition
+        return entry.regionData(field) as? RegionDefinition
+    }
+
+    private companion object {
+        const val VALUE = "value"
+        const val SHAPE = "shape"
+    }
+}
+
+/**
+ * The target the content mode requested for [fieldPath] on [entry] edits, or `null` when the
+ * path names no region geometry.
+ */
+fun regionEditTarget(entry: Entry, fieldPath: String): RegionEditTarget? {
+    if (entry is RegionDefinition) return RegionEditTarget(entry.id, null)
+
+    val field = fieldPath.substringBefore('.').takeIf { it != fieldPath } ?: return null
+    if (entry.regionData(field) == null) return null
+    return RegionEditTarget(entry.id, field)
+}
+
+private fun Entry.regionData(field: String): RegionData? {
+    val property = regionProperties().firstOrNull { it.name == field } ?: return null
+    // An entry's getter is arbitrary user code called once a second from the workspace scan;
+    // one that throws must not take the scan down with it.
+    return runCatching { property.getter.call(this) }.getOrNull() as? RegionData
+}
+
+/**
+ * The properties whose declared type can hold a region.
+ *
+ * The workspace scans every entry in the library for inline definitions once a second, so
+ * filtering by declared type keeps it from invoking getters that cannot return one.
+ *
+ * There is deliberately no cache here: `memberProperties` is already memoized per class by
+ * `kotlin-reflect`, and a cache keyed by entry class would pin the old class loader across a
+ * reload.
+ */
+private fun Entry.regionProperties(): List<KProperty1<out Entry, *>> =
+    this::class.memberProperties.filter { property ->
+        val declared = property.returnType.classifier as? KClass<*> ?: return@filter false
+        declared.isSubclassOf(RegionData::class)
+    }
+
+/**
+ * Every field on the entry holding an inline region definition, as field name to data
+ * pairs. References to definition entries are not listed; those regions are edited on the
+ * definition entry itself.
+ */
+fun Entry.inlineRegionFields(): List<Pair<String, RegionDefinitionData>> =
+    regionProperties().mapNotNull { property ->
+        val data = runCatching { property.getter.call(this) }.getOrNull() as? RegionDefinitionData
+            ?: return@mapNotNull null
+        property.name to data
+    }

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/RegionEditorModes.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/RegionEditorModes.kt
@@ -1,0 +1,56 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.engine.paper.content.ContentContext
+import com.typewritermc.region.data.RegionDefinitionEntry
+import com.typewritermc.region.entries.definition.*
+import com.typewritermc.region.shape.*
+import org.bukkit.entity.Player
+
+/** The content context the shape editors expect: the definition entry and its origin field. */
+fun regionEditorContext(definition: RegionDefinitionEntry): ContentContext =
+    ContentContext(mapOf("entryId" to definition.id, "fieldPath" to "origin"))
+
+/**
+ * The content context for editing an inline definition living in [field] on [entryId].
+ * The path carries the `value` hop the panel serializes algebraic types with, byte equal
+ * to the path the panel's own content editor button sends.
+ */
+fun inlineRegionEditorContext(entryId: String, field: String): ContentContext =
+    ContentContext(mapOf("entryId" to entryId, "fieldPath" to "$field.value.origin"))
+
+/**
+ * The shape specific editor for [definition], or `null` for a definition type without an
+ * in game editor. Shared by the edit command and the workspace mode.
+ */
+fun regionEditorMode(
+    definition: RegionDefinitionEntry,
+    context: ContentContext,
+    player: Player,
+): RegionContentMode? = when (definition) {
+    is CuboidRegionDefinitionEntry -> CuboidRegionContentMode(context, player)
+    is SphereRegionDefinitionEntry -> SphereRegionContentMode(context, player)
+    is EllipsoidRegionDefinitionEntry -> EllipsoidRegionContentMode(context, player)
+    is CapsuleRegionDefinitionEntry -> CapsuleRegionContentMode(context, player)
+    is ConeRegionDefinitionEntry -> ConeRegionContentMode(context, player)
+    is PolygonRegionDefinitionEntry -> PolygonRegionContentMode(context, player)
+    else -> null
+}
+
+/**
+ * The editor for an inline definition, whose shape lives in its data instead of its type.
+ * A definition entry picks its editor from the entry type it was written as; an inline one
+ * can only be picked from the shape the user selected, so it is resolved at edit time.
+ */
+fun regionEditorMode(
+    shape: Shape,
+    context: ContentContext,
+    player: Player,
+): RegionContentMode? = when (shape) {
+    is CuboidShape -> CuboidRegionContentMode(context, player)
+    is SphereShape -> SphereRegionContentMode(context, player)
+    is EllipsoidShape -> EllipsoidRegionContentMode(context, player)
+    is CapsuleShape -> CapsuleRegionContentMode(context, player)
+    is ConeShape -> ConeRegionContentMode(context, player)
+    is PolygonShape -> PolygonRegionContentMode(context, player)
+    else -> null
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/RegionOutline.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/RegionOutline.kt
@@ -1,0 +1,602 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.engine.paper.plugin
+import com.typewritermc.engine.paper.snippets.snippet
+import com.typewritermc.engine.paper.utils.Color
+import com.typewritermc.engine.paper.utils.server
+import com.typewritermc.region.data.ResolvedTransform
+import com.typewritermc.region.shape.Shape
+import com.typewritermc.region.shape.nearestBoundaryPoint
+import com.typewritermc.region.shape.raycastBoundary
+import org.bukkit.Location
+import org.bukkit.Material
+import org.bukkit.entity.BlockDisplay
+import org.bukkit.entity.Display
+import org.bukkit.entity.Player
+import org.bukkit.util.Transformation
+import org.joml.Matrix3f
+import org.joml.Quaternionf
+import org.joml.Vector3f
+import java.util.*
+import kotlin.math.abs
+import kotlin.math.floor
+
+/**
+ * The Bukkit world a region's world identifier resolves to. Identifiers are usually world
+ * UIDs, but panel authored positions may carry a world name instead.
+ */
+internal fun resolveBukkitWorld(identifier: String): org.bukkit.World? {
+    val byId = runCatching { UUID.fromString(identifier) }.getOrNull()?.let { server.getWorld(it) }
+    return byId ?: server.getWorld(identifier)
+}
+
+private const val SAFE_LIFT_ATTEMPTS = 8
+
+/**
+ * Scans upward from [location], up to [SAFE_LIFT_ATTEMPTS] blocks, for a spot where the feet
+ * and head blocks are both passable. Falls back to [location] itself when none is found, so a
+ * boundary teleport never lands the player inside a solid wall the region happens to share.
+ */
+internal fun liftToPassable(location: Location): Location {
+    val candidate = location.clone()
+    repeat(SAFE_LIFT_ATTEMPTS) {
+        val feet = candidate.block
+        val head = candidate.clone().add(0.0, 1.0, 0.0).block
+        if (feet.isPassable && head.isPassable) return candidate
+        candidate.add(0.0, 1.0, 0.0)
+    }
+    return location
+}
+
+/** Where a border teleport should land, and whether [Shape.raycastBoundary] found nothing to aim at. */
+internal data class BorderTeleport(val destination: Location, val usedFallback: Boolean)
+
+/**
+ * The resize tool's face panel: where its entity stands relative to the outline anchor, and the
+ * pose it draws from there.
+ */
+internal data class FaceHighlight(val anchorOffset: Vector3f, val transformation: Transformation)
+
+/**
+ * The point on [shape]'s boundary [eye] is looking at, safely lifted for a teleport. Aiming
+ * works from inside the shape too: the view ray still leaves through the stretch of border
+ * the eye faces. A ray that never crosses the boundary falls back to the nearest point on
+ * it, reported through [BorderTeleport.usedFallback] so a caller can hint at it. `null` when
+ * [shape] has no boundary point to fall back to either.
+ */
+internal fun borderTeleport(world: org.bukkit.World, transform: ResolvedTransform, shape: Shape, eye: Location): BorderTeleport? {
+    val localEye = transform.toLocal(Vector(eye.x, eye.y, eye.z))
+    val direction = eye.direction
+    val ahead = Vector(eye.x + direction.x, eye.y + direction.y, eye.z + direction.z)
+    val localDirection = (transform.toLocal(ahead) - localEye).normalize()
+
+    val aimed = shape.raycastBoundary(localEye, localDirection)
+    val local = aimed ?: shape.nearestBoundaryPoint(localEye) ?: return null
+
+    val border = transform.toWorld(local)
+    val destination = liftToPassable(Location(world, border.x, border.y, border.z, eye.yaw, eye.pitch))
+    return BorderTeleport(destination, usedFallback = aimed == null)
+}
+
+internal val outlineRenderDistance by snippet(
+    "region.outline.render_distance",
+    64.0,
+    "Max distance in blocks from the player at which a region outline's lines render. Only applies to regions too large to draw whole.",
+)
+
+/** A glowing full bright line display visible only to [player], for outline lines, guide lines and handle cubes. */
+private fun spawnLineDisplay(player: Player, location: Location, material: Material, teleportTicks: Int): BlockDisplay =
+    location.world.spawn(location, BlockDisplay::class.java) { display ->
+        display.isPersistent = false
+        display.isVisibleByDefault = false
+        display.block = material.createBlockData()
+        display.brightness = Display.Brightness(15, 15)
+        display.isGlowing = true
+        display.teleportDuration = teleportTicks
+        player.showEntity(plugin, display)
+    }
+
+/**
+ * Solid line rendering of a region's characteristic edges, built from glowing full bright
+ * [BlockDisplay] entities visible only to the editing player. The glow makes the shape
+ * readable through terrain, and display interpolation glides the lines along while the
+ * region is carried.
+ *
+ * The outline is cut into [OutlinePiece]s, each anchored where it is drawn. Once the piece
+ * count outgrows [MAX_LINE_DISPLAYS], only the pieces near the player are spawned, nearest
+ * first.
+ *
+ * Every method must run on the server main thread.
+ */
+internal class RegionOutline(private val player: Player) {
+    private val lines = HashMap<Int, BlockDisplay>()
+    private var pieces: List<OutlinePiece> = emptyList()
+    private var placementKey: Int? = null
+    private var renderKey: Int? = null
+    private var builtScale: Float? = null
+    private var anchor: Location? = null
+    private var viewer: Location? = null
+    private var awaitingChunks = false
+    private var glided = false
+    private var highlight: BlockDisplay? = null
+    private var highlightKey: Any? = null
+
+    /**
+     * [emphasis] scales the line thickness and [scale] the whole outline about the anchor;
+     * alternating them between two values on a timer pulses the outline, interpolated over
+     * [emphasisTicks]. The workspace pulses the aimed at region this way.
+     * Neither field moves a piece's display entity: only [shape], [yawDegrees] and
+     * [pitchDegrees] do, so a pulse rewrites transformations in place without teleporting.
+     *
+     * [snap] applies the update without interpolating. Editor history restores are
+     * discrete jumps, and lines gliding across them look like a rendering fault.
+     */
+    fun update(
+        anchorLocation: Location,
+        yawDegrees: Float,
+        pitchDegrees: Float,
+        shape: Shape,
+        color: Color,
+        emphasis: Float = 1f,
+        emphasisTicks: Int = INTERPOLATION_TICKS,
+        scale: Float = 1f,
+        snap: Boolean = false,
+        rollDegrees: Float = 0f,
+    ) {
+        if (anchorLocation.world != player.world) {
+            despawn()
+            return
+        }
+
+        val nextPlacementKey = Objects.hash(shape, yawDegrees, pitchDegrees, rollDegrees)
+        val nextRenderKey = Objects.hash(nextPlacementKey, color.color, emphasis, scale)
+        val placementChanged = nextPlacementKey != placementKey
+        val renderChanged = nextRenderKey != renderKey
+        // The pieces depend on the geometry and the scale, not on the color or the emphasis.
+        // Rebuilding on those too would cut the whole outline again ten times a second for the region the
+        // workspace is pulsing, which is the one with the most pieces to cut.
+        val geometryChanged = placementChanged || scale != builtScale
+        if (geometryChanged) {
+            pieces = buildOutlinePieces(shape, yawDegrees, pitchDegrees, rollDegrees, scale, adaptiveCircleSegments(shape))
+            builtScale = scale
+        }
+        if (renderChanged) {
+            placementKey = nextPlacementKey
+            renderKey = nextRenderKey
+        }
+
+        val eye = player.location
+        val previousAnchor = anchor
+        val anchorMoved = previousAnchor == null || previousAnchor.world != anchorLocation.world ||
+                previousAnchor.distanceSquared(anchorLocation) > MOVE_EPSILON_SQUARED
+        val previousViewer = viewer
+        val viewerMoved = previousViewer == null || previousViewer.world != eye.world ||
+                previousViewer.distanceSquared(eye) > VIEWER_MOVE_EPSILON_SQUARED
+        // Line displays are not persistent, so an unloading chunk removes them, and pieces whose
+        // chunk was unloaded were skipped. Either way the outline is missing a piece it should
+        // have, and nothing else about it will change while the player and the region stand still.
+        val incomplete = awaitingChunks || lines.values.any { !it.isValid }
+        if (!renderChanged && !anchorMoved && !viewerMoved && !snap && !incomplete) return
+
+        val anchorVector = Vector(anchorLocation.x, anchorLocation.y, anchorLocation.z)
+        val visible = visibleOutlinePieces(
+            pieces,
+            anchorVector,
+            Vector(eye.x, eye.y, eye.z),
+            outlineRenderDistance,
+            MAX_LINE_DISPLAYS,
+        )
+
+        val active = visible.mapTo(HashSet()) { it.index }
+        val iterator = lines.entries.iterator()
+        while (iterator.hasNext()) {
+            val entry = iterator.next()
+            if (entry.key in active) continue
+            entry.value.remove()
+            iterator.remove()
+        }
+
+        // A placement change or the anchor moving teleports a surviving piece; a render only
+        // change (color, emphasis, scale) rewrites its transformation in place without moving
+        // the entity, and a player walking past just adds and drops pieces at the window's edge.
+        val repositioned = placementChanged || anchorMoved
+        val needsUpdate = renderChanged || repositioned || snap
+        // A placement change reshuffles which stretch of outline each display index maps to,
+        // so interpolating across it visibly rotates every reused line toward an unrelated
+        // segment. Those updates snap; only the pulse and the carry glide keep interpolating.
+        val discontinuous = placementChanged || snap
+        val material = nearestConcrete(color)
+        val glow = org.bukkit.Color.fromRGB(color.red, color.green, color.blue)
+        val rotation = regionRotation(yawDegrees, pitchDegrees, rollDegrees)
+        awaitingChunks = false
+        for ((index, piece) in visible) {
+            val location = anchorLocation.clone()
+                .add(piece.anchorOffset.x, piece.anchorOffset.y, piece.anchorOffset.z)
+            // world.spawn force loads its chunk, so a piece whose chunk is unloaded (and
+            // thus invisible anyway) is skipped instead of respawned, or it would reload
+            // that chunk every tick. It is picked back up once the chunk loads again.
+            if (!location.world.isChunkLoaded(location.blockX shr 4, location.blockZ shr 4)) {
+                lines.remove(index)?.remove()
+                awaitingChunks = true
+                continue
+            }
+            var existing = lines[index]?.takeIf { it.isValid }
+            if (existing != null && !needsUpdate) continue
+            // The teleport duration is entity metadata and flushes separately from the
+            // teleport itself, so an entity that glided last update may apply one more
+            // glide to a teleport that must snap. Respawning it at the target is the only
+            // ordering proof snap.
+            if (existing != null && discontinuous && glided) {
+                existing.remove()
+                lines.remove(index)
+                existing = null
+            }
+            val line = existing ?: spawnDisplay(location, material).also { lines[index] = it }
+            if (existing != null && (repositioned || snap)) {
+                line.teleportDuration = if (discontinuous) 0 else INTERPOLATION_TICKS
+                line.teleport(location)
+            }
+            line.block = material.createBlockData()
+            line.glowColorOverride = glow
+            line.interpolationDelay = 0
+            line.interpolationDuration = if (discontinuous || existing == null) 0 else emphasisTicks
+            line.transformation =
+                lineTransformation(rotation, piece.from, piece.to, LINE_THICKNESS * emphasis)
+        }
+
+        if (repositioned || snap) glided = !discontinuous
+
+        if (anchorMoved) {
+            // The panel is not moved here: it stands at the face, and the highlight update that
+            // follows this one every tick places it against the anchor recorded just below.
+            anchor = anchorLocation.clone()
+        }
+        viewer = eye.clone()
+    }
+
+    /**
+     * A translucent glowing panel marking the face the resize tool is aiming at. `null`
+     * removes the panel. When [snapKey] differs from the previous call's, the panel snaps
+     * into place without interpolating, so switching between faces never shows the panel
+     * spinning across the region.
+     *
+     * The entity stands at the face, not at the region's anchor, for the same reason the
+     * lines do: a client is only sent a display entity near the entity itself, and on a
+     * region wider than the tracking range a panel left on the anchor never arrives.
+     *
+     * Sub perceptible pose changes are dropped: view dependent faces recompute from the
+     * live eye every tick, and restarting the interpolation for float noise makes the panel
+     * jitter in place.
+     */
+    fun updateHighlight(highlight: FaceHighlight?, color: Color, snapKey: Any? = null) {
+        if (highlight == null) {
+            despawnHighlight()
+            return
+        }
+        val base = anchor ?: return
+        val location = base.clone().add(
+            highlight.anchorOffset.x.toDouble(),
+            highlight.anchorOffset.y.toDouble(),
+            highlight.anchorOffset.z.toDouble(),
+        )
+        // As with the lines: spawning force loads the chunk, and a panel in an unloaded chunk
+        // is not visible anyway, so it waits for the chunk instead of dragging it back in.
+        if (!location.world.isChunkLoaded(location.blockX shr 4, location.blockZ shr 4)) {
+            despawnHighlight()
+            return
+        }
+
+        val existing = this.highlight?.takeIf { it.isValid }
+        val panel = existing ?: spawnHighlight(location).also { this.highlight = it }
+        val snap = existing == null || snapKey != highlightKey
+        highlightKey = snapKey
+        val moved = panel.location.distanceSquared(location) > MOVE_EPSILON_SQUARED
+        if (!snap && !moved && withinDeadBand(panel.transformation, highlight.transformation)) return
+        if (existing != null && (snap || moved)) {
+            panel.teleportDuration = if (snap) 0 else INTERPOLATION_TICKS
+            panel.teleport(location)
+        }
+        panel.glowColorOverride = org.bukkit.Color.fromRGB(color.red, color.green, color.blue)
+        panel.interpolationDelay = 0
+        panel.interpolationDuration = if (snap) 0 else INTERPOLATION_TICKS
+        panel.transformation = highlight.transformation
+    }
+
+    private fun despawnHighlight() {
+        highlight?.remove()
+        highlight = null
+        highlightKey = null
+    }
+
+    private fun withinDeadBand(current: Transformation, next: Transformation): Boolean =
+        current.translation.distanceSquared(next.translation) < DEAD_BAND_DISTANCE_SQUARED &&
+                current.scale.distanceSquared(next.scale) < DEAD_BAND_DISTANCE_SQUARED &&
+                abs(current.leftRotation.dot(next.leftRotation)) > DEAD_BAND_ROTATION_DOT &&
+                abs(current.rightRotation.dot(next.rightRotation)) > DEAD_BAND_ROTATION_DOT
+
+    fun despawn() {
+        lines.values.forEach { it.remove() }
+        lines.clear()
+        pieces = emptyList()
+        highlight?.remove()
+        highlight = null
+        highlightKey = null
+        placementKey = null
+        renderKey = null
+        builtScale = null
+        anchor = null
+        viewer = null
+        awaitingChunks = false
+        glided = false
+    }
+
+    // Lines spawn with instant teleports; a glide sets the duration only for its own move.
+    private fun spawnDisplay(location: Location, material: Material): BlockDisplay =
+        spawnLineDisplay(player, location, material, 0)
+
+    // The highlight panel keeps gliding teleports, matching its interpolated pose changes.
+    private fun spawnHighlight(location: Location): BlockDisplay =
+        spawnLineDisplay(player, location, Material.WHITE_STAINED_GLASS, INTERPOLATION_TICKS)
+
+    companion object {
+        private const val LINE_THICKNESS = 0.055f
+        private const val INTERPOLATION_TICKS = 2
+        private const val MOVE_EPSILON_SQUARED = 0.0004
+
+        // A player has to move a block before the visible window is recomputed.
+        private const val VIEWER_MOVE_EPSILON_SQUARED = 1.0
+
+        private const val DEAD_BAND_DISTANCE_SQUARED = 0.0004f
+
+        // A quaternion dot of 0.99985 is about two degrees of rotation.
+        private const val DEAD_BAND_ROTATION_DOT = 0.99985f
+
+        /**
+         * The rotation [com.typewritermc.region.data.ResolvedTransform.rotateLocalToWorld]
+         * applies, as a quaternion: roll about Z, then pitch about X, then Minecraft yaw
+         * about Y.
+         */
+        fun regionRotation(yawDegrees: Float, pitchDegrees: Float, rollDegrees: Float = 0f): Quaternionf =
+            Quaternionf()
+                .rotationY(-Math.toRadians(yawDegrees.toDouble()).toFloat())
+                .rotateX(Math.toRadians(pitchDegrees.toDouble()).toFloat())
+                .rotateZ(Math.toRadians(rollDegrees.toDouble()).toFloat())
+
+        /**
+         * A display transformation stretching the unit block into a thin box from [from] to
+         * [to], both in the region's unrotated local frame, centered on the segment axis.
+         */
+        fun lineTransformation(rotation: Quaternionf, from: Vector, to: Vector, thickness: Float): Transformation {
+            val direction = to - from
+            val length = direction.length.toFloat().coerceAtLeast(0.001f)
+            // A zero length segment, which a capsule with no half height produces, has no
+            // direction to rotate towards: rotationTo would divide by its length and write a
+            // NaN quaternion straight into a live display.
+            val aim = if (direction.length < 1e-6) Quaternionf() else Quaternionf().rotationTo(
+                0f, 0f, 1f,
+                direction.x.toFloat(), direction.y.toFloat(), direction.z.toFloat(),
+            )
+            val left = Quaternionf(rotation).mul(aim)
+            val corner = Vector3f(-thickness / 2f, -thickness / 2f, 0f).rotate(left)
+            val start = Vector3f(from.x.toFloat(), from.y.toFloat(), from.z.toFloat()).rotate(Quaternionf(rotation))
+            return Transformation(
+                start.add(corner),
+                left,
+                Vector3f(thickness, thickness, length),
+                Quaternionf(),
+            )
+        }
+
+        /**
+         * A display transformation for a thin panel spanning `2 halfU × 2 halfV` around
+         * [center], oriented by the orthonormal local basis ([uBasis], [vBasis], [normal]).
+         */
+        fun panelTransformation(
+            rotation: Quaternionf,
+            center: Vector,
+            uBasis: Vector,
+            vBasis: Vector,
+            normal: Vector,
+            halfU: Double,
+            halfV: Double,
+        ): FaceHighlight {
+            val orient = Quaternionf().setFromNormalized(
+                Matrix3f(
+                    uBasis.x.toFloat(), uBasis.y.toFloat(), uBasis.z.toFloat(),
+                    vBasis.x.toFloat(), vBasis.y.toFloat(), vBasis.z.toFloat(),
+                    normal.x.toFloat(), normal.y.toFloat(), normal.z.toFloat(),
+                ),
+            )
+            val left = Quaternionf(rotation).mul(orient)
+            val width = (2 * halfU).toFloat().coerceAtLeast(0.05f)
+            val height = (2 * halfV).toFloat().coerceAtLeast(0.05f)
+            val corner = Vector3f(-width / 2f, -height / 2f, -PANEL_THICKNESS / 2f).rotate(left)
+            val at = Vector3f(center.x.toFloat(), center.y.toFloat(), center.z.toFloat()).rotate(Quaternionf(rotation))
+            return FaceHighlight(
+                at,
+                Transformation(corner, left, Vector3f(width, height, PANEL_THICKNESS), Quaternionf()),
+            )
+        }
+
+        private const val PANEL_THICKNESS = 0.04f
+
+        private val CONCRETE_COLORS = listOf(
+            Material.WHITE_CONCRETE to Triple(207, 213, 214),
+            Material.ORANGE_CONCRETE to Triple(224, 97, 1),
+            Material.MAGENTA_CONCRETE to Triple(169, 48, 159),
+            Material.LIGHT_BLUE_CONCRETE to Triple(36, 137, 199),
+            Material.YELLOW_CONCRETE to Triple(241, 175, 21),
+            Material.LIME_CONCRETE to Triple(94, 169, 24),
+            Material.PINK_CONCRETE to Triple(214, 101, 143),
+            Material.GRAY_CONCRETE to Triple(55, 58, 62),
+            Material.LIGHT_GRAY_CONCRETE to Triple(125, 125, 115),
+            Material.CYAN_CONCRETE to Triple(21, 119, 136),
+            Material.PURPLE_CONCRETE to Triple(100, 32, 156),
+            Material.BLUE_CONCRETE to Triple(45, 47, 143),
+            Material.BROWN_CONCRETE to Triple(96, 60, 32),
+            Material.GREEN_CONCRETE to Triple(73, 91, 36),
+            Material.RED_CONCRETE to Triple(142, 33, 33),
+            Material.BLACK_CONCRETE to Triple(8, 10, 15),
+        )
+
+        /** The concrete block whose color sits closest to [color], for the line bodies. */
+        fun nearestConcrete(color: Color): Material = CONCRETE_COLORS.minBy { (_, rgb) ->
+            val (red, green, blue) = rgb
+            val dr = red - color.red
+            val dg = green - color.green
+            val db = blue - color.blue
+            dr * dr + dg * dg + db * db
+        }.first
+    }
+}
+
+/**
+ * Glowing guide lines for the transform tools: the move axis and the rotation ring. The
+ * same display entity technique as [RegionOutline], but each line is anchored at its own
+ * start point relative to [anchorLocation] rather than sharing one entity anchor, so a
+ * builder standing at the far end of a large region still receives every entity, and
+ * updates snap instead of interpolating, since the guide follows the player's aim rather
+ * than the region.
+ *
+ * Every method must run on the server main thread.
+ */
+internal class GuideDisplay(private val player: Player) {
+    private val lines = mutableListOf<BlockDisplay>()
+    private var geometryKey: Int? = null
+    private var anchor: Location? = null
+
+    fun update(
+        anchorLocation: Location,
+        segments: List<Pair<Vector, Vector>>,
+        material: Material,
+        glow: org.bukkit.Color,
+        thickness: Float = GUIDE_THICKNESS,
+    ) {
+        if (anchorLocation.world != player.world || segments.isEmpty()) {
+            despawn()
+            return
+        }
+
+        // Where the guide is actually drawn, which is not the anchor when it hangs on a far
+        // region's boundary. Spawning at the anchor would force that chunk to load, and gating
+        // on it hides a guide standing right in front of the player because the region's own
+        // center, far behind them, happens to be unloaded.
+        val head = segments.first().first
+        val spawnLocation = anchorLocation.clone().add(head.x, head.y, head.z)
+
+        // world.spawn force loads its chunk, and a guide in an unloaded chunk is not visible
+        // anyway, so it is skipped until the chunk loads.
+        if (!spawnLocation.world.isChunkLoaded(spawnLocation.blockX shr 4, spawnLocation.blockZ shr 4)) {
+            despawn()
+            return
+        }
+
+        val key = Objects.hash(segments, material, thickness)
+        val moved = anchor.let {
+            it == null || it.world != anchorLocation.world ||
+                    it.distanceSquared(anchorLocation) > MOVE_EPSILON_SQUARED
+        }
+        // Line displays are not persistent, so an unloading chunk removes one while the
+        // geometry key stays the same. A missing line rebuilds the whole set.
+        if (key == geometryKey && !moved && lines.all { it.isValid }) return
+
+        if (lines.any { !it.isValid }) despawn()
+        while (lines.size > segments.size) lines.removeAt(lines.size - 1).remove()
+        while (lines.size < segments.size) lines.add(spawnLineDisplay(player, spawnLocation, material, 0))
+
+        val identity = Quaternionf()
+        for ((index, segment) in segments.withIndex()) {
+            val (from, to) = segment
+            val line = lines[index]
+            line.teleport(anchorLocation.clone().add(from.x, from.y, from.z))
+            line.block = material.createBlockData()
+            line.glowColorOverride = glow
+            line.interpolationDelay = 0
+            line.interpolationDuration = 0
+            line.transformation =
+                RegionOutline.lineTransformation(identity, Vector.ZERO, to - from, thickness)
+        }
+        geometryKey = key
+        anchor = anchorLocation.clone()
+    }
+
+    fun despawn() {
+        lines.forEach { it.remove() }
+        lines.clear()
+        geometryKey = null
+        anchor = null
+    }
+
+    companion object {
+        private const val MOVE_EPSILON_SQUARED = 0.0004
+    }
+}
+
+/** One glowing cube handle: where it sits, what it looks like, and how big it is. */
+internal data class HandleSpec(
+    val position: Vector,
+    val material: Material,
+    val glow: org.bukkit.Color,
+    val size: Float,
+)
+
+/**
+ * Small solid glowing cubes marking grabbable spots, like the polygon's corner handles.
+ * Each cube's display entity sits at its own handle, so a handle at the far end of a large
+ * region still reaches the client. Updates snap instead of interpolating: handles mark
+ * discrete spots, and the carried one follows the crosshair where a glide would drag behind.
+ *
+ * Every method must run on the server main thread.
+ */
+internal class HandleDisplay(private val player: Player) {
+    private val cubes = mutableListOf<BlockDisplay>()
+    private var rendered: List<HandleSpec> = emptyList()
+
+    fun update(world: org.bukkit.World, handles: List<HandleSpec>) {
+        if (handles.isEmpty() || world != player.world) {
+            despawn()
+            return
+        }
+        // Spawning in an unloaded chunk would force it to load, so far handles wait until
+        // their chunk is; a cube whose chunk unloads anyway reads as invalid and the set
+        // rebuilds without it, which ends the load, unload, respawn cycle.
+        val visible = handles.filter {
+            world.isChunkLoaded(floor(it.position.x).toInt() shr 4, floor(it.position.z).toInt() shr 4)
+        }
+        if (visible.isEmpty()) {
+            despawn()
+            return
+        }
+        if (cubes.any { !it.isValid }) despawn()
+        while (cubes.size > visible.size) cubes.removeAt(cubes.size - 1).remove()
+        val previous = rendered
+        for ((index, handle) in visible.withIndex()) {
+            val location = Location(world, handle.position.x, handle.position.y, handle.position.z)
+            if (index >= cubes.size) {
+                cubes.add(spawnLineDisplay(player, location, handle.material, 0))
+            } else if (previous.getOrNull(index) == handle) {
+                continue
+            }
+            val cube = cubes[index]
+            cube.teleport(location)
+            cube.block = handle.material.createBlockData()
+            cube.glowColorOverride = handle.glow
+            cube.interpolationDelay = 0
+            cube.interpolationDuration = 0
+            cube.transformation = Transformation(
+                Vector3f(-handle.size / 2f, -handle.size / 2f, -handle.size / 2f),
+                Quaternionf(),
+                Vector3f(handle.size, handle.size, handle.size),
+                Quaternionf(),
+            )
+        }
+        rendered = visible
+    }
+
+    fun despawn() {
+        cubes.forEach { it.remove() }
+        cubes.clear()
+        rendered = emptyList()
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/RegionWorkspaceContentMode.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/RegionWorkspaceContentMode.kt
@@ -1,0 +1,646 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.core.entries.Entry
+import com.typewritermc.core.entries.Query
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.interaction.context
+import com.typewritermc.core.utils.ok
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.core.utils.switchContext
+import com.typewritermc.engine.paper.content.ContentContext
+import com.typewritermc.engine.paper.content.ContentMode
+import com.typewritermc.engine.paper.content.ContentModeTrigger
+import com.typewritermc.engine.paper.content.components.*
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.stagedEntry
+import com.typewritermc.engine.paper.entry.triggerFor
+import com.typewritermc.engine.paper.utils.*
+import com.typewritermc.region.content.RegionWorkspaceContentMode.Companion.PULSE_STEP_TICKS
+import com.typewritermc.region.data.RegionDefinition
+import com.typewritermc.region.data.buildShapeOrNull
+import com.typewritermc.region.data.RegionDefinitionData
+import com.typewritermc.region.data.RegionDefinitionEntry
+import com.typewritermc.region.data.ResolvedTransform
+import com.typewritermc.region.data.displayColor
+import com.typewritermc.region.data.hasConstPlacement
+import com.typewritermc.region.shape.Shape
+import kotlinx.coroutines.Dispatchers
+import net.kyori.adventure.bossbar.BossBar
+import org.bukkit.Location
+import org.bukkit.Material
+import org.bukkit.Sound
+import org.bukkit.entity.Player
+import org.bukkit.inventory.ItemStack
+import org.koin.java.KoinJavaComponent
+import java.time.Duration
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.math.PI
+import kotlin.math.cos
+
+/**
+ * The multi region workspace: every statically placed region near the player renders at
+ * once, each outlined in its own color with a floating name tag, so a whole hub of
+ * triggers is visible in one glance. Aim at a region (or cycle with the compass) and
+ * right click to open its full editor as a sub mode; applying or leaving the editor drops
+ * back into the workspace to pick the next region.
+ *
+ * Two toggles filter the listing: the book shows or hides the region definition entries,
+ * the item frame shows or hides inline definitions living inside consumer entries. Inline
+ * regions open the same shape editors through their entry's field paths.
+ *
+ * Dynamic regions (variable bound placement) resolve per player and have no fixed home in
+ * the world, so they are not listed.
+ */
+class RegionWorkspaceContentMode(context: ContentContext, player: Player) : ContentMode(context, player) {
+    private val editRegistry: RegionEditRegistry by KoinJavaComponent.inject(RegionEditRegistry::class.java)
+    /**
+     * Replaced wholesale rather than cleared and refilled. The refresh runs on the tick thread
+     * while the compass reads this on the main one, and an empty window between the two is a
+     * division by zero in [cycleLock].
+     */
+    @Volatile
+    private var nearby: List<WorkspaceRegion> = emptyList()
+    private val outlines = mutableMapOf<String, RegionOutline>()
+    private val holograms = mutableMapOf<String, EditorHologram>()
+
+    @Volatile
+    private var targetedId: String? = null
+
+    @Volatile
+    private var lockedId: String? = null
+
+    @Volatile
+    private var inRangeCount = 0
+
+    @Volatile
+    private var showDefinitions = true
+
+    @Volatile
+    private var showInline = false
+    @Volatile
+    private var refreshTicks = REFRESH_INTERVAL_TICKS
+    private var pulseTicks = 0L
+
+    @Volatile
+    private var disposed = false
+
+    override suspend fun setup(): Result<Unit> {
+        bossBar {
+            val target = targeted()
+            val capped = if (inRangeCount > nearby.size && nearby.isNotEmpty()) {
+                " <gray>(showing the ${nearby.size} closest)</gray>"
+            } else ""
+            title = when {
+                nearby.isEmpty() && !showDefinitions && !showInline ->
+                    "<gray>Everything is hidden. Toggle the book or the item frame."
+
+                nearby.isEmpty() -> "<gray>No ${listedKinds()} within $RANGE blocks."
+                target == null ->
+                    "<white><bold>$inRangeCount</bold> region${if (inRangeCount == 1) "" else "s"} nearby$capped " +
+                            "<gray>· aim at one to select it"
+
+                else -> "<white><bold>$inRangeCount</bold> nearby$capped <gray>· selected " +
+                        "<white>${target.name}</white>${if (lockedId != null) " <yellow>(locked)" else ""}" +
+                        (target.editorName?.let { " <yellow>· ✎ $it is editing" } ?: "") +
+                        (if (target.unpublished) " <gold>· unpublished" else "") +
+                        " · <white>right-click</white> the compass to edit"
+            }
+            color = if (target == null) BossBar.Color.WHITE else BossBar.Color.GREEN
+        }
+        // No double shift exit: the teleport tool's border jump is a sneak gesture, and two
+        // quick shifts around it would silently close the workspace.
+        exit()
+        +selectorItem()
+        +TeleportToolComponent(1, ::teleportToTarget, ::teleportToTargetBorder, ::teleportBack) {}
+        +toggleItem(
+            slot = 3,
+            material = Material.BOOK,
+            name = "Region Entries",
+            description = "the regions defined by their own entry",
+            shown = { showDefinitions },
+        ) { showDefinitions = it }
+        +toggleItem(
+            slot = 4,
+            material = Material.ITEM_FRAME,
+            name = "Inline Regions",
+            description = "the regions defined inside another entry's field",
+            shown = { showInline },
+        ) { showInline = it }
+        return ok(Unit)
+    }
+
+    private fun listedKinds(): String = when {
+        showDefinitions && showInline -> "statically placed regions"
+        showDefinitions -> "statically placed region entries"
+        else -> "statically placed inline regions"
+    }
+
+    override suspend fun initialize() {
+        // Armed again here as well as set in dispose: popping an editor opened from the workspace
+        // initializes this mode again, and left set it would render nothing ever after.
+        disposed = false
+        editRegistry.enterMode(player.uniqueId, RegionModeKind.Workspace)
+        // Rerun when an editor sub mode is popped, which is exactly when the listing is stale:
+        // it still holds the region as it looked before the edit was applied.
+        refreshTicks = REFRESH_INTERVAL_TICKS
+        super.initialize()
+    }
+
+    override suspend fun tick(deltaTime: Duration) {
+        super.tick(deltaTime)
+        refreshTicks++
+        if (refreshTicks >= REFRESH_INTERVAL_TICKS) {
+            refreshTicks = 0
+            refreshNearby()
+        }
+        updateTargeting()
+        // Disposal is checked again on the main thread: the sweep above takes long enough for a
+        // publish or a disconnect to dispose this mode while it runs, and a render landing after
+        // the despawn spawns outlines and name tags into a map nothing despawns again.
+        Dispatchers.Sync.switchContext { if (!disposed) renderRegions() }
+    }
+
+    override suspend fun dispose() {
+        disposed = true
+        editRegistry.exitMode(player.uniqueId, RegionModeKind.Workspace)
+        Dispatchers.Sync.switchContext {
+            outlines.values.forEach(RegionOutline::despawn)
+            outlines.clear()
+            holograms.values.forEach(EditorHologram::despawn)
+            holograms.clear()
+        }
+        super.dispose()
+    }
+
+    private fun refreshNearby() {
+        val playerPosition = Vector(player.location.x, player.location.y, player.location.z)
+        val worldId = player.world.uid.toString()
+        val regions = buildList {
+            if (showDefinitions) {
+                Query.find<RegionDefinitionEntry>()
+                    .mapNotNullTo(this) { published -> workspaceRegion(published, worldId, playerPosition) }
+            }
+            if (showInline) addAll(inlineRegions(worldId, playerPosition))
+        }.sortedBy { it.distance }
+
+        inRangeCount = regions.size
+        val visible = regions.take(MAX_REGIONS)
+        nearby = visible
+        if (lockedId != null && visible.none { it.id == lockedId }) lockedId = null
+    }
+
+    private fun inlineRegions(worldId: String, playerPosition: Vector): List<WorkspaceRegion> =
+        Query.find<Entry>().flatMap { entry ->
+            entry.inlineRegionFields().mapNotNull { (field, data) ->
+                inlineWorkspaceRegion(entry, field, data, worldId, playerPosition)
+            }
+        }.toList()
+
+    /**
+     * An inline definition as the workspace lists it, gated and staged exactly like
+     * [workspaceRegion]: the published placement filters first, then the staged copy of
+     * the owning entry supplies the drawn geometry.
+     */
+    private fun inlineWorkspaceRegion(
+        entry: Entry,
+        field: String,
+        published: RegionDefinitionData,
+        worldId: String,
+        playerPosition: Vector,
+    ): WorkspaceRegion? {
+        if (!published.hasConstPlacement) return null
+        val publishedPlacement = resolvePlacement(published) ?: return null
+        if (publishedPlacement.transform.world.identifier != worldId) return null
+        if (boundaryDistance(publishedPlacement, playerPosition) > RANGE + STAGED_DRIFT_SLACK) return null
+
+        val staged = Ref(entry.id, Entry::class).stagedEntry()
+            ?.inlineRegionFields()?.firstOrNull { it.first == field }?.second
+            ?.takeIf { it.hasConstPlacement }
+        val definition = staged ?: published
+        val placement = (if (definition === published) publishedPlacement else resolvePlacement(definition))
+            ?: return null
+        if (placement.transform.world.identifier != worldId) return null
+        val distance = boundaryDistance(placement, playerPosition)
+        if (distance > RANGE) return null
+
+        val id = "${entry.id}#$field"
+        return WorkspaceRegion(
+            id = id,
+            entryId = entry.id,
+            inlineField = field,
+            name = "${entry.name} (${field})",
+            color = definition.displayColor(id),
+            definitionEntry = null,
+            transform = placement.transform,
+            shape = placement.shape,
+            topOffset = placement.shape.localBounds
+                .rotated(
+                    placement.transform.yawDegrees,
+                    placement.transform.pitchDegrees,
+                    placement.transform.rollDegrees,
+                )
+                .maxY,
+            distance = distance,
+            unpublished = hasUnpublishedRegionChanges(RegionEditTarget(entry.id, field)),
+            editorName = editRegistry.sessionOf(entry.id)
+                ?.takeIf { it.editorId != player.uniqueId }
+                ?.editorName,
+        )
+    }
+
+    /**
+     * The region as the workspace lists it. The workspace is an editing surface, so it
+     * draws the STAGED geometry when one exists: after an in game Apply or a web edit, the
+     * outline follows the saved values instead of the still published ones. The staged copy
+     * is a gson parse away, so the published placement gates first, with enough slack that
+     * an unpublished nudge cannot push a region out of its own listing.
+     */
+    private fun workspaceRegion(
+        published: RegionDefinitionEntry,
+        worldId: String,
+        playerPosition: Vector,
+    ): WorkspaceRegion? {
+        if (!published.hasConstPlacement) return null
+        val publishedPlacement = resolvePlacement(published) ?: return null
+        if (publishedPlacement.transform.world.identifier != worldId) return null
+        if (boundaryDistance(publishedPlacement, playerPosition) > RANGE + STAGED_DRIFT_SLACK) return null
+
+        val definition = Ref(published.id, RegionDefinitionEntry::class).stagedEntry()
+            ?.takeIf { it.hasConstPlacement } ?: published
+        val placement = (if (definition === published) publishedPlacement else resolvePlacement(definition))
+            ?: return null
+        if (placement.transform.world.identifier != worldId) return null
+        val distance = boundaryDistance(placement, playerPosition)
+        if (distance > RANGE) return null
+
+        return WorkspaceRegion(
+            id = definition.id,
+            entryId = definition.id,
+            inlineField = null,
+            name = definition.name,
+            color = definition.displayColor(definition.id),
+            definitionEntry = definition,
+            transform = placement.transform,
+            shape = placement.shape,
+            topOffset = placement.shape.localBounds
+                .rotated(
+                    placement.transform.yawDegrees,
+                    placement.transform.pitchDegrees,
+                    placement.transform.rollDegrees,
+                )
+                .maxY,
+            distance = distance,
+            unpublished = hasUnpublishedRegionChanges(definition.id),
+            editorName = editRegistry.sessionOf(definition.id)
+                ?.takeIf { it.editorId != player.uniqueId }
+                ?.editorName,
+        )
+    }
+
+    private fun resolvePlacement(definition: RegionDefinition): ResolvedPlacement? {
+        val origin = (definition.origin as? ConstVar)?.value ?: return null
+        val offset = (definition.offset as? ConstVar)?.value ?: Vector.ZERO
+        val yaw = (definition.yaw as? ConstVar)?.value ?: 0f
+        val pitch = (definition.pitch as? ConstVar)?.value ?: 0f
+        val roll = (definition.roll as? ConstVar)?.value ?: 0f
+        val shape = definition.buildShapeOrNull() ?: return null
+        return ResolvedPlacement(ResolvedTransform.fromOriginAndOffset(origin, offset, yaw, pitch, roll), shape)
+    }
+
+    /** Distance from [position] to the region's boundary; zero anywhere inside it. */
+    private fun boundaryDistance(placement: ResolvedPlacement, position: Vector): Double =
+        placement.shape.signedDistance(placement.transform.toLocal(position)).coerceAtLeast(0.0)
+
+    /**
+     * The region under the crosshair, picked by [pickTargetedRegion]: the nearest boundary
+     * the view ray enters, so a big region selects from anywhere on its silhouette, and
+     * regions containing the player only win through the wall the aim leaves through.
+     */
+    private fun updateTargeting() {
+        lockedId?.let {
+            targetedId = it
+            return
+        }
+        val eye = player.eyeLocation
+        val direction = eye.direction
+        targetedId = pickTargetedRegion(
+            nearby.map { TargetCandidate(it.id, it.transform, it.shape) },
+            Vector(eye.x, eye.y, eye.z),
+            Vector(direction.x, direction.y, direction.z),
+            RANGE,
+        )
+    }
+
+    private fun targeted(): WorkspaceRegion? = nearby.firstOrNull { it.id == targetedId }
+
+    /**
+     * Where the selection pulse is in its cycle, eased with a cosine so the motion slows
+     * into both extremes. Sampled in [PULSE_STEP_TICKS] keyframes; the
+     * display interpolation fills in between, so the curve stays smooth without resending
+     * every tick.
+     */
+    private fun pulseFactor(): Float {
+        val step = (pulseTicks / PULSE_STEP_TICKS) * PULSE_STEP_TICKS
+        val phase = (step % PULSE_PERIOD_TICKS).toDouble() / PULSE_PERIOD_TICKS
+        return (0.5 - 0.5 * cos(2.0 * PI * phase)).toFloat()
+    }
+
+    /**
+     * Main thread only: keeps one outline and one name tag per nearby region. The selected
+     * region's outline pulses on a short cycle, so the aim is readable without walking
+     * closer.
+     */
+    private fun renderRegions() {
+        pulseTicks++
+        val pulse = pulseFactor()
+        val active = nearby.associateBy { it.id }
+
+        val staleOutlines = outlines.keys - active.keys
+        for (id in staleOutlines) outlines.remove(id)?.despawn()
+        val staleHolograms = holograms.keys - active.keys
+        for (id in staleHolograms) holograms.remove(id)?.despawn()
+
+        for (region in active.values) {
+            val id = region.id
+            // While another player's live edit preview of this region is shown to us, the
+            // spectate outline and tag are the truth; rendering the published state on top
+            // would draw two conflicting boundaries.
+            if (editRegistry.hasLiveView(player.uniqueId, region.entryId)) {
+                outlines.remove(id)?.despawn()
+                holograms.remove(id)?.despawn()
+                continue
+            }
+            val selected = id == targetedId
+            val anchor = region.transform.worldOrigin
+            // The region's own world, not the viewer's: the listing is up to a second stale, so
+            // a player who just changed world would otherwise have its outline spawned beside
+            // them in the wrong one.
+            val world = resolveBukkitWorld(region.transform.world.identifier) ?: continue
+            val location = Location(world, anchor.x, anchor.y, anchor.z)
+            outlines.getOrPut(id) { RegionOutline(player) }.update(
+                location,
+                region.transform.yawDegrees,
+                region.transform.pitchDegrees,
+                region.shape,
+                region.color,
+                emphasis = if (selected) 1f + (PULSE_EMPHASIS - 1f) * pulse else 1f,
+                emphasisTicks = PULSE_STEP_TICKS,
+                scale = if (selected) 1f + (PULSE_SCALE - 1f) * pulse else 1f,
+                rollDegrees = region.transform.rollDegrees,
+            )
+            val color = region.color
+            val hex = String.format("#%02X%02X%02X", color.red, color.green, color.blue)
+            val marker = if (selected) "<yellow>»</yellow> " else ""
+            val suffix = if (selected) " <yellow>«</yellow>" else ""
+            val lines =
+                mutableListOf("$marker<$hex>■</$hex> <white><bold>${region.name}</bold></white> <$hex>■</$hex>$suffix")
+            if (region.inlineField != null) lines += "<#A9B2C3>inline definition"
+            region.editorName?.let { lines += "<yellow>✎ $it is editing" }
+            if (region.unpublished) lines += "<gold>● unpublished changes"
+            holograms.getOrPut(id) { EditorHologram(player) }.update(
+                Location(world, anchor.x, anchor.y + region.topOffset + NAME_LIFT, anchor.z),
+                lines.joinToString("\n"),
+            )
+        }
+    }
+
+    private fun selectorItem(): ItemComponent = object : ItemComponent {
+        override fun item(player: Player): Pair<Int, IntractableItem> {
+            val target = targeted()
+            val item = ItemStack(Material.RECOVERY_COMPASS).apply {
+                editMeta { meta ->
+                    meta.name = target?.let { "<gold><bold>Edit Region</bold> <yellow>[${it.name}]" }
+                        ?: "<gold><bold>Edit Region"
+                    meta.loreString = """
+                        |
+                        |<line> <gray>Aim at a region to select it.
+                        |<line> <gray>Right-click to open its editor.
+                        |<line> <gray>Left-click to cycle and lock the selection,
+                        |<line> <gray>press <white>F</white> to unlock.
+                    """.trimMargin()
+                    @Suppress("UsePropertyAccessSyntax") // Getter and setter signatures differ in nullability, so property syntax doesn't compile
+                    if (lockedId != null) meta.setEnchantmentGlintOverride(true)
+                }
+            }
+            return 0 to (item onInteract { interaction ->
+                when (interaction.type) {
+                    ItemInteractionType.RIGHT_CLICK, ItemInteractionType.SHIFT_RIGHT_CLICK,
+                    ItemInteractionType.INVENTORY_CLICK,
+                        -> openTargetEditor()
+
+                    ItemInteractionType.LEFT_CLICK, ItemInteractionType.SHIFT_LEFT_CLICK -> cycleLock()
+                    ItemInteractionType.SWAP -> {
+                        lockedId = null
+                        player.sendActionBar("<gray>Selection follows your aim again.".asMini())
+                    }
+
+                    else -> {}
+                }
+            })
+        }
+    }
+
+    private fun cycleLock() {
+        val candidates = nearby
+        if (candidates.isEmpty()) {
+            refuse("<red>No regions nearby to select.")
+            return
+        }
+        val currentIndex = candidates.indexOfFirst { it.id == (lockedId ?: targetedId) }
+        val next = candidates[(currentIndex + 1) % candidates.size]
+        lockedId = next.id
+        targetedId = next.id
+        player.playSound(player.location, Sound.UI_BUTTON_CLICK, 0.4f, 1.3f)
+        player.sendActionBar("<gold>Selected <white>${next.name}</white>. <gray>Right-click to edit it.".asMini())
+    }
+
+    private fun openTargetEditor() {
+        val target = targeted() ?: run {
+            refuse("<red>Aim at a region first, or left-click to cycle.")
+            return
+        }
+        val session = editRegistry.sessionOf(target.entryId)
+        if (session != null && session.editorId != player.uniqueId) {
+            refuse("<red>${session.editorName} is editing ${target.name} right now.")
+            return
+        }
+        val (editorContext, mode) = when {
+            target.inlineField != null -> {
+                // Rechecked against the entry as it stands now. The listing is up to a second
+                // stale, and a failed push tears down the whole content interaction, which would
+                // drop the player out of the workspace instead of refusing.
+                if (!inlineStillEditable(target.entryId, target.inlineField)) {
+                    refuse("<red>${target.name} no longer holds a region that can be edited here.")
+                    return
+                }
+                val context = inlineRegionEditorContext(target.entryId, target.inlineField)
+                context to InlineRegionContentMode(context, player)
+            }
+
+            target.definitionEntry != null -> {
+                // Resolved again for the same reason as the inline branch above: the listing is up
+                // to a second stale, and pushing an editor for an entry that a publish deleted
+                // fails its setup, which ends the whole interaction instead of refusing here.
+                val definition = Ref(target.entryId, RegionDefinitionEntry::class).get() ?: run {
+                    refuse("<red>${target.name} no longer exists.")
+                    return
+                }
+                val context = regionEditorContext(definition)
+                val editor = regionEditorMode(definition, context, player) ?: run {
+                    refuse("<red>${target.name} has no in-game editor.")
+                    return
+                }
+                context to editor
+            }
+
+            else -> return
+        }
+        player.playSound(player.location, Sound.UI_LOOM_SELECT_PATTERN, 0.6f, 1.2f)
+        ContentModeTrigger(editorContext, mode).triggerFor(player, context())
+    }
+
+    /** Whether [field] on [entryId] still holds an inline region with a usable shape. */
+    private fun inlineStillEditable(entryId: String, field: String): Boolean {
+        val ref = Ref(entryId, Entry::class)
+        val entry = ref.stagedEntry() ?: ref.get() ?: return false
+        val data = entry.inlineRegionFields().firstOrNull { it.first == field }?.second ?: return false
+        return data.buildShapeOrNull() != null
+    }
+
+    private fun teleportToTarget() {
+        val target = targeted() ?: run {
+            refuse("<red>Aim at a region first, or left-click the compass to cycle.")
+            return
+        }
+        val anchor = target.transform.worldOrigin
+        val world = resolveBukkitWorld(target.transform.world.identifier) ?: run {
+            refuse("<red>That region's world is not loaded.")
+            return
+        }
+        returnLocation = player.location
+        player.teleport(
+            Location(
+                world,
+                anchor.x,
+                anchor.y,
+                anchor.z,
+                player.location.yaw,
+                player.location.pitch
+            )
+        )
+        player.playSound(player.location, Sound.ENTITY_ENDERMAN_TELEPORT, 0.7f, 1f)
+        player.sendActionBar("<gold>Teleported to <white>${target.name}</white>. <gray>Left-click to go back.".asMini())
+    }
+
+    /**
+     * Teleports to the boundary of the targeted region the player is looking at. A ray that
+     * never crosses the boundary falls back to the nearest point on it.
+     */
+    private fun teleportToTargetBorder() {
+        val target = targeted() ?: run {
+            refuse("<red>Aim at a region first, or left-click the compass to cycle.")
+            return
+        }
+
+        val world = resolveBukkitWorld(target.transform.world.identifier) ?: run {
+            refuse("<red>That region's world is not loaded.")
+            return
+        }
+        val result = borderTeleport(world, target.transform, target.shape, player.eyeLocation) ?: run {
+            refuse("<red>Could not find a border to teleport to.")
+            return
+        }
+
+        returnLocation = player.location
+        player.teleport(result.destination)
+        player.playSound(result.destination, Sound.ENTITY_ENDERMAN_TELEPORT, 0.7f, 1.2f)
+        val hint = if (result.usedFallback) " <gray>Nothing in your aim, so this is the nearest edge." else ""
+        player.sendActionBar(
+            "<gold>Teleported to the border of <white>${target.name}</white>.$hint <gray>Left-click to go back.".asMini(),
+        )
+    }
+
+    private var returnLocation: Location? = null
+
+    private fun teleportBack() {
+        val back = returnLocation ?: run {
+            refuse("<red>No previous spot to return to yet.")
+            return
+        }
+        returnLocation = player.location
+        player.teleport(back)
+        player.playSound(back, Sound.ENTITY_ENDERMAN_TELEPORT, 0.7f, 0.8f)
+    }
+
+    private fun refuse(message: String) {
+        player.sendActionBar(message.asMini())
+        player.playSound(player.location, Sound.ENTITY_VILLAGER_NO, 0.6f, 1f)
+    }
+
+    /**
+     * A workspace hotbar toggle. The glint mirrors the shown state, and flipping it forces
+     * the next tick's refresh so the listing reacts immediately.
+     */
+    private fun toggleItem(
+        slot: Int,
+        material: Material,
+        name: String,
+        description: String,
+        shown: () -> Boolean,
+        toggle: (Boolean) -> Unit,
+    ): ItemComponent = object : ItemComponent {
+        override fun item(player: Player): Pair<Int, IntractableItem> {
+            val state = shown()
+            val item = ItemStack(material).apply {
+                editMeta { meta ->
+                    meta.name = "<gold><bold>$name</bold> ${if (state) "<green>[shown]" else "<gray>[hidden]"}"
+                    meta.loreString = """
+                        |
+                        |<line> <gray>Click to ${if (state) "hide" else "show"} $description.
+                    """.trimMargin()
+                    @Suppress("UsePropertyAccessSyntax") // Getter and setter signatures differ in nullability, so property syntax doesn't compile
+                    if (state) meta.setEnchantmentGlintOverride(true)
+                }
+            }
+            return slot to (item onInteract { interaction ->
+                if (!interaction.type.isActivation) return@onInteract
+                val shownNow = !shown()
+                toggle(shownNow)
+                refreshTicks = REFRESH_INTERVAL_TICKS
+                player.playSound(player.location, Sound.UI_BUTTON_CLICK, 0.4f, if (shownNow) 1.4f else 0.9f)
+                player.sendActionBar(
+                    "<gold>$name <gray>are now ${if (shownNow) "<green>shown</green>" else "hidden"}.".asMini(),
+                )
+            })
+        }
+    }
+
+    private data class ResolvedPlacement(val transform: ResolvedTransform, val shape: Shape)
+
+    private data class WorkspaceRegion(
+        val id: String,
+        val entryId: String,
+        val inlineField: String?,
+        val name: String,
+        val color: Color,
+        val definitionEntry: RegionDefinitionEntry?,
+        val transform: ResolvedTransform,
+        val shape: Shape,
+        val topOffset: Double,
+        val distance: Double,
+        val unpublished: Boolean,
+        val editorName: String?,
+    )
+
+    companion object {
+        private const val RANGE = 64.0
+        private const val STAGED_DRIFT_SLACK = 64.0
+        private const val MAX_REGIONS = 6
+        private const val REFRESH_INTERVAL_TICKS = 20
+        private const val NAME_LIFT = 1.0
+        private const val PULSE_PERIOD_TICKS = 16L
+        private const val PULSE_STEP_TICKS = 2
+        private const val PULSE_EMPHASIS = 2.2f
+        private const val PULSE_SCALE = 1.08f
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/ShapeRegionContentModes.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/ShapeRegionContentModes.kt
@@ -1,0 +1,794 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.core.utils.point.World
+import com.typewritermc.engine.paper.content.ContentContext
+import com.typewritermc.engine.paper.content.components.ItemComponent
+import com.typewritermc.engine.paper.content.components.ItemInteractionType
+import com.typewritermc.engine.paper.utils.round
+import com.typewritermc.region.shape.*
+import org.bukkit.Location
+import org.bukkit.Particle
+import org.bukkit.entity.Player
+import kotlin.math.*
+
+private const val MIN_EXTENT = 0.5
+
+/**
+ * The refusal for a resize step that changed nothing: either the shape is at its minimum and
+ * the step tried to shrink it, or the step was smaller than the rounding. Only the sign of
+ * the step separates the two, and reporting "cannot shrink" for a growing step reads as a
+ * bug in the tool.
+ */
+private fun noResize(what: String, delta: Double): ResizeResult = ResizeResult(
+    if (delta < 0.0) "<red>$what cannot shrink further."
+    else "<red>$what did not move, the step is too small.",
+    changed = false,
+)
+
+/**
+ * Capture based on two marked blocks. Left click marks the primary point and right click
+ * marks the secondary point. The moment both are set, the marks derive the placement and
+ * size straight into the working model, so marking again one point reshapes the live preview
+ * and the transform tools keep working on the result.
+ */
+abstract class TwoPointRegionContentMode(
+    context: ContentContext,
+    player: Player,
+    private val shapeName: String,
+    private val primaryLabel: String,
+    private val secondaryLabel: String,
+) : RegionContentMode(context, player) {
+    @Volatile
+    protected var primary: CapturedBlock? = null
+        private set
+
+    @Volatile
+    protected var secondary: CapturedBlock? = null
+        private set
+
+    final override fun wandComponent(): ItemComponent = RegionWandComponent(
+        title = "<gold><bold>Region Wand",
+        loreText = """
+            |
+            |<line> <gray>Left-click a block to mark $primaryLabel.
+            |<line> <gray>Right-click a block to mark $secondaryLabel.
+            |<line> <gray>Press <white>Q</white> to undo a mark, sneak <white>Q</white> to redo.
+        """.trimMargin(),
+        onDrop = ::undoOrRedoHeldTool,
+    ) { interaction, block ->
+        when (interaction.type) {
+            ItemInteractionType.LEFT_CLICK, ItemInteractionType.SHIFT_LEFT_CLICK -> markPrimary(block)
+            ItemInteractionType.RIGHT_CLICK, ItemInteractionType.SHIFT_RIGHT_CLICK -> markSecondary(block)
+            else -> return@RegionWandComponent
+        }
+    }
+
+    private fun markPrimary(block: CapturedBlock) = mark(primaryLabel, 0.9f, block) {
+        primary = block
+        if (secondary?.world != block.world) secondary = null
+    }
+
+    private fun markSecondary(block: CapturedBlock) = mark(secondaryLabel, 1.15f, block) {
+        secondary = block
+        if (primary?.world != block.world) primary = null
+    }
+
+    /**
+     * Ghost captures fill the marks in order, and once both are set they mark again whichever
+     * point sits closer to the marked block, so a spectator can nudge either corner without
+     * leaving the wall they are hovering in.
+     */
+    final override fun spectatorMark(block: CapturedBlock) {
+        val first = primary
+        val second = secondary
+        when {
+            first == null -> markPrimary(block)
+            second == null -> markSecondary(block)
+            blockDistanceSquared(first, block) <= blockDistanceSquared(second, block) -> markPrimary(block)
+            else -> markSecondary(block)
+        }
+    }
+
+    private fun blockDistanceSquared(a: CapturedBlock, b: CapturedBlock): Double {
+        if (a.world != b.world) return Double.MAX_VALUE
+        return (a.center - b.center).lengthSquared
+    }
+
+    private fun mark(label: String, pitch: Float, block: CapturedBlock, assign: () -> Unit) {
+        if (!placementWritable(rotation = capturesRotation)) return
+
+        val markedPrimary = primary
+        val markedSecondary = secondary
+        var derived = true
+        // A refused capture is not a step in the history either. Recording it would leave an undo
+        // that changes nothing and a redo that puts the refused mark back, without the geometry
+        // that mark was refused for.
+        val allowed = recorded(EditTool.WAND, "Marked $label") {
+            assign()
+            derived = deriveFromMarks()
+            derived
+        }
+        if (!allowed) return
+
+        // A refused capture takes its mark back. Keeping it leaves the editor believing it holds
+        // a captured region, so the boss bar invites the builder to adjust geometry that is still
+        // the entry's own, and the refusal that just said why is the only sign otherwise.
+        if (!derived) {
+            primary = markedPrimary
+            secondary = markedSecondary
+            return
+        }
+        captureFeedback("<gold>Marked $label <white>(${block.x}, ${block.y}, ${block.z})", pitch)
+    }
+
+    /** `false` when both points are marked but describe no region, which [applyCapture] refuses. */
+    private fun deriveFromMarks(): Boolean {
+        val a = primary ?: return true
+        val b = secondary ?: return true
+        if (a.world != b.world) return true
+        if (applyCapture(a, b)) return true
+        refuse("<red>The two marked points are too close together.")
+        return false
+    }
+
+    final override fun hasCapturedGeometry(): Boolean = primary != null && secondary != null
+
+    final override fun instruction(): String = when {
+        primary == null && secondary == null ->
+            "Mark the $shapeName: <red>left-click</red> for $primaryLabel, <green>right-click</green> for $secondaryLabel"
+
+        primary == null -> "<red>Left-click</red> a block to mark $primaryLabel"
+        secondary == null -> "<green>Right-click</green> a block to mark $secondaryLabel"
+        else -> "Adjust with the tools, re-mark a point, or click <yellow>Apply</yellow>"
+    }
+
+    override fun renderMarkers(eye: Location) {
+        primary?.let { emitMarker(it, Particle.FLAME, eye) }
+        secondary?.let { emitMarker(it, Particle.HAPPY_VILLAGER, eye) }
+    }
+
+    /**
+     * Derives the placement and size from the two marks into the working model. Returns
+     * `false` when the marks cannot describe the shape, like a cone with no length.
+     */
+    protected abstract fun applyCapture(a: CapturedBlock, b: CapturedBlock): Boolean
+
+    /** Whether [applyCapture] writes yaw and pitch as well as the origin. */
+    protected open val capturesRotation: Boolean = false
+
+    protected fun updateOriginFromCapture(world: World, anchor: Vector) {
+        resetResizeShift()
+        updateWorkingOrigin(originMovedTo(world, anchor.x.round(2), anchor.y.round(2), anchor.z.round(2)))
+    }
+
+    final override fun collectState(state: MutableMap<String, Any?>) {
+        state[KEY_PRIMARY] = primary
+        state[KEY_SECONDARY] = secondary
+        collectSizeState(state)
+    }
+
+    final override fun restoreStateValue(key: String, value: Any?) {
+        when (key) {
+            KEY_PRIMARY -> primary = value as? CapturedBlock
+            KEY_SECONDARY -> secondary = value as? CapturedBlock
+            else -> restoreSizeValue(key, value)
+        }
+    }
+
+    /** The mode's working size values, captured alongside the marks in undo history. */
+    protected open fun collectSizeState(state: MutableMap<String, Any?>) {}
+
+    protected open fun restoreSizeValue(key: String, value: Any?) {}
+
+    private companion object {
+        const val KEY_PRIMARY = "marks.primary"
+        const val KEY_SECONDARY = "marks.secondary"
+    }
+}
+
+/** Builds the six axis faces of a box like shape, half extents given per axis. */
+private fun boxFaces(halfX: Double, halfY: Double, halfZ: Double): List<RegionFace> = listOf(
+    RegionFace(
+        "+x",
+        "+X face",
+        Vector(halfX, 0.0, 0.0),
+        Vector(1, 0, 0),
+        Vector(0, 1, 0),
+        Vector(0, 0, 1),
+        halfY,
+        halfZ
+    ),
+    RegionFace(
+        "-x",
+        "-X face",
+        Vector(-halfX, 0.0, 0.0),
+        Vector(-1, 0, 0),
+        Vector(0, 0, 1),
+        Vector(0, 1, 0),
+        halfZ,
+        halfY
+    ),
+    RegionFace(
+        "+y",
+        "top face",
+        Vector(0.0, halfY, 0.0),
+        Vector(0, 1, 0),
+        Vector(0, 0, 1),
+        Vector(1, 0, 0),
+        halfZ,
+        halfX
+    ),
+    RegionFace(
+        "-y",
+        "bottom face",
+        Vector(0.0, -halfY, 0.0),
+        Vector(0, -1, 0),
+        Vector(1, 0, 0),
+        Vector(0, 0, 1),
+        halfX,
+        halfZ
+    ),
+    RegionFace(
+        "+z",
+        "+Z face",
+        Vector(0.0, 0.0, halfZ),
+        Vector(0, 0, 1),
+        Vector(1, 0, 0),
+        Vector(0, 1, 0),
+        halfX,
+        halfY
+    ),
+    RegionFace(
+        "-z",
+        "-Z face",
+        Vector(0.0, 0.0, -halfZ),
+        Vector(0, 0, -1),
+        Vector(0, 1, 0),
+        Vector(1, 0, 0),
+        halfY,
+        halfX
+    ),
+)
+
+/** The player marks two opposite corners of the box. */
+class CuboidRegionContentMode(context: ContentContext, player: Player) :
+    TwoPointRegionContentMode(context, player, "box", "corner A", "corner B") {
+    private val size by lazy {
+        val shape = editedShape<CuboidShape>()
+        WorkingSize(shape?.halfX ?: 1.0, shape?.halfY ?: 1.0, shape?.halfZ ?: 1.0)
+    }
+
+    override fun workingShape(): Shape = CuboidShape(size.x, size.y, size.z)
+
+    override fun hologramSizeLine(): String = "<#A9B2C3>half <white>${size.x} × ${size.y} × ${size.z}"
+
+    override fun faceSpec() = object : FaceSpec {
+        override fun faces(localEye: Vector): List<RegionFace> = boxFaces(size.x, size.y, size.z)
+
+        override fun moveFace(face: RegionFace, delta: Double): ResizeResult {
+            val (current, field) = when (face.id) {
+                "+x", "-x" -> size.x to "halfX"
+                "+y", "-y" -> size.y to "halfY"
+                else -> size.z to "halfZ"
+            }
+            val newHalf = (current + delta / 2).coerceAtLeast(MIN_EXTENT).round(2)
+            val applied = (newHalf - current) * 2
+            if (applied == 0.0) return noResize("The ${face.label}", delta)
+            if (!shiftResizeAnchor(face.normal, applied / 2)) {
+                return ResizeResult("<red>The origin is bound to a variable, the face cannot move.", changed = false)
+            }
+
+            when (face.id) {
+                "+x", "-x" -> size.x = newHalf
+                "+y", "-y" -> size.y = newHalf
+                else -> size.z = newHalf
+            }
+            restageSizeFields()
+            return ResizeResult("<gold>${face.label} <white>half $newHalf")
+        }
+    }
+
+    override fun applyCapture(a: CapturedBlock, b: CapturedBlock): Boolean {
+        val box = BlockBox.spanning(a, b)
+        updateOriginFromCapture(a.world, box.center)
+        resetWorkingRotation()
+        size.x = box.halfX
+        size.y = box.halfY
+        size.z = box.halfZ
+        restageSizeFields()
+        return true
+    }
+
+    override fun collectSizeState(state: MutableMap<String, Any?>) {
+        state["size.halfX"] = size.x
+        state["size.halfY"] = size.y
+        state["size.halfZ"] = size.z
+    }
+
+    override fun restoreSizeValue(key: String, value: Any?) {
+        when (key) {
+            "size.halfX" -> size.x = value as? Double ?: size.x
+            "size.halfY" -> size.y = value as? Double ?: size.y
+            "size.halfZ" -> size.z = value as? Double ?: size.z
+        }
+    }
+
+    override fun restageSizeFields() {
+        val shape = editedShape<CuboidShape>()
+        restageShapeField("halfX", size.x, shape?.halfX)
+        restageShapeField("halfY", size.y, shape?.halfY)
+        restageShapeField("halfZ", size.z, shape?.halfZ)
+    }
+}
+
+/** The player marks the center and a point on the boundary. */
+class SphereRegionContentMode(context: ContentContext, player: Player) :
+    TwoPointRegionContentMode(context, player, "sphere", "the center", "a boundary point") {
+    private val size by lazy {
+        WorkingValue(editedShape<SphereShape>()?.radius ?: 1.0)
+    }
+
+    override fun workingShape(): Shape = SphereShape(size.value)
+
+    override fun hologramSizeLine(): String = "<#A9B2C3>radius <white>${size.value}"
+
+    override fun supportsRotation(): Boolean = false
+
+    override fun faceSpec() = object : FaceSpec {
+        override fun faces(localEye: Vector): List<RegionFace> {
+            val direction = localEye.takeIf { it.length > Vector.EPSILON }?.normalize() ?: Vector(1, 0, 0)
+            val (uBasis, vBasis) = perpendicularBasis(direction)
+            return listOf(
+                RegionFace("surface", "surface", direction * size.value, direction, uBasis, vBasis, 0.75, 0.75),
+            )
+        }
+
+        override fun moveFace(face: RegionFace, delta: Double): ResizeResult {
+            val radius = (size.value + delta).coerceAtLeast(MIN_EXTENT).round(2)
+            if (radius == size.value && delta != 0.0) return noResize("The sphere", delta)
+            size.value = radius
+            restageSizeFields()
+            return ResizeResult("<gold>Radius <white>$radius")
+        }
+    }
+
+    override fun applyCapture(a: CapturedBlock, b: CapturedBlock): Boolean {
+        updateOriginFromCapture(a.world, a.center)
+        size.value = a.center.distance(b.center).round(2).coerceAtLeast(MIN_EXTENT)
+        restageSizeFields()
+        return true
+    }
+
+    override fun collectSizeState(state: MutableMap<String, Any?>) {
+        state["size.radius"] = size.value
+    }
+
+    override fun restoreSizeValue(key: String, value: Any?) {
+        if (key == "size.radius") size.value = value as? Double ?: size.value
+    }
+
+    override fun restageSizeFields() {
+        restageShapeField("radius", size.value, editedShape<SphereShape>()?.radius)
+    }
+}
+
+/** The player marks two corners of a box. The ellipsoid is inscribed in that box. */
+class EllipsoidRegionContentMode(context: ContentContext, player: Player) :
+    TwoPointRegionContentMode(context, player, "ellipsoid", "corner A", "corner B") {
+    private val size by lazy {
+        val shape = editedShape<EllipsoidShape>()
+        WorkingSize(shape?.radiusX ?: 1.0, shape?.radiusY ?: 1.0, shape?.radiusZ ?: 1.0)
+    }
+
+    override fun workingShape(): Shape = EllipsoidShape(size.x, size.y, size.z)
+
+    override fun hologramSizeLine(): String = "<#A9B2C3>radii <white>${size.x} × ${size.y} × ${size.z}"
+
+    override fun faceSpec() = object : FaceSpec {
+        override fun faces(localEye: Vector): List<RegionFace> = listOf(
+            RegionFace(
+                "+x",
+                "+X cap",
+                Vector(size.x, 0.0, 0.0),
+                Vector(1, 0, 0),
+                Vector(0, 1, 0),
+                Vector(0, 0, 1),
+                size.y * 0.5,
+                size.z * 0.5
+            ),
+            RegionFace(
+                "-x",
+                "-X cap",
+                Vector(-size.x, 0.0, 0.0),
+                Vector(-1, 0, 0),
+                Vector(0, 0, 1),
+                Vector(0, 1, 0),
+                size.z * 0.5,
+                size.y * 0.5
+            ),
+            RegionFace(
+                "+y",
+                "top cap",
+                Vector(0.0, size.y, 0.0),
+                Vector(0, 1, 0),
+                Vector(0, 0, 1),
+                Vector(1, 0, 0),
+                size.z * 0.5,
+                size.x * 0.5
+            ),
+            RegionFace(
+                "-y",
+                "bottom cap",
+                Vector(0.0, -size.y, 0.0),
+                Vector(0, -1, 0),
+                Vector(1, 0, 0),
+                Vector(0, 0, 1),
+                size.x * 0.5,
+                size.z * 0.5
+            ),
+            RegionFace(
+                "+z",
+                "+Z cap",
+                Vector(0.0, 0.0, size.z),
+                Vector(0, 0, 1),
+                Vector(1, 0, 0),
+                Vector(0, 1, 0),
+                size.x * 0.5,
+                size.y * 0.5
+            ),
+            RegionFace(
+                "-z",
+                "-Z cap",
+                Vector(0.0, 0.0, -size.z),
+                Vector(0, 0, -1),
+                Vector(0, 1, 0),
+                Vector(1, 0, 0),
+                size.y * 0.5,
+                size.x * 0.5
+            ),
+        )
+
+        override fun moveFace(face: RegionFace, delta: Double): ResizeResult {
+            val (current, field) = when (face.id) {
+                "+x", "-x" -> size.x to "radiusX"
+                "+y", "-y" -> size.y to "radiusY"
+                else -> size.z to "radiusZ"
+            }
+            val newRadius = (current + delta / 2).coerceAtLeast(MIN_EXTENT).round(2)
+            val applied = (newRadius - current) * 2
+            if (applied == 0.0) return noResize("The ${face.label}", delta)
+            if (!shiftResizeAnchor(face.normal, applied / 2)) {
+                return ResizeResult("<red>The origin is bound to a variable, the cap cannot move.", changed = false)
+            }
+
+            when (face.id) {
+                "+x", "-x" -> size.x = newRadius
+                "+y", "-y" -> size.y = newRadius
+                else -> size.z = newRadius
+            }
+            restageSizeFields()
+            return ResizeResult("<gold>${face.label} <white>radius $newRadius")
+        }
+    }
+
+    override fun applyCapture(a: CapturedBlock, b: CapturedBlock): Boolean {
+        val box = BlockBox.spanning(a, b)
+        updateOriginFromCapture(a.world, box.center)
+        resetWorkingRotation()
+        size.x = box.halfX.coerceAtLeast(MIN_EXTENT)
+        size.y = box.halfY.coerceAtLeast(MIN_EXTENT)
+        size.z = box.halfZ.coerceAtLeast(MIN_EXTENT)
+        restageSizeFields()
+        return true
+    }
+
+    override fun collectSizeState(state: MutableMap<String, Any?>) {
+        state["size.radiusX"] = size.x
+        state["size.radiusY"] = size.y
+        state["size.radiusZ"] = size.z
+    }
+
+    override fun restoreSizeValue(key: String, value: Any?) {
+        when (key) {
+            "size.radiusX" -> size.x = value as? Double ?: size.x
+            "size.radiusY" -> size.y = value as? Double ?: size.y
+            "size.radiusZ" -> size.z = value as? Double ?: size.z
+        }
+    }
+
+    override fun restageSizeFields() {
+        val shape = editedShape<EllipsoidShape>()
+        restageShapeField("radiusX", size.x, shape?.radiusX)
+        restageShapeField("radiusY", size.y, shape?.radiusY)
+        restageShapeField("radiusZ", size.z, shape?.radiusZ)
+    }
+}
+
+/**
+ * The player marks two corners of a box. The capsule is inscribed in that box: the radius
+ * comes from the wider horizontal half extent and the cylinder half height is the vertical
+ * space left after the two hemispheres.
+ */
+class CapsuleRegionContentMode(context: ContentContext, player: Player) :
+    TwoPointRegionContentMode(context, player, "capsule", "corner A", "corner B") {
+    private val size by lazy {
+        val shape = editedShape<CapsuleShape>()
+        WorkingCapsule(shape?.radius ?: 1.0, shape?.halfHeight ?: 1.0)
+    }
+
+    override fun workingShape(): Shape = CapsuleShape(size.radius, size.halfHeight)
+
+    override fun hologramSizeLine(): String =
+        "<#A9B2C3>radius <white>${size.radius}</white> <#A9B2C3>half height <white>${size.halfHeight}"
+
+    override fun faceSpec() = object : FaceSpec {
+        override fun faces(localEye: Vector): List<RegionFace> {
+            val top = size.halfHeight + size.radius
+            val lateral = Vector(localEye.x, 0.0, localEye.z)
+            val sideDirection = lateral.takeIf { it.length > Vector.EPSILON }?.normalize() ?: Vector(1, 0, 0)
+            val sideCenter =
+                sideDirection * size.radius + Vector(0.0, localEye.y.coerceIn(-size.halfHeight, size.halfHeight), 0.0)
+            val sideU = Vector(0, 1, 0).cross(sideDirection)
+            return listOf(
+                RegionFace(
+                    "+y",
+                    "top cap",
+                    Vector(0.0, top, 0.0),
+                    Vector(0, 1, 0),
+                    Vector(0, 0, 1),
+                    Vector(1, 0, 0),
+                    size.radius * 0.6,
+                    size.radius * 0.6
+                ),
+                RegionFace(
+                    "-y",
+                    "bottom cap",
+                    Vector(0.0, -top, 0.0),
+                    Vector(0, -1, 0),
+                    Vector(1, 0, 0),
+                    Vector(0, 0, 1),
+                    size.radius * 0.6,
+                    size.radius * 0.6
+                ),
+                RegionFace(
+                    "side",
+                    "side",
+                    sideCenter,
+                    sideDirection,
+                    sideU,
+                    Vector(0, 1, 0),
+                    size.radius * 0.6,
+                    size.halfHeight + size.radius * 0.4
+                ),
+            )
+        }
+
+        override fun moveFace(face: RegionFace, delta: Double): ResizeResult = when (face.id) {
+            "side" -> {
+                val radius = (size.radius + delta).coerceAtLeast(MIN_EXTENT).round(2)
+                if (radius == size.radius && delta != 0.0) {
+                    noResize("The capsule", delta)
+                } else {
+                    size.radius = radius
+                    restageSizeFields()
+                    ResizeResult("<gold>Radius <white>$radius")
+                }
+            }
+
+            else -> {
+                val current = size.halfHeight
+                val newHalf = (current + delta / 2).coerceAtLeast(0.0).round(2)
+                val applied = (newHalf - current) * 2
+                if (applied == 0.0) {
+                    ResizeResult("<red>The ${face.label} cannot move further.", changed = false)
+                } else if (!shiftResizeAnchor(face.normal, applied / 2)) {
+                    ResizeResult("<red>The origin is bound to a variable, the cap cannot move.", changed = false)
+                } else {
+                    size.halfHeight = newHalf
+                    restageSizeFields()
+                    ResizeResult("<gold>${face.label} <white>half height $newHalf")
+                }
+            }
+        }
+    }
+
+    override fun applyCapture(a: CapturedBlock, b: CapturedBlock): Boolean {
+        val box = BlockBox.spanning(a, b)
+        updateOriginFromCapture(a.world, box.center)
+        resetWorkingRotation()
+        size.radius = max(box.halfX, box.halfZ).coerceAtLeast(MIN_EXTENT).round(2)
+        size.halfHeight = (box.halfY - size.radius).coerceAtLeast(0.0).round(2)
+        restageSizeFields()
+        return true
+    }
+
+    override fun collectSizeState(state: MutableMap<String, Any?>) {
+        state["size.radius"] = size.radius
+        state["size.halfHeight"] = size.halfHeight
+    }
+
+    override fun restoreSizeValue(key: String, value: Any?) {
+        when (key) {
+            "size.radius" -> size.radius = value as? Double ?: size.radius
+            "size.halfHeight" -> size.halfHeight = value as? Double ?: size.halfHeight
+        }
+    }
+
+    override fun restageSizeFields() {
+        val shape = editedShape<CapsuleShape>()
+        restageShapeField("radius", size.radius, shape?.radius)
+        restageShapeField("halfHeight", size.halfHeight, shape?.halfHeight)
+    }
+}
+
+/**
+ * The player marks the apex and a point the cone aims at. The half angle keeps the entry's
+ * current value.
+ */
+class ConeRegionContentMode(context: ContentContext, player: Player) :
+    TwoPointRegionContentMode(context, player, "cone", "the apex", "the target") {
+    private val size by lazy {
+        val shape = editedShape<ConeShape>()
+        // Seeded exactly as the entry holds it. Rounding a stored angle into the tool's own range
+        // here would show the builder a cone that is not theirs, and save that back the moment
+        // they applied anything.
+        WorkingCone(shape?.length ?: 8.0, shape?.halfAngleDegrees ?: DEFAULT_HALF_ANGLE)
+    }
+
+    override fun workingShape(): Shape = ConeShape(size.length, size.halfAngleDegrees)
+
+    override fun hologramSizeLine(): String =
+        "<#A9B2C3>length <white>${size.length}</white> <#A9B2C3>half angle <white>${size.halfAngleDegrees}°"
+
+    override fun faceSpec() = object : FaceSpec {
+        override fun faces(localEye: Vector): List<RegionFace> {
+            val halfAngle = Math.toRadians(size.halfAngleDegrees)
+            val rimRadius = size.length * sin(halfAngle)
+            val azimuth = atan2(localEye.y, localEye.x).takeIf { !it.isNaN() } ?: 0.0
+            val lateralDirection = Vector(
+                sin(halfAngle) * cos(azimuth),
+                sin(halfAngle) * sin(azimuth),
+                cos(halfAngle),
+            )
+            val lateralNormal = Vector(
+                cos(halfAngle) * cos(azimuth),
+                cos(halfAngle) * sin(azimuth),
+                -sin(halfAngle),
+            )
+            val lateralU = Vector(-sin(azimuth), cos(azimuth), 0.0)
+            return listOf(
+                RegionFace(
+                    "base",
+                    "base",
+                    Vector(0.0, 0.0, size.length),
+                    Vector(0, 0, 1),
+                    Vector(1, 0, 0),
+                    Vector(0, 1, 0),
+                    rimRadius * 0.7,
+                    rimRadius * 0.7
+                ),
+                RegionFace(
+                    "side", "side",
+                    lateralDirection * (size.length * 0.6),
+                    lateralNormal,
+                    lateralU,
+                    lateralNormal.cross(lateralU),
+                    0.8,
+                    size.length * 0.35,
+                ),
+                RegionFace("apex", "apex", Vector.ZERO, Vector(0, 0, -1), Vector(0, 1, 0), Vector(1, 0, 0), 0.5, 0.5),
+            )
+        }
+
+        override fun moveFace(face: RegionFace, delta: Double): ResizeResult = when (face.id) {
+            "base" -> {
+                val length = (size.length + delta).coerceAtLeast(1.0).round(2)
+                if (length == size.length && delta != 0.0) {
+                    noResize("The cone", delta)
+                } else {
+                    size.length = length
+                    restageSizeFields()
+                    ResizeResult("<gold>Length <white>$length")
+                }
+            }
+
+            "side" -> {
+                val halfAngle = (size.halfAngleDegrees + delta * DEGREES_PER_BLOCK).coerceIn(1.0, 89.0).round(2)
+                if (halfAngle == size.halfAngleDegrees && delta != 0.0) {
+                    ResizeResult("<red>The half angle is at its limit.", changed = false)
+                } else {
+                    size.halfAngleDegrees = halfAngle
+                    restageSizeFields()
+                    ResizeResult("<gold>Half angle <white>$halfAngle°")
+                }
+            }
+
+            else -> {
+                val length = (size.length + delta).coerceAtLeast(1.0).round(2)
+                val applied = length - size.length
+                if (applied == 0.0) {
+                    ResizeResult("<red>The apex cannot move further.", changed = false)
+                } else if (!shiftResizeAnchor(Vector(0, 0, -1), applied)) {
+                    ResizeResult("<red>The origin is bound to a variable, the apex cannot move.", changed = false)
+                } else {
+                    size.length = length
+                    restageSizeFields()
+                    ResizeResult("<gold>Apex moved, length <white>$length")
+                }
+            }
+        }
+    }
+
+    override val capturesRotation: Boolean = true
+
+    override fun applyCapture(a: CapturedBlock, b: CapturedBlock): Boolean {
+        val aim = aim(a, b) ?: return false
+        updateOriginFromCapture(a.world, a.center)
+        updateWorkingYaw(aim.yawDegrees)
+        updateWorkingPitch(aim.pitchDegrees)
+        size.length = aim.length
+        restageSizeFields()
+        return true
+    }
+
+    override fun collectSizeState(state: MutableMap<String, Any?>) {
+        state["size.length"] = size.length
+        state["size.halfAngle"] = size.halfAngleDegrees
+    }
+
+    override fun restoreSizeValue(key: String, value: Any?) {
+        when (key) {
+            "size.length" -> size.length = value as? Double ?: size.length
+            "size.halfAngle" -> size.halfAngleDegrees = value as? Double ?: size.halfAngleDegrees
+        }
+    }
+
+    override fun restageSizeFields() {
+        val shape = editedShape<ConeShape>()
+        restageShapeField("length", size.length, shape?.length)
+        restageShapeField("halfAngleDegrees", size.halfAngleDegrees, shape?.halfAngleDegrees)
+    }
+
+    /**
+     * Solves the yaw and pitch for which [com.typewritermc.region.data.ResolvedTransform.rotateLocalToWorld]
+     * maps the local +Z cone axis onto the direction from [a] to [b]. That mapping follows
+     * Minecraft's yaw/pitch convention, sending +Z to
+     * `(-sinYaw * cosPitch, -sinPitch, cosYaw * cosPitch)`.
+     */
+    private fun aim(a: CapturedBlock, b: CapturedBlock): ConeAim? {
+        val dx = b.center.x - a.center.x
+        val dy = b.center.y - a.center.y
+        val dz = b.center.z - a.center.z
+        val length = sqrt(dx * dx + dy * dy + dz * dz)
+        if (length < MIN_EXTENT) return null
+
+        val yaw = Math.toDegrees(atan2(-dx, dz)).toFloat().round(2)
+        val pitch = Math.toDegrees(asin(-dy / length)).toFloat().round(2)
+        return ConeAim(length.round(2), yaw, pitch)
+    }
+
+    private data class ConeAim(val length: Double, val yawDegrees: Float, val pitchDegrees: Float)
+
+    companion object {
+        private const val DEFAULT_HALF_ANGLE = 30.0
+        private const val DEGREES_PER_BLOCK = 5.0
+    }
+}
+
+/** An orthonormal pair perpendicular to [normal], right handed so `u × v = normal`. */
+internal fun perpendicularBasis(normal: Vector): Pair<Vector, Vector> {
+    val reference = if (abs(normal.y) < 0.9) Vector(0, 1, 0) else Vector(1, 0, 0)
+    val u = reference.cross(normal).normalize()
+    val v = normal.cross(u)
+    return u to v
+}
+
+private class WorkingSize(var x: Double, var y: Double, var z: Double)
+
+private class WorkingValue(var value: Double)
+
+private class WorkingCapsule(var radius: Double, var halfHeight: Double)
+
+private class WorkingCone(var length: Double, var halfAngleDegrees: Double)

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/TransformTools.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/TransformTools.kt
@@ -1,0 +1,380 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.engine.paper.content.components.IntractableItem
+import com.typewritermc.engine.paper.content.components.ItemComponent
+import com.typewritermc.engine.paper.content.components.ItemInteractionType
+import com.typewritermc.engine.paper.content.components.onInteract
+import com.typewritermc.engine.paper.utils.loreString
+import com.typewritermc.engine.paper.utils.name
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import org.bukkit.inventory.ItemStack
+import kotlin.math.abs
+
+internal const val MOVE_STEP = 0.5
+internal const val MOVE_STEP_LARGE = 2.0
+internal const val MOVE_FINE_STEP = 0.25
+internal const val ROTATE_STEP = 15f
+internal const val ROTATE_STEP_LARGE = 45f
+internal const val ROTATE_FINE_STEP = 5f
+internal const val RESIZE_STEP = 0.5
+internal const val RESIZE_FINE_STEP = 0.25
+
+// The hotbar layout is fixed so every shape editor puts the same tool in the same slot:
+// capture and transform tools on the left, a gap, then teleport and the meta items.
+// A shape without a tool leaves its slot empty instead of shifting the others.
+internal const val WAND_SLOT = 0
+internal const val MOVE_SLOT = 1
+internal const val ROTATE_SLOT = 2
+internal const val RESIZE_SLOT = 3
+internal const val TELEPORT_SLOT = 5
+internal const val UNDO_SLOT = 6
+internal const val APPLY_SLOT = 7
+
+/** The tool identities the edit history scopes undo by. */
+internal object EditTool {
+    const val WAND = "wand"
+    const val MOVE = "move"
+    const val ROTATE = "rotate"
+    const val RESIZE = "resize"
+}
+
+/** The axis a tool is locked to. [Auto] follows the player's look direction. */
+enum class AxisLock(val display: String) {
+    Auto("Auto"),
+    X("X"),
+    Y("Y"),
+    Z("Z"),
+    ;
+
+    fun next(): AxisLock = entries[(ordinal + 1) % entries.size]
+}
+
+/**
+ * The outcome of a face move: the action bar feedback and whether anything changed.
+ * Unchanged results play a refusal sound instead of the resize click.
+ */
+data class ResizeResult(val message: String, val changed: Boolean = true)
+
+/**
+ * A boundary feature the resize tool can aim at, step, and grab: a cuboid face, a polygon
+ * wall, a cone's base, a sphere's surface under the crosshair. Everything is in the
+ * shape's local frame. [normal], [uBasis] and [vBasis] form a right handed orthonormal
+ * basis; [halfU] and [halfV] span the highlight panel and the hit test area.
+ */
+data class RegionFace(
+    val id: String,
+    val label: String,
+    val center: Vector,
+    val normal: Vector,
+    val uBasis: Vector,
+    val vBasis: Vector,
+    val halfU: Double,
+    val halfV: Double,
+)
+
+/**
+ * How a content mode resizes its shape: which faces exist for the viewer at [localEye],
+ * and what moving a face outward by a delta means. [moveFace] is called with the absolute
+ * delta from the drag's start state, on top of a freshly restored base state, so it can
+ * apply values absolutely.
+ */
+interface FaceSpec {
+    fun faces(localEye: Vector): List<RegionFace>
+    fun moveFace(face: RegionFace, delta: Double): ResizeResult
+}
+
+/**
+ * The face the player is aiming at: the closest face panel the view ray hits, or, when it
+ * hits none, the face nearest to the ray among those whose outside the player is on.
+ *
+ * [preferredId] adds hysteresis: while the previously targeted face is still hit, or still
+ * nearly as close as the best fallback candidate, it stays picked. Without it, aiming near
+ * an edge flip flops the pick between two faces every tick and the highlight jitters.
+ */
+internal fun pickFace(
+    faces: List<RegionFace>,
+    localEye: Vector,
+    localDirection: Vector,
+    preferredId: String? = null,
+): RegionFace? {
+    var bestHit: RegionFace? = null
+    var bestHitDistance = Double.MAX_VALUE
+    var preferredHit: RegionFace? = null
+    var bestNear: RegionFace? = null
+    var bestNearDistance = Double.MAX_VALUE
+    var preferredNear: RegionFace? = null
+    var preferredNearDistance = Double.MAX_VALUE
+
+    for (face in faces) {
+        val toCenter = face.center - localEye
+        val denominator = localDirection.dot(face.normal)
+        if (abs(denominator) > 1e-9) {
+            val t = toCenter.dot(face.normal) / denominator
+            if (t > 0.05) {
+                val hit = localEye + localDirection * t
+                val offset = hit - face.center
+                if (abs(offset.dot(face.uBasis)) <= face.halfU + FACE_HIT_MARGIN &&
+                    abs(offset.dot(face.vBasis)) <= face.halfV + FACE_HIT_MARGIN
+                ) {
+                    if (face.id == preferredId) preferredHit = face
+                    if (t < bestHitDistance) {
+                        bestHitDistance = t
+                        bestHit = face
+                    }
+                }
+            }
+        }
+
+        if (face.normal.dot(localEye - face.center) <= 0.0) continue
+        val along = toCenter.dot(localDirection)
+        if (along <= 0.0) continue
+        val closest = localEye + localDirection * along
+        val distance = (face.center - closest).length
+        if (face.id == preferredId) {
+            preferredNear = face
+            preferredNearDistance = distance
+        }
+        if (distance < bestNearDistance) {
+            bestNearDistance = distance
+            bestNear = face
+        }
+    }
+
+    if (preferredHit != null) return preferredHit
+    if (bestHit != null) return bestHit
+    if (preferredNear != null && preferredNearDistance <= bestNearDistance + NEAR_PICK_STICKINESS) return preferredNear
+    return bestNear
+}
+
+/**
+ * How far along the face normal the player is dragging: the parameter of the closest point
+ * on the line `center + t * normal` to the view ray. Everything in world space, directions
+ * unit length. Zero when the two are (nearly) parallel.
+ */
+internal fun dragDelta(eye: Vector, direction: Vector, faceCenter: Vector, faceNormal: Vector): Double {
+    val w = faceCenter - eye
+    val b = faceNormal.dot(direction)
+    val denominator = 1.0 - b * b
+    if (abs(denominator) < 1e-9) return 0.0
+    val d0 = faceNormal.dot(w)
+    val e0 = direction.dot(w)
+    return (e0 * b - d0) / denominator
+}
+
+/**
+ * The step sign that moves a face the way the player is looking: `1.0` when the face's
+ * [outwardNormal] points along the [view], so an outward step pushes it away, and `-1.0`
+ * when the face looks back at the player, so the same push must step it inward instead.
+ */
+internal fun pushPullSign(view: Vector, outwardNormal: Vector): Double =
+    if (view.dot(outwardNormal) >= 0.0) 1.0 else -1.0
+
+private const val FACE_HIT_MARGIN = 0.3
+private const val NEAR_PICK_STICKINESS = 0.75
+
+internal data class ToolClick(val grow: Boolean, val large: Boolean)
+
+/**
+ * A hotbar tool in the region editor. Right click applies a positive step, left click a
+ * negative one, sneak clicking applies the large step. Pressing the swap hands key cycles
+ * the tool's mode and dropping the item undoes that tool's changes, when wired.
+ */
+internal class TransformToolComponent(
+    private val slot: Int,
+    private val material: Material,
+    private val title: () -> String,
+    private val loreText: () -> String,
+    private val glint: () -> Boolean = { false },
+    private val onSwap: (() -> Unit)? = null,
+    private val onDrop: (() -> Unit)? = null,
+    private val onClick: (ToolClick) -> Unit,
+) : ItemComponent {
+    override fun item(player: Player): Pair<Int, IntractableItem> {
+        val item = ItemStack(material).apply {
+            editMeta { meta ->
+                meta.name = title()
+                meta.loreString = loreText()
+                @Suppress("UsePropertyAccessSyntax") // Getter and setter signatures differ in nullability, so property syntax doesn't compile
+                if (glint()) meta.setEnchantmentGlintOverride(true)
+            }
+        }
+        return slot to (item onInteract { interaction ->
+            when (interaction.type) {
+                ItemInteractionType.RIGHT_CLICK -> onClick(ToolClick(grow = true, large = false))
+                ItemInteractionType.SHIFT_RIGHT_CLICK -> onClick(ToolClick(grow = true, large = true))
+                ItemInteractionType.LEFT_CLICK -> onClick(ToolClick(grow = false, large = false))
+                ItemInteractionType.SHIFT_LEFT_CLICK -> onClick(ToolClick(grow = false, large = true))
+                ItemInteractionType.SWAP -> onSwap?.invoke()
+                ItemInteractionType.DROP -> onDrop?.invoke()
+                else -> {}
+            }
+        })
+    }
+}
+
+/**
+ * The teleport shard. Right click (or an inventory click) brings the editor to the region,
+ * sneak right click teleports to the border the player is looking at, left click returns
+ * them to where they teleported from. An amethyst shard because it has no vanilla use
+ * behavior of its own: throwable or edible items fight the click routing with client side
+ * prediction.
+ */
+internal class TeleportToolComponent(
+    private val slot: Int,
+    private val onTeleport: () -> Unit,
+    private val onTeleportBorder: () -> Unit,
+    private val onReturn: () -> Unit,
+    private val onDrop: () -> Unit,
+) : ItemComponent {
+    override fun item(player: Player): Pair<Int, IntractableItem> {
+        val item = ItemStack(Material.AMETHYST_SHARD).apply {
+            editMeta { meta ->
+                meta.name = "<gold><bold>Teleport"
+                meta.loreString = """
+                    |
+                    |<line> <gray>Right-click to teleport to the region.
+                    |<line> <gray>Sneak right-click to teleport to the border you are looking at.
+                    |<line> <gray>Left-click to go back to where you were.
+                    |<line> <gray>Click again to bounce between the two.
+                """.trimMargin()
+            }
+        }
+        return slot to (item onInteract { interaction ->
+            when (interaction.type) {
+                ItemInteractionType.SHIFT_RIGHT_CLICK -> onTeleportBorder()
+                ItemInteractionType.RIGHT_CLICK, ItemInteractionType.INVENTORY_CLICK -> onTeleport()
+                ItemInteractionType.LEFT_CLICK, ItemInteractionType.SHIFT_LEFT_CLICK -> onReturn()
+                ItemInteractionType.DROP -> onDrop()
+                else -> {}
+            }
+        })
+    }
+}
+
+/**
+ * The undo and redo item. Sneak clicking undoes or redoes everything.
+ */
+internal class UndoItemComponent(
+    private val undoCount: () -> Int,
+    private val redoCount: () -> Int,
+    private val onUndo: (all: Boolean) -> Unit,
+    private val onRedo: (all: Boolean) -> Unit,
+) : ItemComponent {
+    override fun item(player: Player): Pair<Int, IntractableItem> {
+        val undos = undoCount()
+        val redos = redoCount()
+        val item = when {
+            undos > 0 -> undoableItem(undos, redos)
+            redos > 0 -> redoOnlyItem(redos)
+            else -> emptyHistoryItem()
+        }
+        return UNDO_SLOT to (item onInteract { interaction ->
+            when (interaction.type) {
+                ItemInteractionType.LEFT_CLICK, ItemInteractionType.DROP -> onUndo(false)
+                ItemInteractionType.SHIFT_LEFT_CLICK -> onUndo(true)
+                ItemInteractionType.RIGHT_CLICK -> onRedo(false)
+                ItemInteractionType.SHIFT_RIGHT_CLICK -> onRedo(true)
+                else -> {}
+            }
+        })
+    }
+
+    private fun undoableItem(undos: Int, redos: Int): ItemStack = ItemStack(Material.ARROW).apply {
+        amount = undos.coerceIn(1, 64)
+        editMeta { meta ->
+            meta.name = "<gold><bold>Undo <gray>/ <gold><bold>Redo"
+            meta.loreString = """
+                |
+                |<line> <gray>Left-click to undo <white>($undos)</white>, right-click to redo <white>($redos)</white>.
+                |<line> <gray>Sneak-click to undo or redo <white>everything</white>.
+                |<line> <gray>Press <white>Q</white> on a tool to undo that tool's last change,
+                |<line> <gray>sneak <white>Q</white> to redo it.
+            """.trimMargin()
+        }
+    }
+
+    private fun redoOnlyItem(redos: Int): ItemStack = ItemStack(Material.SPECTRAL_ARROW).apply {
+        amount = redos.coerceIn(1, 64)
+        editMeta { meta ->
+            meta.name = "<gold><bold>Redo <dark_gray>(everything is undone)"
+            meta.loreString = """
+                |
+                |<line> <gray>Right-click to redo <white>($redos)</white>.
+                |<line> <gray>Sneak right-click to redo <white>everything</white>.
+            """.trimMargin()
+        }
+    }
+
+    private fun emptyHistoryItem(): ItemStack = ItemStack(Material.FEATHER).apply {
+        editMeta { meta ->
+            meta.name = "<gray><bold>History <dark_gray>(no changes yet)"
+            meta.loreString = """
+                |
+                |<line> <gray>Changes made with the tools land here.
+                |<line> <gray>The feather turns into an undo arrow
+                |<line> <gray>as soon as there is something to undo.
+            """.trimMargin()
+        }
+    }
+}
+
+/**
+ * The world direction a move step nudges toward. A locked axis moves along that world
+ * axis, signed toward the player's look. On [AxisLock.Auto] the axis follows the look
+ * through [autoMoveDirection]; pass the previously chosen direction to keep it steady.
+ */
+internal fun moveDirection(player: Player, lock: AxisLock, previousAuto: Vector? = null): Vector {
+    val location = player.location
+    val direction = location.direction
+    return when (lock) {
+        AxisLock.X -> Vector(if (direction.x >= 0) 1.0 else -1.0, 0.0, 0.0)
+        AxisLock.Y -> Vector(0.0, if (location.pitch < 0) 1.0 else -1.0, 0.0)
+        AxisLock.Z -> Vector(0.0, 0.0, if (direction.z >= 0) 1.0 else -1.0)
+        AxisLock.Auto -> autoMoveDirection(
+            Vector(direction.x, direction.y, direction.z),
+            location.pitch,
+            previousAuto,
+        )
+    }
+}
+
+// Hysteresis for the auto axis: entering the vertical axis takes a steeper look than
+// staying on it, and the other horizontal axis has to clearly dominate before a switch,
+// so the axis does not flip the moment the aim brushes a diagonal.
+private const val AUTO_VERTICAL_ENTER_DEGREES = 55f
+private const val AUTO_VERTICAL_EXIT_DEGREES = 35f
+private const val AUTO_HORIZONTAL_SWITCH_RATIO = 1.4
+
+/**
+ * The world axis the look direction picks on [AxisLock.Auto], sticky around [previous]:
+ * the vertical axis engages past [AUTO_VERTICAL_ENTER_DEGREES] of pitch and holds until
+ * the pitch flattens below [AUTO_VERTICAL_EXIT_DEGREES], and a held horizontal axis only
+ * gives way when the other one dominates by [AUTO_HORIZONTAL_SWITCH_RATIO].
+ */
+internal fun autoMoveDirection(direction: Vector, pitch: Float, previous: Vector? = null): Vector {
+    val wasVertical = previous != null && abs(previous.y) > 0.5
+    val verticalThreshold = if (wasVertical) AUTO_VERTICAL_EXIT_DEGREES else AUTO_VERTICAL_ENTER_DEGREES
+    if (abs(pitch) > verticalThreshold) return Vector(0.0, if (pitch < 0) 1.0 else -1.0, 0.0)
+
+    val pickX = when {
+        previous != null && abs(previous.x) > 0.5 ->
+            abs(direction.z) <= abs(direction.x) * AUTO_HORIZONTAL_SWITCH_RATIO
+
+        previous != null && abs(previous.z) > 0.5 ->
+            abs(direction.x) > abs(direction.z) * AUTO_HORIZONTAL_SWITCH_RATIO
+
+        else -> abs(direction.x) >= abs(direction.z)
+    }
+    if (pickX) return Vector(if (direction.x >= 0) 1.0 else -1.0, 0.0, 0.0)
+    return Vector(0.0, 0.0, if (direction.z >= 0) 1.0 else -1.0)
+}
+
+/** Normalizes to the (-180, 180] range Minecraft yaw uses. */
+internal fun normalizeDegrees(degrees: Float): Float {
+    var value = degrees % 360f
+    if (value > 180f) value -= 360f
+    if (value <= -180f) value += 360f
+    return value
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/UnpublishedChanges.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/UnpublishedChanges.kt
@@ -1,0 +1,41 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.core.entries.Entry
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.stagedEntry
+import com.typewritermc.region.data.RegionDefinition
+import com.typewritermc.region.data.buildShapeOrNull
+import com.typewritermc.region.data.RegionDefinitionEntry
+
+/**
+ * `true` when the region's staged geometry differs from the published one: someone
+ * applied placement or shape changes, in game or on the web, that are not live yet.
+ * Compares the constant placement values and the built shape, which are data classes,
+ * so variable bound fields and a staged copy that fails to parse never read as a
+ * difference.
+ */
+fun hasUnpublishedRegionChanges(entryId: String): Boolean {
+    val ref = Ref(entryId, RegionDefinitionEntry::class)
+    return differs(ref.get(), ref.stagedEntry())
+}
+
+/** [hasUnpublishedRegionChanges] for the region an editor writes to, inline or not. */
+fun hasUnpublishedRegionChanges(target: RegionEditTarget): Boolean {
+    val ref = Ref(target.entryId, Entry::class)
+    return differs(ref.get()?.let(target::definitionOf), ref.stagedEntry()?.let(target::definitionOf))
+}
+
+private fun differs(published: RegionDefinition?, staged: RegionDefinition?): Boolean {
+    if (published == null || staged == null) return false
+    return staged.geometrySignature() != published.geometrySignature()
+}
+
+private fun RegionDefinition.geometrySignature(): List<Any?> = listOf(
+    (origin as? ConstVar)?.value,
+    (offset as? ConstVar)?.value,
+    (yaw as? ConstVar)?.value,
+    (pitch as? ConstVar)?.value,
+    (roll as? ConstVar)?.value,
+    buildShapeOrNull(),
+)

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/WorkspaceTargeting.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/content/WorkspaceTargeting.kt
@@ -1,0 +1,94 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.region.data.ResolvedTransform
+import com.typewritermc.region.shape.LocalBounds
+import com.typewritermc.region.shape.Shape
+import com.typewritermc.region.shape.raycastBoundary
+import kotlin.math.abs
+
+/** A region the workspace can target: its identity and resolved geometry. */
+internal data class TargetCandidate(
+    val id: String,
+    val transform: ResolvedTransform,
+    val shape: Shape,
+)
+
+/**
+ * The region under the crosshair, in two tiers. A region the eye is outside of competes
+ * with the boundary the ray enters through; a region the eye is inside of competes with
+ * the boundary the ray exits through. Entry hits always beat exit hits: standing inside a
+ * large region, every ray leaves it through some stretch of floor or wall, and letting
+ * that exit compete would make the surrounding region win every aim at a smaller one.
+ *
+ * Within a tier the nearest hit wins. Aiming at a wall from inside nested regions selects
+ * the region that wall belongs to. `null` when the ray crosses no boundary within [range].
+ */
+internal fun pickTargetedRegion(
+    candidates: List<TargetCandidate>,
+    eye: Vector,
+    direction: Vector,
+    range: Double,
+): String? {
+    var bestEntryId: String? = null
+    var bestEntryDistance = Double.MAX_VALUE
+    var bestExitId: String? = null
+    var bestExitDistance = Double.MAX_VALUE
+
+    for (candidate in candidates) {
+        val localEye = candidate.transform.toLocal(eye)
+        val localDirection = (candidate.transform.toLocal(eye + direction) - localEye).normalize()
+        // raycastBoundary steps at a fixed interval, so it costs the same whether the ray comes
+        // near the region or not. The bounding box contains the shape, so a ray missing the
+        // box cannot cross the boundary, and no crossing lies past where the ray leaves it.
+        val reach = boundsExit(candidate.shape.localBounds, localEye, localDirection, range) ?: continue
+        val hit = candidate.shape.raycastBoundary(localEye, localDirection, reach) ?: continue
+        val distance = (hit - localEye).length
+        if (candidate.shape.contains(localEye)) {
+            if (distance < bestExitDistance) {
+                bestExitDistance = distance
+                bestExitId = candidate.id
+            }
+        } else {
+            if (distance < bestEntryDistance) {
+                bestEntryDistance = distance
+                bestEntryId = candidate.id
+            }
+        }
+    }
+    return bestEntryId ?: bestExitId
+}
+
+/**
+ * How far along the ray the shape can still be reached: where the ray leaves [bounds], capped
+ * at [range], or `null` when the ray never enters them. The box is grown by [BOUNDS_SLACK] so
+ * a boundary exactly on a face is not cut off by rounding.
+ */
+private fun boundsExit(bounds: LocalBounds, eye: Vector, direction: Vector, range: Double): Double? {
+    var entry = 0.0
+    var exit = range
+    for (axis in 0..2) {
+        val origin = axis.pick(eye)
+        val step = axis.pick(direction)
+        val low = axis.pick(Vector(bounds.minX, bounds.minY, bounds.minZ)) - BOUNDS_SLACK
+        val high = axis.pick(Vector(bounds.maxX, bounds.maxY, bounds.maxZ)) + BOUNDS_SLACK
+        if (abs(step) < 1e-9) {
+            if (origin < low || origin > high) return null
+            continue
+        }
+        val near = (low - origin) / step
+        val far = (high - origin) / step
+        entry = maxOf(entry, minOf(near, far))
+        exit = minOf(exit, maxOf(near, far))
+        if (entry > exit) return null
+    }
+    return exit
+}
+
+private fun Int.pick(vector: Vector): Double = when (this) {
+    0 -> vector.x
+    1 -> vector.y
+    else -> vector.z
+}
+
+private const val BOUNDS_SLACK = 0.5

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/data/CrossingCause.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/data/CrossingCause.kt
@@ -1,0 +1,26 @@
+package com.typewritermc.region.data
+
+/**
+ * Why a player became (or stopped being) a member of a region.
+ *
+ * - [PLAYER_MOVED]: the player walked or rode across the boundary (PlayerMoveEvent or
+ *   VehicleMoveEvent).
+ * - [TELEPORTED]: the player teleported across the boundary (PlayerTeleportEvent).
+ * - [ENGULFED]: the region's geometry advanced into a stationary player (no Bukkit event).
+ * - [DISCONNECTED]: the player logged out while inside. Only ever a leave, and their session
+ *   is already being torn down, so actions that need the player online will not land.
+ */
+enum class CrossingCause {
+    PLAYER_MOVED,
+    TELEPORTED,
+    ENGULFED,
+    DISCONNECTED,
+    ;
+
+    /**
+     * Whether the engine can undo this crossing by cancelling a Bukkit event. A crossing that
+     * cannot be undone always happened, so a handler must react to it even when it refused the
+     * player's last attempt to walk in.
+     */
+    val revocable: Boolean get() = this == PLAYER_MOVED || this == TELEPORTED
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/data/DistanceMode.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/data/DistanceMode.kt
@@ -1,0 +1,14 @@
+package com.typewritermc.region.data
+
+/**
+ * How a distance to the region boundary is measured.
+ *
+ * [FULL] measures against the whole boundary, floor and ceiling included. [HORIZONTAL]
+ * measures in the horizontal XZ plane only, against the region's vertical silhouette, so
+ * floor and ceiling faces do not contribute. Use it when a region face lies on the ground
+ * and the distance should reflect the walls instead of the floor underfoot.
+ */
+enum class DistanceMode {
+    FULL,
+    HORIZONTAL,
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/data/RegionData.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/data/RegionData.kt
@@ -1,0 +1,72 @@
+package com.typewritermc.region.data
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.entries.emptyRef
+import com.typewritermc.core.extension.annotations.AlgebraicTypeInfo
+import com.typewritermc.core.extension.annotations.ContentEditor
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.core.extension.annotations.Min
+import com.typewritermc.core.extension.annotations.WithAlpha
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.utils.Color
+import com.typewritermc.region.content.InlineRegionContentMode
+import com.typewritermc.region.shape.Shape
+import com.typewritermc.region.shape.SphereShape
+
+/**
+ * How a consumer entry points at a region. A [RegionReferenceData] references a named
+ * [RegionDefinitionEntry]. A [RegionDefinitionData] inlines the definition in the entry
+ * itself.
+ *
+ * Use a reference when several entries share one region. Use an inline definition for a
+ * region that only one entry uses.
+ */
+sealed interface RegionData {
+    /**
+     * Resolves the underlying [RegionDefinition]. Returns `null` only for a reference that
+     * points at a missing entry id.
+     */
+    fun resolveDefinition(): RegionDefinition?
+}
+
+@AlgebraicTypeInfo("region_inline", Colors.PURPLE, "mdi:cube-outline")
+data class RegionDefinitionData(
+    @Help("World position the region is anchored to. The editor captures it from where you stand.")
+    @ContentEditor(InlineRegionContentMode::class)
+    override val origin: Var<Position> = RegionDefaults.ORIGIN,
+    @Help(RegionDefaults.OFFSET_HELP)
+    override val offset: Var<Vector> = RegionDefaults.OFFSET,
+    @Help(RegionDefaults.YAW_HELP)
+    override val yaw: Var<Float> = RegionDefaults.YAW,
+    @Help(RegionDefaults.PITCH_HELP)
+    override val pitch: Var<Float> = RegionDefaults.PITCH,
+    @Help(RegionDefaults.ROLL_HELP)
+    override val roll: Var<Float> = RegionDefaults.ROLL,
+    @Help(RegionDefaults.ROTATE_WITH_ORIGIN_HELP)
+    override val rotateWithOrigin: Boolean = RegionDefaults.ROTATE_WITH_ORIGIN,
+    @Help("The region's shape and its size fields.")
+    @Default("""{"case":"sphere_shape","value":{"radius":1.0}}""")
+    val shape: Shape = SphereShape(1.0),
+    @Min(1)
+    @Help(RegionDefaults.REFRESH_RATE_HELP)
+    @Default("1")
+    override val refreshRateTicks: Int = RegionDefaults.REFRESH_RATE_TICKS,
+    @Help(RegionDefaults.COLOR_HELP)
+    @WithAlpha
+    @Default(RegionDefaults.COLOR_DEFAULT)
+    override val color: Color = RegionDefaults.COLOR,
+) : RegionData, RegionDefinition {
+    override fun buildShape(): Shape = shape
+    override fun resolveDefinition(): RegionDefinition = this
+}
+
+@AlgebraicTypeInfo("region_reference", Colors.PURPLE, "mdi:link-variant")
+data class RegionReferenceData(
+    val definition: Ref<RegionDefinitionEntry> = emptyRef(),
+) : RegionData {
+    override fun resolveDefinition(): RegionDefinition? = definition.get()
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/data/RegionDefaults.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/data/RegionDefaults.kt
@@ -1,0 +1,53 @@
+package com.typewritermc.region.data
+
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.utils.Color
+
+/**
+ * Default values for [RegionDefinition] placement fields. Concrete shape entries reference
+ * these as constructor defaults so changing a single default propagates everywhere.
+ */
+object RegionDefaults {
+    val ORIGIN: Var<Position> = ConstVar(Position.ORIGIN)
+    val OFFSET: Var<Vector> = ConstVar(Vector.ZERO)
+    val YAW: Var<Float> = ConstVar(0f)
+    val PITCH: Var<Float> = ConstVar(0f)
+    val ROLL: Var<Float> = ConstVar(0f)
+    const val ROTATE_WITH_ORIGIN: Boolean = false
+    const val REFRESH_RATE_TICKS: Int = 1
+
+    /** Fully transparent, meaning automatic: a palette color picked from the entry id. */
+    val COLOR: Color = Color(0)
+
+    const val COLOR_HELP: String =
+        "Color used for editor outlines, previews and debug visuals of this region. " +
+                "Leave fully transparent to pick a stable color automatically."
+
+    const val OFFSET_HELP: String = "Translation from the resolved origin, in the yaw-rotated local frame."
+
+    const val YAW_HELP: String = "Rotation around the vertical axis. Turns the region and the offset with it."
+
+    const val PITCH_HELP: String = "Rotation around the horizontal axis. Turns the region only, not the offset."
+
+    const val ROLL_HELP: String = "Rotation around the facing axis. Lets the region tilt in any vertical plane."
+
+    const val ROTATE_WITH_ORIGIN_HELP: String =
+        "Add the origin position's own yaw and pitch to the region's rotation."
+
+    const val REFRESH_RATE_HELP: String =
+        "How often a region that follows a variable re-checks where it is. " +
+                "Higher values cost less and lag further behind."
+
+    /**
+     * The panel picks the first case of an algebraic field unless the field declares a
+     * default, and the cases are ordered by name, so every field pointing at a region has to
+     * name the reference case or a new entry opens on an inline region of size zero.
+     */
+    const val REGION_REFERENCE: String = """{"case":"region_reference","value":{"definition":null}}"""
+
+    /** Transparent, which [com.typewritermc.region.data.displayColor] reads as automatic. */
+    const val COLOR_DEFAULT: String = "0"
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/data/RegionDefinition.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/data/RegionDefinition.kt
@@ -1,0 +1,97 @@
+package com.typewritermc.region.data
+
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.entry.entries.get
+import com.typewritermc.engine.paper.utils.Color
+import com.typewritermc.region.shape.Shape
+
+/**
+ * The geometric description of a region. It holds the four placement variables and builds
+ * the local frame shape via [buildShape]. The runtime resolves the placement per viewer
+ * into a [ResolvedTransform] and tests membership by inverse transforming player positions.
+ *
+ * Every placement field is a [Var]. Static regions use `ConstVar` and dynamic regions use
+ * any `VariableEntry`. The shape itself is plain data and is constructed once per tracker.
+ * [buildShape] is a function rather than a property because entries may not hold state, so
+ * concrete entries build the shape from their primitive constructor fields.
+ *
+ * When [rotateWithOrigin] is set, the origin position's own yaw and pitch are added to the
+ * [yaw] and [pitch] fields. A region anchored to an entity's position variable then turns
+ * with the entity's facing, which is how a vision cone follows a guard.
+ *
+ * [refreshRateTicks] is not a [Var] because changing it at runtime would break the
+ * scheduler's ordering. To slow a region down conditionally, gate the handlers with a
+ * `Var<Boolean>` instead.
+ */
+interface RegionDefinition {
+    val origin: Var<Position>
+    val offset: Var<Vector>
+    val yaw: Var<Float>
+    val pitch: Var<Float>
+    val roll: Var<Float>
+    val rotateWithOrigin: Boolean
+    val refreshRateTicks: Int
+    val color: Color
+    fun buildShape(): Shape
+}
+
+/**
+ * The color this region is drawn with in editor outlines, previews and debug visuals.
+ * A fully transparent [RegionDefinition.color] means the user left it on automatic, and a
+ * stable palette color is picked from [seed] (the entry id), so every region keeps its own
+ * recognizable hue without any configuration.
+ */
+fun RegionDefinition.displayColor(seed: String): Color {
+    if (color.alpha != 0) return color
+    val index = ((seed.hashCode() % DISPLAY_PALETTE.size) + DISPLAY_PALETTE.size) % DISPLAY_PALETTE.size
+    return DISPLAY_PALETTE[index]
+}
+
+private val DISPLAY_PALETTE = listOf(
+    Color(0xFFE74C3C.toInt()),
+    Color(0xFFE67E22.toInt()),
+    Color(0xFFF1C40F.toInt()),
+    Color(0xFF2ECC71.toInt()),
+    Color(0xFF1ABC9C.toInt()),
+    Color(0xFF3498DB.toInt()),
+    Color(0xFF9B59B6.toInt()),
+    Color(0xFFE91E63.toInt()),
+    Color(0xFFA3E635.toInt()),
+    Color(0xFF22D3EE.toInt()),
+    Color(0xFFF97316.toInt()),
+    Color(0xFF818CF8.toInt()),
+)
+
+/**
+ * The shape this definition describes, or `null` when its fields do not describe a valid
+ * one.
+ *
+ * Shapes validate their own dimensions and throw, and the panel's `@Min` and `@Max` are
+ * hints that the stored json does not have to respect. Building a shape straight out of an
+ * `Initializable` therefore let one out of range number abort the whole load loop, which
+ * took every region flag and every region event on the server down with it. Callers that
+ * build from stored data ask here and skip the definition instead.
+ */
+fun RegionDefinition.buildShapeOrNull(): Shape? = runCatching { buildShape() }.getOrNull()
+
+/**
+ * Names this definition at the start of a console line.
+ *
+ * An inline definition belongs to no entry of its own, so it is named by where it stands. A
+ * builder reading the console can walk there; an entry id could not be found anywhere in game.
+ */
+fun RegionDefinition.describeInLog(): String {
+    if (this is RegionDefinitionEntry) return "Region '$name'"
+    val origin = origin.get(null) ?: return "An inline region"
+    return "The inline region at ${origin.blockX}, ${origin.blockY}, ${origin.blockZ}"
+}
+
+/**
+ * `true` when every placement variable is a `ConstVar`, meaning the region resolves to the
+ * same world placement for every player and can be tracked once, shared by all subscribers.
+ */
+val RegionDefinition.hasConstPlacement: Boolean
+    get() = origin is ConstVar && offset is ConstVar && yaw is ConstVar && pitch is ConstVar && roll is ConstVar

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/data/RegionDefinitionEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/data/RegionDefinitionEntry.kt
@@ -1,0 +1,24 @@
+package com.typewritermc.region.data
+
+import com.typewritermc.core.entries.PriorityEntry
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.extension.annotations.Tags
+import com.typewritermc.engine.paper.entry.ManifestEntry
+import com.typewritermc.region.entries.modifier.RegionModifierEntry
+
+/**
+ * The named, reusable form of a region definition. Users create one and reference it from
+ * any number of region consumers via [RegionReferenceData].
+ *
+ * Concrete shape entries (sphere, cuboid, capsule, cone, ellipsoid, …) extend this and
+ * build their own [com.typewritermc.region.shape.Shape] from the shape specific fields they
+ * expose.
+ *
+ * A region's priority decides which of two overlapping regions gets its way. It is the page's
+ * priority unless the entry overrides it, and the region's flags inherit it.
+ */
+@Tags("region_definition")
+interface RegionDefinitionEntry : ManifestEntry, PriorityEntry, RegionDefinition {
+    /** The rules this region carries about what may happen inside it. */
+    val modifiers: List<Ref<out RegionModifierEntry>>
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/data/ResolvedTransform.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/data/ResolvedTransform.kt
@@ -1,0 +1,92 @@
+package com.typewritermc.region.data
+
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.core.utils.point.World
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * The world placement of a region, resolved for one viewer.
+ *
+ * [worldOrigin] is the anchor point: the resolved `origin` plus the yaw rotated `offset`.
+ * [yawDegrees] and [pitchDegrees] rotate the shape around that anchor, following
+ * Minecraft's convention: the shape's local +Z axis maps to the world direction an entity
+ * with that yaw and pitch faces. This lets placement variables be tied directly to an
+ * entity's yaw/pitch. [rollDegrees] then turns the shape around that facing axis, which lets a
+ * region tilt in any vertical plane, not only the one its yaw faces.
+ *
+ * The rotation matrix is computed once per resolve, so callers that repeatedly map
+ * between world and local space do not pay for the trigonometry per conversion.
+ */
+data class ResolvedTransform(
+    val world: World,
+    val worldOrigin: Vector,
+    val yawDegrees: Float,
+    val pitchDegrees: Float,
+    val rollDegrees: Float = 0f,
+) {
+    private val basis: Matrix3 = rotationMatrix(yawDegrees, pitchDegrees, rollDegrees)
+
+    companion object {
+        /**
+         * Builds a transform from the placement variables. The offset is rotated by
+         * yaw (its horizontal components only; Y is always vertical), then added to the
+         * origin to produce the world anchor.
+         */
+        fun fromOriginAndOffset(
+            origin: Position,
+            offset: Vector,
+            yawDegrees: Float,
+            pitchDegrees: Float,
+            rollDegrees: Float = 0f,
+        ): ResolvedTransform {
+            val yaw = Math.toRadians(yawDegrees.toDouble())
+            val cosYaw = cos(yaw)
+            val sinYaw = sin(yaw)
+            val rotatedOffsetX = cosYaw * offset.x - sinYaw * offset.z
+            val rotatedOffsetZ = sinYaw * offset.x + cosYaw * offset.z
+            return ResolvedTransform(
+                world = origin.world,
+                worldOrigin = Vector(
+                    origin.x + rotatedOffsetX,
+                    origin.y + offset.y,
+                    origin.z + rotatedOffsetZ,
+                ),
+                yawDegrees = yawDegrees,
+                pitchDegrees = pitchDegrees,
+                rollDegrees = rollDegrees,
+            )
+        }
+    }
+
+    /**
+     * Converts a world space vector to the local frame of this transform.
+     */
+    fun toLocal(worldVec: Vector): Vector = basis.transposedTimes(
+        Vector(
+            worldVec.x - worldOrigin.x,
+            worldVec.y - worldOrigin.y,
+            worldVec.z - worldOrigin.z,
+        ),
+    )
+
+    /**
+     * Converts a local frame vector to world coordinates.
+     */
+    fun toWorld(localVec: Vector): Vector {
+        val rotated = rotateLocalToWorld(localVec)
+        return Vector(worldOrigin.x + rotated.x, worldOrigin.y + rotated.y, worldOrigin.z + rotated.z)
+    }
+
+    fun toWorldPosition(localVec: Vector): Position {
+        val world = toWorld(localVec)
+        return Position(this.world, world.x, world.y, world.z)
+    }
+
+    /**
+     * Rotates a local frame direction (e.g. an outward normal) into world coordinates
+     * without applying [worldOrigin] translation.
+     */
+    fun rotateLocalToWorld(localDir: Vector): Vector = basis * localDir
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/data/RotationMath.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/data/RotationMath.kt
@@ -1,0 +1,54 @@
+package com.typewritermc.region.data
+
+import com.typewritermc.core.utils.point.Vector
+import kotlin.math.acos
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * A 3x3 rotation matrix, row major: the world orientation the region's three stored
+ * angles (yaw, pitch, roll) describe, applied to local offsets.
+ */
+internal class Matrix3(
+    val m00: Double, val m01: Double, val m02: Double,
+    val m10: Double, val m11: Double, val m12: Double,
+    val m20: Double, val m21: Double, val m22: Double,
+) {
+    operator fun times(v: Vector): Vector = Vector(
+        m00 * v.x + m01 * v.y + m02 * v.z,
+        m10 * v.x + m11 * v.y + m12 * v.z,
+        m20 * v.x + m21 * v.y + m22 * v.z,
+    )
+
+    /** Applies the inverse rotation: for a rotation matrix the transpose is the inverse. */
+    fun transposedTimes(v: Vector): Vector = Vector(
+        m00 * v.x + m10 * v.y + m20 * v.z,
+        m01 * v.x + m11 * v.y + m21 * v.z,
+        m02 * v.x + m12 * v.y + m22 * v.z,
+    )
+}
+
+/**
+ * The rotation the three stored angles describe: Minecraft yaw about the vertical axis,
+ * then pitch about the local horizontal axis, then roll about the local facing (+Z) axis.
+ * With roll zero this is exactly the yaw and pitch convention the transform always had.
+ */
+internal fun rotationMatrix(yawDegrees: Float, pitchDegrees: Float, rollDegrees: Float): Matrix3 {
+    val cy = cos(Math.toRadians(yawDegrees.toDouble()))
+    val sy = sin(Math.toRadians(yawDegrees.toDouble()))
+    val cp = cos(Math.toRadians(pitchDegrees.toDouble()))
+    val sp = sin(Math.toRadians(pitchDegrees.toDouble()))
+    val cr = cos(Math.toRadians(rollDegrees.toDouble()))
+    val sr = sin(Math.toRadians(rollDegrees.toDouble()))
+    return Matrix3(
+        cy * cr - sy * sp * sr, -cy * sr - sy * sp * cr, -sy * cp,
+        cp * sr, cp * cr, -sp,
+        sy * cr + cy * sp * sr, -sy * sr + cy * sp * cr, cy * cp,
+    )
+}
+
+/** How far the region leans from upright, whichever mix of pitch and roll produced it. */
+internal fun tiltDegrees(pitchDegrees: Float, rollDegrees: Float): Double {
+    val upY = cos(Math.toRadians(pitchDegrees.toDouble())) * cos(Math.toRadians(rollDegrees.toDouble()))
+    return Math.toDegrees(acos(upY.coerceIn(-1.0, 1.0)))
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/action/RegionBoundaryPushActionEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/action/RegionBoundaryPushActionEntry.kt
@@ -1,0 +1,99 @@
+package com.typewritermc.region.entries.action
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.core.utils.launch
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.engine.paper.entry.Criteria
+import com.typewritermc.engine.paper.entry.Modifier
+import com.typewritermc.engine.paper.entry.TriggerableEntry
+import com.typewritermc.engine.paper.entry.entries.ActionEntry
+import com.typewritermc.engine.paper.entry.entries.ActionTrigger
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.utils.Sync
+import com.typewritermc.engine.paper.utils.position
+import com.typewritermc.engine.paper.utils.toBukkitVector
+import com.typewritermc.region.RegionEngine
+import com.typewritermc.region.data.RegionData
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionReferenceData
+import com.typewritermc.region.shape.averageUnitDirection
+import kotlinx.coroutines.Dispatchers
+import org.koin.java.KoinJavaComponent
+import kotlin.math.abs
+
+@Entry("region_boundary_push", "Push the player outward from the region's boundary", Colors.RED, "fa-solid:wind")
+/**
+ * Pushes the player away from the region's boundary. The action resolves the region's
+ * shape, finds the nearest outward direction, and applies a velocity pulse along it.
+ *
+ * This is useful for engulf crossings, where a moving region reaches a stationary player.
+ * There is no `PlayerMoveEvent` to cancel, but the push moves the player out on the next
+ * physics tick.
+ *
+ * ## How could this be used?
+ *
+ * Pair it with a `RegionEnterEventEntry` and a criteria gate for low rank players. Cancel
+ * the move when possible and fall back to the push when not.
+ */
+class RegionBoundaryPushActionEntry(
+    override val id: String = "",
+    override val name: String = "",
+    override val criteria: List<Criteria> = emptyList(),
+    override val modifiers: List<Modifier> = emptyList(),
+    override val triggers: List<Ref<TriggerableEntry>> = emptyList(),
+    @Help("The region whose boundary to push the player away from.")
+    @Default(RegionDefaults.REGION_REFERENCE)
+    val region: RegionData = RegionReferenceData(),
+    @Help("Magnitude of the push velocity (block/tick units).")
+    @Default("0.6")
+    val magnitude: Var<Double> = ConstVar(0.6),
+    @Help("Vertical component added on top of the horizontal push, e.g. a small hop.")
+    @Default("0.2")
+    val verticalBoost: Var<Double> = ConstVar(0.2),
+) : ActionEntry {
+    override fun ActionTrigger.execute() {
+        val engine: RegionEngine = KoinJavaComponent.get(RegionEngine::class.java)
+        val tracker = engine.query(region, player) ?: return
+        val transform = tracker.lastTransform ?: return
+
+        val position = player.position
+        if (position.world != transform.world) return
+
+        val local = transform.toLocal(Vector(position.x, position.y, position.z))
+        val direction = averageUnitDirection(tracker.shape.outwardNormals(local)) ?: return
+        var worldDirection = transform.rotateLocalToWorld(direction)
+
+        // A grounded player whose nearest face is the floor or ceiling cannot be pushed
+        // through it; send them toward the nearest lateral exit instead.
+        if (player.isOnGround && abs(worldDirection.y) > VERTICAL_DOMINANCE) {
+            tracker.horizontalEscapeDirection(position)?.let { worldDirection = it }
+        }
+
+        // The magnitude is clamped because it scales the direction away from the region, and a
+        // negative one would pull the player in, which is the one thing this entry promises not
+        // to do. The boost is left alone: it is added on the world Y axis, so a negative value is
+        // a stomp downwards rather than a reversal.
+        val strength = magnitude.get(player, context).coerceAtLeast(0.0)
+        val boost = verticalBoost.get(player, context)
+        val push = Vector(
+            worldDirection.x * strength,
+            worldDirection.y * strength + boost,
+            worldDirection.z * strength,
+        )
+
+        // Velocity writes are only safe on the main thread; actions run on the
+        // interaction coroutine.
+        Dispatchers.Sync.launch {
+            if (player.isOnline) player.velocity = player.velocity.add(push.toBukkitVector())
+        }
+    }
+
+    companion object {
+        private const val VERTICAL_DOMINANCE = 0.7
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/audience/BoundaryProximityAudienceEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/audience/BoundaryProximityAudienceEntry.kt
@@ -1,0 +1,82 @@
+package com.typewritermc.region.entries.audience
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.entries.ref
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.engine.paper.entry.entries.*
+import com.typewritermc.engine.paper.utils.position
+import com.typewritermc.region.data.DistanceMode
+import com.typewritermc.region.data.RegionData
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionReferenceData
+import com.typewritermc.region.handler.ProximityHandler
+import com.typewritermc.region.handler.RegionHandler
+import kotlin.math.abs
+import org.bukkit.entity.Player
+
+@Entry(
+    "region_proximity_audience",
+    "Filter players within a distance of a region boundary",
+    Colors.MEDIUM_SEA_GREEN,
+    "mdi:radar"
+)
+/**
+ * Restricts the child audience to players whose absolute distance from the region's
+ * boundary is at most [distance]. Players just inside and just outside the boundary are
+ * both included. To pick one side only, nest an [InRegionAudienceEntry], optionally
+ * inverted, inside.
+ *
+ * [distance] may be bound to a variable, and the band is then measured against whatever the
+ * variable says at the moment the player is classified. Around a region whose placement is
+ * constant, that moment is a move: a band that shrinks while the player stands still does not
+ * catch them until they take a step. Give the region a variable placement, which puts it on the
+ * refresh loop, to have a band close on a player who is not moving.
+ *
+ * ## How could this be used?
+ *
+ * Show a barrier block wall only to players within 8 blocks of the safe zone boundary,
+ * combined with an inverted [InRegionAudienceEntry] to only show it from the outside.
+ */
+class BoundaryProximityAudienceEntry(
+    override val id: String = "",
+    override val name: String = "",
+    override val children: List<Ref<out AudienceEntry>> = emptyList(),
+    @Help("The region whose boundary band to filter against.")
+    @Default(RegionDefaults.REGION_REFERENCE)
+    val region: RegionData = RegionReferenceData(),
+    @Help("Max absolute distance from the boundary (in blocks) that counts as 'in the band'.")
+    @Default("5.0")
+    val distance: Var<Double> = ConstVar(5.0),
+    @Help("How the distance is measured. Horizontal ignores the floor and ceiling faces and measures against the region's vertical silhouette.")
+    val distanceMode: DistanceMode = DistanceMode.FULL,
+) : AudienceFilterEntry {
+    override suspend fun display(): AudienceFilter =
+        BoundaryProximityAudienceFilter(ref(), region, distance, distanceMode)
+}
+
+class BoundaryProximityAudienceFilter(
+    ref: Ref<out AudienceFilterEntry>,
+    region: RegionData,
+    private val distance: Var<Double>,
+    private val distanceMode: DistanceMode,
+) : RegionAudienceFilter(ref, region) {
+    override fun filter(player: Player): Boolean {
+        val tracker = engine.query(region, player) ?: return false
+        val signed = tracker.signedDistance(player.position, distanceMode) ?: return false
+        return abs(signed) <= distance.get(player)
+    }
+
+    override fun createHandler(player: Player): RegionHandler = ProximityHandler(
+        owner = this,
+        tracked = player.uniqueId,
+        distance = distance,
+        distanceMode = distanceMode,
+        onEnterBand = { _, _, _ -> player.updateFilter(true); false },
+        onLeaveBand = { _, _, _ -> player.updateFilter(false); false },
+        // See InRegionAudienceFilter: a band the engine rolls back has to reach the filter too.
+        onResync = { _, member -> player.updateFilter(member) },
+    )
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/audience/InRegionAudienceEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/audience/InRegionAudienceEntry.kt
@@ -1,0 +1,67 @@
+package com.typewritermc.region.entries.audience
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.entries.ref
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.engine.paper.entry.entries.AudienceEntry
+import com.typewritermc.engine.paper.entry.entries.AudienceFilter
+import com.typewritermc.engine.paper.entry.entries.AudienceFilterEntry
+import com.typewritermc.engine.paper.entry.entries.Invertible
+import com.typewritermc.region.data.RegionData
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionReferenceData
+import com.typewritermc.region.handler.EnterExitHandler
+import com.typewritermc.region.handler.RegionHandler
+import org.bukkit.entity.Player
+
+@Entry(
+    "region_inside_audience",
+    "Filter players based on whether they're inside a region",
+    Colors.MEDIUM_SEA_GREEN,
+    "mdi:map-marker-check"
+)
+/**
+ * Restricts the child audience to players inside [region]. Children attach via the standard
+ * [AudienceFilterEntry.children] composition.
+ *
+ * ## How could this be used?
+ *
+ * Wrap a particle audience effect so it only plays while the player is inside the safe
+ * zone. Or invert it and wrap a damage tick to only hurt players outside the safe zone.
+ */
+class InRegionAudienceEntry(
+    override val id: String = "",
+    override val name: String = "",
+    override val children: List<Ref<out AudienceEntry>> = emptyList(),
+    @Help("The region whose membership controls the audience.")
+    @Default(RegionDefaults.REGION_REFERENCE)
+    val region: RegionData = RegionReferenceData(),
+    override val inverted: Boolean = false,
+) : AudienceFilterEntry, Invertible {
+    override suspend fun display(): AudienceFilter = InRegionAudienceFilter(ref(), region)
+}
+
+class InRegionAudienceFilter(
+    ref: Ref<out AudienceFilterEntry>,
+    region: RegionData,
+) : RegionAudienceFilter(ref, region) {
+    override fun filter(player: Player): Boolean {
+        val tracker = engine.query(region, player) ?: return false
+        return tracker.isInside(player)
+    }
+
+    override fun createHandler(player: Player): RegionHandler = EnterExitHandler(
+        owner = this,
+        tracked = player.uniqueId,
+        onEnter = { _, _, _ -> player.updateFilter(true); false },
+        onLeave = { _, _, _ -> player.updateFilter(false); false },
+        // The filter holds what the callbacks pushed into it, so a crossing the engine rolls back
+        // has to reach it as well. Otherwise a player refused at the boundary is left in the
+        // audience: the enter they were denied already switched them on, and the crossing that
+        // would switch them off again never happens.
+        onResync = { _, member -> player.updateFilter(member) },
+    )
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/audience/RegionAudienceFilter.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/audience/RegionAudienceFilter.kt
@@ -1,0 +1,52 @@
+package com.typewritermc.region.entries.audience
+
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.engine.paper.entry.entries.AudienceFilter
+import com.typewritermc.engine.paper.entry.entries.AudienceFilterEntry
+import com.typewritermc.region.RegionEngine
+import com.typewritermc.region.data.RegionData
+import com.typewritermc.region.handler.RegionHandler
+import org.bukkit.entity.Player
+import org.koin.java.KoinJavaComponent
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Shared base for region based [AudienceFilter]s. It observes the [RegionEngine] when a
+ * player is added, cancels the subscription when they are removed, and drains everything on
+ * dispose. Concrete filters only decide which [RegionHandler] to attach and what the filter
+ * returns for a player.
+ */
+abstract class RegionAudienceFilter(
+    ref: Ref<out AudienceFilterEntry>,
+    protected val region: RegionData,
+) : AudienceFilter(ref) {
+    protected val engine: RegionEngine by lazy {
+        KoinJavaComponent.get(RegionEngine::class.java)
+    }
+    private val subs = ConcurrentHashMap<UUID, RegionEngine.Subscription>()
+
+    /**
+     * The handler kind this filter attaches for [player]. Called once per player when
+     * they enter the filter's audience. Implementations typically build an [EnterExitHandler][com.typewritermc.region.handler.EnterExitHandler]
+     * or a [ProximityHandler][com.typewritermc.region.handler.ProximityHandler] and have it
+     * call [player.refresh][AudienceFilter.refresh] on transition.
+     */
+    protected abstract fun createHandler(player: Player): RegionHandler
+
+    override fun onPlayerAdd(player: Player) {
+        super.onPlayerAdd(player)
+        engine.observe(region, player, createHandler(player))?.also { subs[player.uniqueId] = it }
+    }
+
+    override fun onPlayerRemove(player: Player) {
+        super.onPlayerRemove(player)
+        subs.remove(player.uniqueId)?.cancel()
+    }
+
+    override fun dispose() {
+        subs.values.forEach(RegionEngine.Subscription::cancel)
+        subs.clear()
+        super.dispose()
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/audience/RegionBarrierAudienceEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/audience/RegionBarrierAudienceEntry.kt
@@ -1,0 +1,250 @@
+package com.typewritermc.region.entries.audience
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.core.utils.launch
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.engine.paper.entry.entries.*
+import com.typewritermc.engine.paper.utils.Sync
+import com.typewritermc.engine.paper.utils.position
+import com.typewritermc.engine.paper.utils.toBukkitVector
+import com.typewritermc.region.RegionEngine
+import com.typewritermc.region.content.RegionEditRegistry
+import com.typewritermc.region.data.DistanceMode
+import com.typewritermc.region.data.RegionData
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionReferenceData
+import com.typewritermc.region.handler.LazyInsideQueryHandler
+import com.typewritermc.region.shape.averageUnitDirection
+import com.typewritermc.region.tracker.RegionTracker
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.sqrt
+import kotlinx.coroutines.Dispatchers
+import org.bukkit.entity.Player
+import org.bukkit.util.Vector as BukkitVector
+import org.koin.java.KoinJavaComponent
+
+enum class BarrierMode {
+    KEEP_IN,
+    KEEP_OUT,
+}
+
+@Entry(
+    "region_barrier_audience",
+    "Continuously push players back at a region boundary",
+    Colors.MEDIUM_SEA_GREEN,
+    "mdi:shield-half-full"
+)
+/**
+ * Continuously pushes audience players back when they approach or cross the region
+ * boundary from the wrong side. [BarrierMode.KEEP_IN] holds players inside the region and
+ * [BarrierMode.KEEP_OUT] holds them outside.
+ *
+ * The push ramps up across [activationDistance] blocks around the boundary and is applied
+ * as velocity, so it turns players back rather than blocking them outright. For hard blocking,
+ * use a `RegionEnterEventEntry` or `RegionExitEventEntry` with `cancel` instead. The
+ * barrier also covers crossings that cannot be cancelled, like a moving region engulfing a
+ * player.
+ *
+ * The ramp only builds where the push has somewhere to go. A player on the allowed side whose
+ * nearest face is under their feet is left alone, because a region resting on the terrain has
+ * its floor face exactly where everyone stands and the ramp would lift the lot of them. They
+ * are pushed once they actually cross.
+ *
+ * With [DistanceMode.HORIZONTAL] the boundary is the region's vertical silhouette: floor and
+ * ceiling faces neither push nor count toward the activation distance, so a region resting
+ * on the ground pushes only against its walls, ramp included.
+ *
+ * A player who ends up on the wrong side is actively expelled. When they stand on the
+ * ground and the nearest face is the floor or ceiling, the push is redirected toward the
+ * nearest lateral exit, so they walk out through a wall instead of being pushed into the floor.
+ *
+ * Players inside a region content mode (editor, workspace or debugger) are left alone, so
+ * the barrier cannot push the player editing it.
+ *
+ * ## How could this be used?
+ *
+ * Keep players in the arena during a boss fight, or gently push low level players away
+ * from a high level zone while a title explains why.
+ */
+class RegionBarrierAudienceEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("The region whose boundary to enforce.")
+    @Default(RegionDefaults.REGION_REFERENCE)
+    val region: RegionData = RegionReferenceData(),
+    @Help("KeepIn holds audience players inside the region; KeepOut holds them outside.")
+    val mode: BarrierMode = BarrierMode.KEEP_IN,
+    @Help("Peak push velocity (blocks/tick) at and beyond the boundary. The barrier never drives a player faster than 1 block per tick, so values above that behave the same as 1.")
+    @Default("0.6")
+    val strength: Var<Double> = ConstVar(0.6),
+    @Help("Distance from the boundary (on the allowed side) where the push starts ramping up. A face underfoot does not ramp; use Horizontal to ramp against the walls of a region standing on the ground.")
+    @Default("1.5")
+    val activationDistance: Var<Double> = ConstVar(1.5),
+    @Help("Measure against the whole boundary, or only the vertical silhouette (Horizontal).")
+    val distanceMode: DistanceMode = DistanceMode.FULL,
+) : AudienceEntry {
+    override suspend fun display(): AudienceDisplay =
+        RegionBarrierDisplay(region, mode, strength, activationDistance, distanceMode, id)
+}
+
+class RegionBarrierDisplay(
+    private val region: RegionData,
+    private val mode: BarrierMode,
+    private val strength: Var<Double>,
+    private val activationDistance: Var<Double>,
+    private val distanceMode: DistanceMode,
+    private val entryId: String?,
+) : AudienceDisplay(), TickableDisplay {
+    private val engine: RegionEngine by KoinJavaComponent.inject(RegionEngine::class.java)
+    private val editRegistry: RegionEditRegistry by KoinJavaComponent.inject(RegionEditRegistry::class.java)
+    private val subscriptions = ConcurrentHashMap<UUID, RegionEngine.Subscription>()
+
+    override fun onPlayerAdd(player: Player) {
+        engine.observe(region, player, LazyInsideQueryHandler(this, player.uniqueId))
+            ?.also { subscriptions[player.uniqueId] = it }
+    }
+
+    override fun onPlayerRemove(player: Player) {
+        subscriptions.remove(player.uniqueId)?.cancel()
+    }
+
+    override fun dispose() {
+        subscriptions.values.forEach(RegionEngine.Subscription::cancel)
+        subscriptions.clear()
+        super.dispose()
+    }
+
+    override fun tick() {
+        val pushes = players.mapNotNull { player ->
+            if (editRegistry.inRegionMode(player.uniqueId)) return@mapNotNull null
+            if (editRegistry.isSuppressed(player.uniqueId, entryId, region)) return@mapNotNull null
+            pushFor(player)?.let { player to it }
+        }
+        if (pushes.isEmpty()) return
+
+        // TickableDisplay.tick runs off main; velocity writes belong on the main thread.
+        // One hop applies every push of this tick.
+        Dispatchers.Sync.launch {
+            for ((player, push) in pushes) {
+                if (player.isOnline) player.velocity = pushedVelocity(player.velocity, push)
+            }
+        }
+    }
+
+    /**
+     * The push added to [velocity], unless the player is already moving that way faster than
+     * [MAX_PUSH_SPEED].
+     *
+     * The push repeats every tick for as long as the player is on the wrong side, and adding
+     * it unconditionally compounds against Minecraft's drag into a launch. Capping the
+     * component the barrier is responsible for keeps the speed it can reach bounded, and
+     * still leaves speed from an elytra or an explosion alone.
+     */
+    private fun pushedVelocity(velocity: BukkitVector, push: Vector): BukkitVector {
+        val magnitude = sqrt(push.x * push.x + push.y * push.y + push.z * push.z)
+        if (magnitude < MIN_ACTIVATION) return velocity
+        val along = (velocity.x * push.x + velocity.y * push.y + velocity.z * push.z) / magnitude
+        val room = MAX_PUSH_SPEED - along
+        if (room <= 0.0) return velocity
+
+        // The push is scaled to what is left under the cap instead of added whole, so a high
+        // strength cannot overshoot the cap by its own value on the tick it first engages.
+        val scale = minOf(1.0, room / magnitude)
+        return velocity.add(push.mul(scale).toBukkitVector())
+    }
+
+    private fun pushFor(player: Player): Vector? =
+        subscriptions[player.uniqueId]?.tracker?.let { pushFor(player, it) }
+
+    /** The push [player] receives from [tracker], or `null` for no push. Internal for the specs. */
+    internal fun pushFor(player: Player, tracker: RegionTracker): Vector? {
+        val transform = tracker.lastTransform ?: return null
+
+        val position = player.position
+        if (position.world != transform.world) return null
+
+        val signed = tracker.signedDistance(position, distanceMode) ?: return null
+        val factor = pushFactor(player, signed)
+        if (factor <= 0.0) return null
+
+        val violating = when (mode) {
+            BarrierMode.KEEP_IN -> signed > 0.0
+            BarrierMode.KEEP_OUT -> signed < 0.0
+        }
+        var worldDirection = when (distanceMode) {
+            DistanceMode.FULL -> {
+                val local = transform.toLocal(Vector(position.x, position.y, position.z))
+                val outward = averageUnitDirection(tracker.shape.outwardNormals(local)) ?: return null
+                transform.rotateLocalToWorld(if (mode == BarrierMode.KEEP_IN) outward.mul(-1.0) else outward)
+            }
+
+            DistanceMode.HORIZONTAL -> {
+                val escape = tracker.horizontalEscapeDirection(position) ?: return null
+                if (mode == BarrierMode.KEEP_IN) escape.mul(-1.0) else escape
+            }
+        }
+
+        // A player on the wrong side of the barrier is often nearest to a floor or ceiling
+        // face, and a grounded player pushed into either only feels slowed. Steer them
+        // toward the nearest lateral exit instead. The silhouette mode is lateral already.
+        if (distanceMode == DistanceMode.FULL &&
+            violating && player.isOnGround && abs(worldDirection.y) > VERTICAL_DOMINANCE
+        ) {
+            tracker.horizontalEscapeDirection(position)?.let { escape ->
+                worldDirection = if (mode == BarrierMode.KEEP_IN) escape.mul(-1.0) else escape
+            }
+        }
+
+        // A player standing where the barrier wants them is never shoved upwards. The nearest
+        // boundary of a region resting on the terrain is the floor underfoot, so the ramp would
+        // otherwise lift everyone in the arena a block and a half into the air, land them, and do
+        // it again for as long as they stay. Only for a player something is holding up, the ground
+        // or their own flight: someone falling towards the same face is on their way to crossing
+        // it, and someone already on the wrong side is pushed regardless, with the redirect above
+        // walking them out sideways.
+        if (!violating && (player.isOnGround || player.isFlying) && worldDirection.y > VERTICAL_DOMINANCE) {
+            return null
+        }
+
+        val magnitude = strength.get(player).coerceAtLeast(0.0) * factor
+        if (magnitude <= 0.0) return null
+        return Vector(
+            worldDirection.x * magnitude,
+            worldDirection.y * magnitude,
+            worldDirection.z * magnitude,
+        )
+    }
+
+    /**
+     * How hard to push. The value ramps across the activation band, from 0 when the player
+     * is fully on the allowed side to 1 at or past the boundary.
+     */
+    private fun pushFactor(player: Player, signedDistance: Double): Double {
+        val activation = activationDistance.get(player).coerceAtLeast(0.0)
+        val ramp = max(activation, MIN_ACTIVATION)
+        val factor = when (mode) {
+            BarrierMode.KEEP_IN -> (signedDistance + activation) / ramp
+            BarrierMode.KEEP_OUT -> (activation - signedDistance) / ramp
+        }
+        return factor.coerceIn(0.0, 1.0)
+    }
+
+    companion object {
+        private const val MIN_ACTIVATION = 0.001
+
+        /**
+         * Above this vertical share of the push direction, a grounded violating player is
+         * redirected laterally instead.
+         */
+        private const val VERTICAL_DOMINANCE = 0.7
+
+        /** Fastest the barrier will drive a player away from the boundary, in blocks per tick. */
+        private const val MAX_PUSH_SPEED = 1.0
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/definition/CapsuleRegionDefinitionEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/definition/CapsuleRegionDefinitionEntry.kt
@@ -1,0 +1,67 @@
+package com.typewritermc.region.entries.definition
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.extension.annotations.*
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.utils.Color
+import com.typewritermc.region.content.CapsuleRegionContentMode
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionDefinitionEntry
+import com.typewritermc.region.entries.modifier.RegionModifierEntry
+import com.typewritermc.region.shape.CapsuleShape
+import com.typewritermc.region.shape.Shape
+import java.util.Optional
+
+@Entry("capsule_region_definition", "A capsule region (cylinder with hemispherical caps)", Colors.PURPLE, "mdi:pill")
+/**
+ * Defines a capsule shaped region aligned with the local Y axis: a cylinder of [radius]
+ * and total cylindrical height `2 * halfHeight`, capped by two hemispheres of [radius].
+ *
+ * ## How could this be used?
+ *
+ * Make a personal bubble around a player by anchoring the origin to the player's location,
+ * with `radius = 1.5` and `halfHeight = 1.0` to cover a standing player.
+ */
+class CapsuleRegionDefinitionEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("World position the region is anchored to. The editor captures it from the box you mark.")
+    @ContentEditor(CapsuleRegionContentMode::class)
+    override val origin: Var<Position> = RegionDefaults.ORIGIN,
+    @Help(RegionDefaults.OFFSET_HELP)
+    override val offset: Var<Vector> = RegionDefaults.OFFSET,
+    @Help(RegionDefaults.YAW_HELP)
+    override val yaw: Var<Float> = RegionDefaults.YAW,
+    @Help(RegionDefaults.PITCH_HELP)
+    override val pitch: Var<Float> = RegionDefaults.PITCH,
+    @Help("Rotation around the facing axis. Lets the region tilt in any vertical plane.")
+    override val roll: Var<Float> = RegionDefaults.ROLL,
+    @Help("Add the origin position's own yaw and pitch to the region's rotation.")
+    override val rotateWithOrigin: Boolean = RegionDefaults.ROTATE_WITH_ORIGIN,
+    @Help(RegionDefaults.COLOR_HELP)
+    @WithAlpha
+    @Default(RegionDefaults.COLOR_DEFAULT)
+    override val color: Color = RegionDefaults.COLOR,
+    @Help("Which region wins where two overlap. Higher wins. Defaults to the page's priority.")
+    override val priorityOverride: Optional<Int> = Optional.empty(),
+    @Help("The rules this region carries: what may and may not happen inside it.")
+    override val modifiers: List<Ref<out RegionModifierEntry>> = emptyList(),
+    @Min(0)
+    @Help("Radius of the capsule, both of its rounded ends and of the column between them.")
+    @Default("1.0")
+    val radius: Double = 1.0,
+    @Min(0)
+    @Help("Distance from the center to where each rounded end begins, before the radius is added.")
+    @Default("1.0")
+    val halfHeight: Double = 1.0,
+    @Min(1)
+    @Help("How often a region that follows a variable re-checks where it is. Higher values cost less and lag further behind.")
+    @Default("1")
+    override val refreshRateTicks: Int = RegionDefaults.REFRESH_RATE_TICKS,
+) : RegionDefinitionEntry {
+    override fun buildShape(): Shape = CapsuleShape(radius, halfHeight)
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/definition/ConeRegionDefinitionEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/definition/ConeRegionDefinitionEntry.kt
@@ -1,0 +1,69 @@
+package com.typewritermc.region.entries.definition
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.extension.annotations.*
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.utils.Color
+import com.typewritermc.region.content.ConeRegionContentMode
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionDefinitionEntry
+import com.typewritermc.region.entries.modifier.RegionModifierEntry
+import com.typewritermc.region.shape.ConeShape
+import com.typewritermc.region.shape.Shape
+import java.util.Optional
+
+@Entry("cone_region_definition", "A cone region (e.g. NPC field of view)", Colors.PURPLE, "mdi:cone")
+/**
+ * Defines a cone shaped region pointing along the local +Z axis. To make a guard's vision
+ * cone, anchor [origin] to the guard's position variable and enable [rotateWithOrigin] so
+ * the cone turns with the guard's facing.
+ *
+ * ## How could this be used?
+ *
+ * A vision cone: anchor to an NPC position variable, set `offset = (0, 1.6, 0)` for eye
+ * height, enable `rotateWithOrigin`, `length = 12`, `halfAngleDegrees = 30`.
+ */
+class ConeRegionDefinitionEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("World position the cone's point is anchored to. The editor captures it from the apex you mark.")
+    @ContentEditor(ConeRegionContentMode::class)
+    override val origin: Var<Position> = RegionDefaults.ORIGIN,
+    @Help(RegionDefaults.OFFSET_HELP)
+    override val offset: Var<Vector> = RegionDefaults.OFFSET,
+    @Help("Cone direction yaw. Tie to NPC/player yaw for a follow-the-look effect.")
+    override val yaw: Var<Float> = RegionDefaults.YAW,
+    @Help("Cone direction pitch. Tie to NPC/player pitch for vertical tracking.")
+    override val pitch: Var<Float> = RegionDefaults.PITCH,
+    @Help("Rotation around the facing axis. Lets the region tilt in any vertical plane.")
+    override val roll: Var<Float> = RegionDefaults.ROLL,
+    @Help("Add the origin position's own yaw and pitch to the region's rotation.")
+    override val rotateWithOrigin: Boolean = RegionDefaults.ROTATE_WITH_ORIGIN,
+    @Help(RegionDefaults.COLOR_HELP)
+    @WithAlpha
+    @Default(RegionDefaults.COLOR_DEFAULT)
+    override val color: Color = RegionDefaults.COLOR,
+    @Help("Which region wins where two overlap. Higher wins. Defaults to the page's priority.")
+    override val priorityOverride: Optional<Int> = Optional.empty(),
+    @Help("The rules this region carries: what may and may not happen inside it.")
+    override val modifiers: List<Ref<out RegionModifierEntry>> = emptyList(),
+    @Min(0)
+    @Help("How far the cone reaches from its point.")
+    @Default("8.0")
+    val length: Double = 8.0,
+    @Min(1)
+    @Max(89)
+    @Help("Half-angle of the cone in degrees. A wider angle opens the cone; 89 is nearly a half sphere.")
+    @Default("30.0")
+    val halfAngleDegrees: Double = 30.0,
+    @Min(1)
+    @Help("How often a region that follows a variable re-checks where it is. Higher values cost less and lag further behind.")
+    @Default("1")
+    override val refreshRateTicks: Int = RegionDefaults.REFRESH_RATE_TICKS,
+) : RegionDefinitionEntry {
+    override fun buildShape(): Shape = ConeShape(length, halfAngleDegrees)
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/definition/CuboidRegionDefinitionEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/definition/CuboidRegionDefinitionEntry.kt
@@ -1,0 +1,72 @@
+package com.typewritermc.region.entries.definition
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.extension.annotations.*
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.utils.Color
+import com.typewritermc.region.content.CuboidRegionContentMode
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionDefinitionEntry
+import com.typewritermc.region.entries.modifier.RegionModifierEntry
+import com.typewritermc.region.shape.CuboidShape
+import com.typewritermc.region.shape.Shape
+import java.util.Optional
+
+@Entry("cuboid_region_definition", "A box region, rotatable on all three axes", Colors.PURPLE, "mdi:cube-outline")
+/**
+ * Defines a box shaped region centered on the resolved transform. The user specifies the
+ * box's *half extents* along each axis; the geometric center sits at the resolved origin,
+ * so to anchor by a corner set the [offset] accordingly.
+ *
+ * ## How could this be used?
+ *
+ * A 5×3×5 patio trigger box around a dialogue NPC: `halfX = 2.5, halfY = 1.5, halfZ = 2.5`,
+ * origin set to the NPC's location, `offset = (0, 1.5, 0)` so the box rests on the ground.
+ */
+class CuboidRegionDefinitionEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("World position the region is anchored to. The editor captures two corners and fills the half-extents.")
+    @ContentEditor(CuboidRegionContentMode::class)
+    override val origin: Var<Position> = RegionDefaults.ORIGIN,
+    @Help("Translation from the resolved origin, in the yaw-rotated local frame.")
+    override val offset: Var<Vector> = RegionDefaults.OFFSET,
+    @Help("Rotation around the vertical axis. Rotates the box itself and the offset's horizontal components.")
+    override val yaw: Var<Float> = RegionDefaults.YAW,
+    @Help("Rotation around the horizontal axis. Rotates the box only, not the offset.")
+    override val pitch: Var<Float> = RegionDefaults.PITCH,
+    @Help("Rotation around the facing axis. Lets the region tilt in any vertical plane.")
+    override val roll: Var<Float> = RegionDefaults.ROLL,
+    @Help("Add the origin position's own yaw and pitch to the region's rotation.")
+    override val rotateWithOrigin: Boolean = RegionDefaults.ROTATE_WITH_ORIGIN,
+    @Help(RegionDefaults.COLOR_HELP)
+    @WithAlpha
+    @Default(RegionDefaults.COLOR_DEFAULT)
+    override val color: Color = RegionDefaults.COLOR,
+    @Help("Which region wins where two overlap. Higher wins. Defaults to the page's priority.")
+    override val priorityOverride: Optional<Int> = Optional.empty(),
+    @Help("The rules this region carries: what may and may not happen inside it.")
+    override val modifiers: List<Ref<out RegionModifierEntry>> = emptyList(),
+    @Min(0)
+    @Help("Distance from the center to the east and west faces. The full width is twice this.")
+    @Default("1.0")
+    val halfX: Double = 1.0,
+    @Min(0)
+    @Help("Distance from the center to the floor and ceiling. The full height is twice this.")
+    @Default("1.0")
+    val halfY: Double = 1.0,
+    @Min(0)
+    @Help("Distance from the center to the north and south faces. The full depth is twice this.")
+    @Default("1.0")
+    val halfZ: Double = 1.0,
+    @Min(1)
+    @Help("How often a region that follows a variable re-checks where it is. Higher values cost less and lag further behind.")
+    @Default("1")
+    override val refreshRateTicks: Int = RegionDefaults.REFRESH_RATE_TICKS,
+) : RegionDefinitionEntry {
+    override fun buildShape(): Shape = CuboidShape(halfX, halfY, halfZ)
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/definition/EllipsoidRegionDefinitionEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/definition/EllipsoidRegionDefinitionEntry.kt
@@ -1,0 +1,71 @@
+package com.typewritermc.region.entries.definition
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.extension.annotations.*
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.utils.Color
+import com.typewritermc.region.content.EllipsoidRegionContentMode
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionDefinitionEntry
+import com.typewritermc.region.entries.modifier.RegionModifierEntry
+import com.typewritermc.region.shape.EllipsoidShape
+import com.typewritermc.region.shape.Shape
+import java.util.Optional
+
+@Entry("ellipsoid_region_definition", "A triaxial ellipsoid region", Colors.PURPLE, "mdi:ellipse-outline")
+/**
+ * Defines an ellipsoidal region with independent radii along X, Y, and Z. Useful when a
+ * sphere is too symmetric, like a wide low dome or a tall narrow column.
+ *
+ * ## How could this be used?
+ *
+ * A flat arena floor zone (`radiusX = radiusZ = 10`, `radiusY = 1.5`) that triggers an
+ * effect on players standing on it but ignores spectators in the stands above.
+ */
+class EllipsoidRegionDefinitionEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("World position the region is anchored to. The editor captures it from the box you mark.")
+    @ContentEditor(EllipsoidRegionContentMode::class)
+    override val origin: Var<Position> = RegionDefaults.ORIGIN,
+    @Help(RegionDefaults.OFFSET_HELP)
+    override val offset: Var<Vector> = RegionDefaults.OFFSET,
+    @Help(RegionDefaults.YAW_HELP)
+    override val yaw: Var<Float> = RegionDefaults.YAW,
+    @Help(RegionDefaults.PITCH_HELP)
+    override val pitch: Var<Float> = RegionDefaults.PITCH,
+    @Help("Rotation around the facing axis. Lets the region tilt in any vertical plane.")
+    override val roll: Var<Float> = RegionDefaults.ROLL,
+    @Help("Add the origin position's own yaw and pitch to the region's rotation.")
+    override val rotateWithOrigin: Boolean = RegionDefaults.ROTATE_WITH_ORIGIN,
+    @Help(RegionDefaults.COLOR_HELP)
+    @WithAlpha
+    @Default(RegionDefaults.COLOR_DEFAULT)
+    override val color: Color = RegionDefaults.COLOR,
+    @Help("Which region wins where two overlap. Higher wins. Defaults to the page's priority.")
+    override val priorityOverride: Optional<Int> = Optional.empty(),
+    @Help("The rules this region carries: what may and may not happen inside it.")
+    override val modifiers: List<Ref<out RegionModifierEntry>> = emptyList(),
+    @Min(0)
+    @Help("Half-extent along the local X axis.")
+    @Default("5.0")
+    val radiusX: Double = 5.0,
+    @Min(0)
+    @Help("Half-extent along the local Y axis (vertical before pitch).")
+    @Default("5.0")
+    val radiusY: Double = 5.0,
+    @Min(0)
+    @Help("Half-extent along the local Z axis.")
+    @Default("5.0")
+    val radiusZ: Double = 5.0,
+    @Min(1)
+    @Help("How often a region that follows a variable re-checks where it is. Higher values cost less and lag further behind.")
+    @Default("1")
+    override val refreshRateTicks: Int = RegionDefaults.REFRESH_RATE_TICKS,
+) : RegionDefinitionEntry {
+    override fun buildShape(): Shape = EllipsoidShape(radiusX, radiusY, radiusZ)
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/definition/PolygonRegionDefinitionEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/definition/PolygonRegionDefinitionEntry.kt
@@ -1,0 +1,75 @@
+package com.typewritermc.region.entries.definition
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.extension.annotations.*
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.utils.Color
+import com.typewritermc.region.content.PolygonRegionContentMode
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionDefinitionEntry
+import com.typewritermc.region.entries.modifier.RegionModifierEntry
+import com.typewritermc.region.shape.PolygonShape
+import com.typewritermc.region.shape.Shape
+import java.util.Optional
+
+@Entry(
+    "polygon_region_definition",
+    "A polygon-prism region anchored to a position",
+    Colors.PURPLE,
+    "mdi:vector-polygon"
+)
+/**
+ * Defines a polygonal prism region: the polygon spanned by [points] in the horizontal
+ * plane, extruded [halfHeight] blocks up and down from the world resolved [origin] (plus
+ * yaw rotated [offset]).
+ *
+ * Points are local frame coordinates relative to the resolved origin; only their X and Z
+ * components are used. At least three points are required; the polygon may be concave but
+ * must not self intersect.
+ *
+ * ## How could this be used?
+ *
+ * Trace the actual outline of a build that no box or sphere fits (a town wall, an
+ * irregular arena floor) and hook enter/leave events or displays to it.
+ */
+class PolygonRegionDefinitionEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("World position the region is anchored to. The editor captures outline points walked in game.")
+    @ContentEditor(PolygonRegionContentMode::class)
+    override val origin: Var<Position> = RegionDefaults.ORIGIN,
+    @Help("Translation from the resolved origin, in the yaw-rotated local frame.")
+    override val offset: Var<Vector> = RegionDefaults.OFFSET,
+    @Help("Rotation around the vertical axis, applied to the whole polygon.")
+    override val yaw: Var<Float> = RegionDefaults.YAW,
+    @Help("Rotation around the horizontal axis. Usually 0 for prisms.")
+    override val pitch: Var<Float> = RegionDefaults.PITCH,
+    @Help("Rotation around the facing axis. Lets the region tilt in any vertical plane.")
+    override val roll: Var<Float> = RegionDefaults.ROLL,
+    @Help("Add the origin position's own yaw and pitch to the region's rotation.")
+    override val rotateWithOrigin: Boolean = RegionDefaults.ROTATE_WITH_ORIGIN,
+    @Help(RegionDefaults.COLOR_HELP)
+    @WithAlpha
+    @Default(RegionDefaults.COLOR_DEFAULT)
+    override val color: Color = RegionDefaults.COLOR,
+    @Help("Which region wins where two overlap. Higher wins. Defaults to the page's priority.")
+    override val priorityOverride: Optional<Int> = Optional.empty(),
+    @Help("The rules this region carries: what may and may not happen inside it.")
+    override val modifiers: List<Ref<out RegionModifierEntry>> = emptyList(),
+    @Help("Polygon outline points relative to the origin; only X and Z are used. Needs at least 3.")
+    val points: List<Vector> = emptyList(),
+    @Min(0)
+    @Help("Half the prism's height in blocks; the prism spans origin Y ± this value.")
+    @Default("2.0")
+    val halfHeight: Double = 2.0,
+    @Min(1)
+    @Help("How often a region that follows a variable re-checks where it is. Higher values cost less and lag further behind.")
+    @Default("1")
+    override val refreshRateTicks: Int = RegionDefaults.REFRESH_RATE_TICKS,
+) : RegionDefinitionEntry {
+    override fun buildShape(): Shape = PolygonShape(points, halfHeight)
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/definition/SphereRegionDefinitionEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/definition/SphereRegionDefinitionEntry.kt
@@ -1,0 +1,63 @@
+package com.typewritermc.region.entries.definition
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.extension.annotations.*
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.utils.Color
+import com.typewritermc.region.content.SphereRegionContentMode
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionDefinitionEntry
+import com.typewritermc.region.entries.modifier.RegionModifierEntry
+import com.typewritermc.region.shape.Shape
+import com.typewritermc.region.shape.SphereShape
+import java.util.Optional
+
+@Entry("sphere_region_definition", "A spherical region anchored to a position", Colors.PURPLE, "mdi:sphere")
+/**
+ * Defines a spherical region: a ball of radius [radius] centered on the world resolved
+ * [origin] (plus yaw rotated [offset]).
+ *
+ * ## How could this be used?
+ *
+ * Anchor [origin] to a fixed position for a static merchant zone, or to an NPC location
+ * variable to make a no trespass sphere that follows the NPC.
+ */
+class SphereRegionDefinitionEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("World position the region is anchored to. The editor captures the center and a boundary point.")
+    @ContentEditor(SphereRegionContentMode::class)
+    override val origin: Var<Position> = RegionDefaults.ORIGIN,
+    @Help("Translation from the resolved origin, in the yaw-rotated local frame.")
+    override val offset: Var<Vector> = RegionDefaults.OFFSET,
+    @Help("Rotation around the vertical axis. Spheres are rotationally symmetric so this only matters for the offset.")
+    override val yaw: Var<Float> = RegionDefaults.YAW,
+    @Help("Rotation around the horizontal axis. Spheres are rotationally symmetric.")
+    override val pitch: Var<Float> = RegionDefaults.PITCH,
+    @Help("Rotation around the facing axis. Spheres are rotationally symmetric, and the offset is placed by yaw alone, so this changes nothing here.")
+    override val roll: Var<Float> = RegionDefaults.ROLL,
+    @Help("Add the origin position's own yaw and pitch to the region's rotation.")
+    override val rotateWithOrigin: Boolean = RegionDefaults.ROTATE_WITH_ORIGIN,
+    @Help(RegionDefaults.COLOR_HELP)
+    @WithAlpha
+    @Default(RegionDefaults.COLOR_DEFAULT)
+    override val color: Color = RegionDefaults.COLOR,
+    @Help("Which region wins where two overlap. Higher wins. Defaults to the page's priority.")
+    override val priorityOverride: Optional<Int> = Optional.empty(),
+    @Help("The rules this region carries: what may and may not happen inside it.")
+    override val modifiers: List<Ref<out RegionModifierEntry>> = emptyList(),
+    @Min(0)
+    @Help("Sphere radius in blocks.")
+    @Default("5.0")
+    val radius: Double = 5.0,
+    @Min(1)
+    @Help("How often a region that follows a variable re-checks where it is. Higher values cost less and lag further behind.")
+    @Default("1")
+    override val refreshRateTicks: Int = RegionDefaults.REFRESH_RATE_TICKS,
+) : RegionDefinitionEntry {
+    override fun buildShape(): Shape = SphereShape(radius)
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/display/BoundaryRenderArea.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/display/BoundaryRenderArea.kt
@@ -1,0 +1,67 @@
+package com.typewritermc.region.entries.display
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.AlgebraicTypeInfo
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import org.bukkit.entity.Player
+
+/**
+ * How much of the boundary a display renders.
+ *
+ * [FullBoundary] renders every boundary sample. [NearBoundary] renders only the samples
+ * within its radius of the player, a spherical window that follows them.
+ */
+sealed interface BoundaryRenderArea {
+    /**
+     * The window to filter samples with for [player], or `null` when the display renders
+     * the full boundary.
+     */
+    fun window(player: Player): NearWindow?
+}
+
+@AlgebraicTypeInfo("full_boundary", Colors.GREEN, "mdi:globe-model")
+class FullBoundary : BoundaryRenderArea {
+    override fun window(player: Player): NearWindow? = null
+
+    override fun equals(other: Any?): Boolean = other is FullBoundary
+    override fun hashCode(): Int = javaClass.hashCode()
+}
+
+@AlgebraicTypeInfo("near_boundary", Colors.GREEN, "mdi:map-marker-radius")
+data class NearBoundary(
+    @Default("6.0")
+    val radius: Var<Double> = ConstVar(6.0),
+) : BoundaryRenderArea {
+    override fun window(player: Player): NearWindow {
+        val location = player.location
+        return NearWindow(
+            location.blockX,
+            location.blockY,
+            location.blockZ,
+            radius.get(player).coerceAtLeast(0.0),
+        )
+    }
+}
+
+/**
+ * The near mode window, anchored to the block the player stands in. Anchoring to the block
+ * instead of the exact position keeps the window stable while the player moves within one
+ * block, so cached displays only recompute on block crossings.
+ */
+data class NearWindow(
+    val anchorX: Int,
+    val anchorY: Int,
+    val anchorZ: Int,
+    val radius: Double,
+) {
+    private val radiusSquared: Double = radius * radius
+
+    fun contains(x: Double, y: Double, z: Double): Boolean {
+        val dx = x - (anchorX + 0.5)
+        val dy = y - (anchorY + 0.5)
+        val dz = z - (anchorZ + 0.5)
+        return dx * dx + dy * dy + dz * dz <= radiusSquared
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/display/GroundLineAnimation.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/display/GroundLineAnimation.kt
@@ -1,0 +1,64 @@
+package com.typewritermc.region.entries.display
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.AlgebraicTypeInfo
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import org.bukkit.entity.Player
+import java.time.Duration
+
+/**
+ * How the ground line flows around the region.
+ *
+ * A flowing line is drawn from the same points as a still one; it is the points that march along
+ * the loop, at [blocksPerSecond], in the [direction] the case picked.
+ */
+sealed interface GroundLineAnimation {
+    fun blocksPerSecond(player: Player): Double
+
+    /** `1` to flow along the path's point order, `-1` to flow against it. */
+    fun direction(path: GroundLinePath): Int
+}
+
+@AlgebraicTypeInfo("static", Colors.GREEN, "mdi:minus")
+class StaticGroundLine : GroundLineAnimation {
+    override fun blocksPerSecond(player: Player): Double = 0.0
+    override fun direction(path: GroundLinePath): Int = 1
+
+    override fun equals(other: Any?): Boolean = other is StaticGroundLine
+    override fun hashCode(): Int = javaClass.hashCode()
+}
+
+@AlgebraicTypeInfo("clockwise", Colors.GREEN, "mdi:rotate-right")
+data class ClockwiseGroundLine(
+    @Help("How fast the line flows, in blocks per second.")
+    @Default("2.0")
+    val speed: Var<Double> = ConstVar(2.0),
+) : GroundLineAnimation {
+    override fun blocksPerSecond(player: Player): Double = speed.get(player)
+    override fun direction(path: GroundLinePath): Int = path.clockwiseDirection
+}
+
+@AlgebraicTypeInfo("counter_clockwise", Colors.GREEN, "mdi:rotate-left")
+data class CounterClockwiseGroundLine(
+    @Help("How fast the line flows, in blocks per second.")
+    @Default("2.0")
+    val speed: Var<Double> = ConstVar(2.0),
+) : GroundLineAnimation {
+    override fun blocksPerSecond(player: Player): Double = speed.get(player)
+    override fun direction(path: GroundLinePath): Int = -path.clockwiseDirection
+}
+
+/** How far along the loop the line has flowed after [elapsed], signed by the flow direction. */
+internal fun groundLinePhase(
+    animation: GroundLineAnimation,
+    path: GroundLinePath,
+    player: Player,
+    elapsed: Duration,
+): Double {
+    val speed = animation.blocksPerSecond(player)
+    if (speed == 0.0) return 0.0
+    return animation.direction(path) * speed * (elapsed.toMillis() / 1000.0)
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/display/GroundLineFacing.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/display/GroundLineFacing.kt
@@ -1,0 +1,56 @@
+package com.typewritermc.region.entries.display
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.AlgebraicTypeInfo
+import com.typewritermc.core.utils.point.Vector
+import kotlin.math.atan2
+
+/**
+ * Which way the entities on a ground line look.
+ *
+ * Independent of the animation, except that "along the line" means the way the entities are
+ * actually travelling, so it turns around with a counter clockwise flow.
+ */
+sealed interface GroundLineFacing {
+    /** [travelDirection] is `1` along the path's point order and `-1` against it. */
+    fun yaw(point: PathPoint, travelDirection: Int): Float
+}
+
+@AlgebraicTypeInfo("outward", Colors.GREEN, "mdi:arrow-expand-horizontal")
+class FaceOutward : GroundLineFacing {
+    override fun yaw(point: PathPoint, travelDirection: Int): Float = yawOf(point.outward)
+
+    override fun equals(other: Any?): Boolean = other is FaceOutward
+    override fun hashCode(): Int = javaClass.hashCode()
+}
+
+@AlgebraicTypeInfo("inward", Colors.GREEN, "mdi:arrow-collapse-horizontal")
+class FaceInward : GroundLineFacing {
+    override fun yaw(point: PathPoint, travelDirection: Int): Float = yawOf(point.outward * -1.0)
+
+    override fun equals(other: Any?): Boolean = other is FaceInward
+    override fun hashCode(): Int = javaClass.hashCode()
+}
+
+@AlgebraicTypeInfo("along_line", Colors.GREEN, "mdi:arrow-right")
+class FaceAlongLine : GroundLineFacing {
+    override fun yaw(point: PathPoint, travelDirection: Int): Float =
+        yawOf(point.tangent * travelDirection.toDouble())
+
+    override fun equals(other: Any?): Boolean = other is FaceAlongLine
+    override fun hashCode(): Int = javaClass.hashCode()
+}
+
+@AlgebraicTypeInfo("against_line", Colors.GREEN, "mdi:arrow-left")
+class FaceAgainstLine : GroundLineFacing {
+    override fun yaw(point: PathPoint, travelDirection: Int): Float =
+        yawOf(point.tangent * -travelDirection.toDouble())
+
+    override fun equals(other: Any?): Boolean = other is FaceAgainstLine
+    override fun hashCode(): Int = javaClass.hashCode()
+}
+
+private fun yawOf(direction: Vector): Float {
+    if (direction == Vector.ZERO) return 0f
+    return Math.toDegrees(atan2(-direction.x, direction.z)).toFloat()
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/display/GroundLinePath.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/display/GroundLinePath.kt
@@ -1,0 +1,125 @@
+package com.typewritermc.region.entries.display
+
+import com.typewritermc.core.utils.point.Vector
+import kotlin.math.hypot
+
+internal const val ANIMATION_PATH_STEP = 1.0
+
+/** Where the outline is walkable by arc length, and never bridged across a hole. */
+private const val HOLE_THRESHOLD = 2.0
+
+/** A vertex of the ground line: where it is, which way is out, and which way the loop runs. */
+data class PathPoint(val position: Vector, val outward: Vector, val tangent: Vector)
+
+/**
+ * The ground outline as a closed loop that can be walked by arc length: a point every
+ * [ANIMATION_PATH_STEP] blocks, cumulative distances, and the direction the loop winds. An
+ * animated line needs all three.
+ *
+ * Stretches longer than [HOLE_THRESHOLD] are holes, where the line left the terrain or ran into
+ * an unloaded chunk. [pointAt] returns `null` inside one, so no point is placed across a gap.
+ *
+ * The type is public so [GroundLineAnimation] and [GroundLineFacing], which are public for the
+ * web panel, can take it in their signatures; the constructor stays module internal, built only
+ * by [GroundOutlineCache].
+ */
+class GroundLinePath internal constructor(points: List<GroundOutlinePoint>) {
+    val vertices: List<PathPoint> = buildVertices(points)
+    private val arcs: DoubleArray = DoubleArray(vertices.size)
+    private val holes: BooleanArray = BooleanArray(vertices.size)
+    val totalArc: Double
+
+    /** The distance along the loop at which vertex [index] sits. */
+    fun arcOf(index: Int): Double = arcs[index]
+
+    /** `1` when walking the vertices in order runs clockwise seen from above, `-1` otherwise. */
+    val clockwiseDirection: Int = windingOf(vertices)
+
+    init {
+        var arc = 0.0
+        for (index in vertices.indices) {
+            arcs[index] = arc
+            val next = vertices[(index + 1) % vertices.size].position
+            val length = horizontalDistance(vertices[index].position, next)
+            holes[index] = length > HOLE_THRESHOLD
+            arc += length
+        }
+        totalArc = arc
+    }
+
+    /**
+     * The point [arc] blocks along the loop from its first vertex, or `null` when that lands
+     * strictly inside a hole. A hole only blocks its interior; the vertex that starts it is
+     * still a real point. Negative and overlong distances wrap.
+     */
+    fun pointAt(arc: Double): PathPoint? {
+        if (vertices.size < 2 || totalArc < 1e-6) return vertices.firstOrNull()
+        val target = arc.mod(totalArc)
+
+        // Binary search, not a scan: every entity on the line looks its position up every tick.
+        val found = arcs.binarySearch(target)
+        val index = if (found >= 0) found else (-found - 2).coerceAtLeast(0)
+
+        val start = vertices[index]
+        val end = vertices[(index + 1) % vertices.size]
+        val segment = horizontalDistance(start.position, end.position)
+        if (segment < 1e-9) return start
+        val fraction = ((target - arcs[index]) / segment).coerceIn(0.0, 1.0)
+        if (fraction <= 0.0) return start
+        if (holes[index]) return null
+
+        return PathPoint(
+            position = start.position + (end.position - start.position) * fraction,
+            outward = lerpDirection(start.outward, end.outward, fraction),
+            tangent = lerpDirection(start.tangent, end.tangent, fraction),
+        )
+    }
+}
+
+private fun buildVertices(points: List<GroundOutlinePoint>): List<PathPoint> {
+    if (points.isEmpty()) return emptyList()
+    if (points.size == 1) return listOf(PathPoint(points[0].position, points[0].outward, Vector.ZERO))
+    if (points.size == 2) return buildTwoPointVertices(points)
+
+    return points.mapIndexed { index, point ->
+        val previous = points[(index + points.size - 1) % points.size].position
+        val next = points[(index + 1) % points.size].position
+        val tangent = Vector(next.x - previous.x, 0.0, next.z - previous.z).normalize()
+        PathPoint(point.position, point.outward, tangent)
+    }
+}
+
+/** With only two points the loop doubles back on itself, so both vertices share one tangent. */
+private fun buildTwoPointVertices(points: List<GroundOutlinePoint>): List<PathPoint> {
+    val (first, second) = points
+    val tangent = Vector(second.position.x - first.position.x, 0.0, second.position.z - first.position.z).normalize()
+    return listOf(
+        PathPoint(first.position, first.outward, tangent),
+        PathPoint(second.position, second.outward, tangent),
+    )
+}
+
+/**
+ * The winding of the loop from the sign of its shoelace sum over the XZ plane. Seen from above,
+ * with X running east and Z running south, a positive sum walks clockwise.
+ */
+private fun windingOf(vertices: List<PathPoint>): Int {
+    if (vertices.size < 3) return 1
+    var sum = 0.0
+    for (index in vertices.indices) {
+        val current = vertices[index].position
+        val next = vertices[(index + 1) % vertices.size].position
+        sum += current.x * next.z - next.x * current.z
+    }
+    return if (sum >= 0.0) 1 else -1
+}
+
+private fun lerpDirection(from: Vector, to: Vector, fraction: Double): Vector {
+    if (from == Vector.ZERO) return to
+    if (to == Vector.ZERO) return from
+    val lerped = from + (to - from) * fraction
+    if (lerped.length < 1e-9) return from
+    return lerped.normalize()
+}
+
+private fun horizontalDistance(from: Vector, to: Vector): Double = hypot(to.x - from.x, to.z - from.z)

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/display/GroundLinePattern.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/display/GroundLinePattern.kt
@@ -1,0 +1,41 @@
+package com.typewritermc.region.entries.display
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.AlgebraicTypeInfo
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import org.bukkit.entity.Player
+
+/** Which stretches of the ground line emit particles. */
+sealed interface GroundLinePattern {
+    /** Whether the point [arc] blocks along the line emits. */
+    fun emitsAt(arc: Double, player: Player): Boolean
+}
+
+@AlgebraicTypeInfo("solid", Colors.GREEN, "mdi:minus")
+class SolidLine : GroundLinePattern {
+    override fun emitsAt(arc: Double, player: Player): Boolean = true
+
+    override fun equals(other: Any?): Boolean = other is SolidLine
+    override fun hashCode(): Int = javaClass.hashCode()
+}
+
+@AlgebraicTypeInfo("dashed", Colors.GREEN, "mdi:dots-horizontal")
+data class DashedLine(
+    @Help("How long a lit stretch is, in blocks.")
+    @Default("4.0")
+    val dash: Var<Double> = ConstVar(4.0),
+    @Help("How long the dark stretch between two dashes is, in blocks.")
+    @Default("3.0")
+    val gap: Var<Double> = ConstVar(3.0),
+) : GroundLinePattern {
+    override fun emitsAt(arc: Double, player: Player): Boolean {
+        val lit = dash.get(player).coerceAtLeast(0.0)
+        val dark = gap.get(player).coerceAtLeast(0.0)
+        val period = lit + dark
+        if (period < 1e-6) return true
+        return arc.mod(period) < lit
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/display/GroundOutline.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/display/GroundOutline.kt
@@ -1,0 +1,777 @@
+package com.typewritermc.region.entries.display
+
+import com.google.common.collect.Sets
+import com.typewritermc.core.utils.launch
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.engine.paper.utils.Sync
+import com.typewritermc.region.data.ResolvedTransform
+import com.typewritermc.region.entries.display.GroundOutlineCache.Companion.TERRAIN_REFRESH
+import com.typewritermc.region.shape.Shape
+import com.typewritermc.region.tracker.RegionTracker
+import kotlinx.coroutines.Dispatchers
+import org.bukkit.World
+import java.time.Duration
+import java.time.Instant
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.math.*
+
+/**
+ * A point on the line where a region meets the ground. [outward] points horizontally away
+ * from the region's footprint, or [Vector.ZERO] when the direction is ambiguous. [corner]
+ * marks a point where the outline turns sharply; resampling keeps corners exactly in
+ * place.
+ */
+internal data class GroundOutlinePoint(val position: Vector, val outward: Vector, val corner: Boolean = false)
+
+/**
+ * Caches one ground outline sampling. Terrain has no change signal the displays can
+ * subscribe to, so a sampling stays valid for [TERRAIN_REFRESH] and is redone when the
+ * region's resolved transform changes.
+ *
+ * The sampling reads blocks, which is only safe on the server thread, while the displays
+ * that ask for it tick off it. So a stale cache does not resample in place: it schedules the
+ * work on the main thread and keeps handing out the previous sampling until that lands. The
+ * ground line is therefore up to one refresh behind a terrain change, and never reads a chunk
+ * section while the server is writing to it.
+ */
+/**
+ * Points from one sampling, with the stamp identifying it. Callers keeping derived state ask
+ * whether the stamp changed rather than whether the points differ.
+ */
+internal class StampedPoints(val stamp: Instant, val points: List<GroundOutlinePoint>)
+
+internal class GroundOutlineCache {
+    @Volatile
+    private var sampling: Sampling = Sampling.NONE
+    private val spacings: MutableSet<Double> = Sets.newConcurrentHashSet()
+    private val refreshing = AtomicBoolean(false)
+
+    fun pointsFor(shape: Shape, transform: ResolvedTransform, world: World, now: Instant): List<GroundOutlinePoint> {
+        val current = sampling
+        if (current.isStale(transform, world, now)) refresh(shape, transform, world, now)
+        return current.points
+    }
+
+    /**
+     * The outline distributed evenly, one point per [spacing] blocks, memoized per sampling and
+     * per spacing so callers resampling the same cache at different spacings never thrash a
+     * shared memo.
+     */
+    fun resampledFor(
+        shape: Shape,
+        transform: ResolvedTransform,
+        world: World,
+        now: Instant,
+        spacing: Double,
+    ): StampedPoints {
+        val current = samplingWith(shape, transform, world, now, spacing)
+        // Falls back to the sampling's own resolution rather than nothing: an empty list would
+        // blank the line for the tick or two before the refresh lands.
+        return StampedPoints(current.computedAt, current.resampled[spacing] ?: current.points)
+    }
+
+    /**
+     * The sampling to serve [spacing] from, scheduling a refresh when it is stale or when this
+     * spacing is one the current sampling was not resampled for.
+     *
+     * Every caller takes its points and its stamp from the one sampling this returns. Reading the
+     * stamp separately lets a refresh land in between, which stamps the old points as current and
+     * keeps them on screen until the sampling after that.
+     */
+    private fun samplingWith(
+        shape: Shape,
+        transform: ResolvedTransform,
+        world: World,
+        now: Instant,
+        spacing: Double,
+    ): Sampling {
+        // A spacing bound to a variable can differ per player and change as they move, so the
+        // set is bounded rather than left to grow with every value it has ever seen. One entry
+        // goes, not all of them, and never the one being asked for: emptying the set, or evicting
+        // the caller's own spacing, makes the next call miss and schedule another refresh, so the
+        // cache thrashes exactly when it is under load.
+        if (spacing !in spacings) {
+            while (spacings.size >= MAX_SPACINGS) {
+                spacings.remove(spacings.firstOrNull { it != spacing } ?: break)
+            }
+        }
+        val fresh = spacings.add(spacing)
+
+        val current = sampling
+        if (fresh || current.isStale(transform, world, now)) refresh(shape, transform, world, now)
+        return current
+    }
+
+    private fun refresh(shape: Shape, transform: ResolvedTransform, world: World, now: Instant) {
+        if (!refreshing.compareAndSet(false, true)) return
+        Dispatchers.Sync.launch {
+            try {
+                val points = sampleGroundOutline(shape, transform, world)
+                sampling = Sampling(
+                    transformHash = transform.hashCode(),
+                    worldId = world.uid,
+                    computedAt = now,
+                    points = points,
+                    resampled = spacings.associateWith { resampleBySpacing(points, it, shape, transform, world) },
+                )
+            } finally {
+                refreshing.set(false)
+            }
+        }
+    }
+
+    private class Sampling(
+        private val transformHash: Int?,
+        private val worldId: UUID?,
+        val computedAt: Instant,
+        val points: List<GroundOutlinePoint>,
+        val resampled: Map<Double, List<GroundOutlinePoint>>,
+    ) {
+        fun isStale(transform: ResolvedTransform, world: World, now: Instant): Boolean =
+            transformHash != transform.hashCode() ||
+                    worldId != world.uid ||
+                    Duration.between(computedAt, now) >= TERRAIN_REFRESH
+
+        companion object {
+            val NONE = Sampling(null, null, Instant.EPOCH, emptyList(), emptyMap())
+        }
+    }
+
+    // One field rather than a path and a stamp side by side: a display's tick is not pinned to one
+    // thread, and two fields can be read as a pair that never existed.
+    @Volatile
+    private var cachedPath: StampedPath? = null
+
+    /** The outline as a walkable loop, at animation resolution, memoized per sampling. */
+    fun pathFor(shape: Shape, transform: ResolvedTransform, world: World, now: Instant): GroundLinePath {
+        val current = samplingWith(shape, transform, world, now, ANIMATION_PATH_STEP)
+        val cached = cachedPath
+        if (cached != null && cached.stamp == current.computedAt) return cached.path
+
+        val points = current.resampled[ANIMATION_PATH_STEP] ?: current.points
+        return GroundLinePath(points).also { cachedPath = StampedPath(current.computedAt, it) }
+    }
+
+    private class StampedPath(val stamp: Instant, val path: GroundLinePath)
+
+    companion object {
+        private val TERRAIN_REFRESH: Duration = Duration.ofSeconds(2)
+
+        /** How many distinct spacings one cache keeps resampled at a time. */
+        private const val MAX_SPACINGS = 8
+    }
+}
+
+/**
+ * One [GroundOutlineCache] per sampling identity: every viewer of a statically placed
+ * region shares one tracker and therefore one cache, so many players cost one terrain
+ * sampling instead of one each. A viewer dependent region resolves per player and keeps a
+ * cache per viewer. The boundary displays tick their players sequentially, so the shared
+ * cache is never touched from two threads at once.
+ */
+internal class GroundCachePool {
+    private val shared = GroundOutlineCache()
+    private val perViewer = ConcurrentHashMap<UUID, GroundOutlineCache>()
+
+    fun cacheFor(tracker: RegionTracker, playerId: UUID): GroundOutlineCache =
+        if (tracker.viewer == null) shared else perViewer.computeIfAbsent(playerId) { GroundOutlineCache() }
+
+    fun forget(playerId: UUID) {
+        perViewer.remove(playerId)
+    }
+
+    fun clear() {
+        perViewer.clear()
+    }
+}
+
+/**
+ * Samples the outline of the region's footprint on the ground: for every block column
+ * under the region, the lowest walkable surface (solid block with a non solid block above)
+ * inside the region's vertical span is located and the column is classified by whether the
+ * region contains the point just above that surface. The outline is every inside column
+ * that borders an outside one. A region floating in the air, or one with no surface below
+ * it in its span, produces no points.
+ *
+ * Outline points near the footprint silhouette are then projected onto it with the shape's
+ * horizontal signed distance, so the line follows the true boundary instead of the block
+ * centers, and silhouette corners falling between two block columns (a rotated cuboid's
+ * tip) get an explicit point where the two edges meet. Points deep inside the footprint,
+ * where the line follows a terrain break like a cliff, keep their block column.
+ *
+ * Points come back ordered by angle around the anchor with sharp turns marked as corners,
+ * so [resampleBySpacing] can distribute them evenly, and consecutive samplings of
+ * unchanged terrain produce an identical list.
+ *
+ * Reads blocks, so it runs on the main thread, scheduled by [GroundOutlineCache]. Unloaded
+ * chunks are skipped and never counted as outside.
+ */
+internal fun sampleGroundOutline(
+    shape: Shape,
+    transform: ResolvedTransform,
+    world: World,
+    terrain: GroundTerrain = SnapshotTerrain(world),
+): List<GroundOutlinePoint> {
+    val bounds = shape.localBounds.rotated(transform.yawDegrees, transform.pitchDegrees, transform.rollDegrees)
+    val anchor = transform.worldOrigin
+    val minX = floor(anchor.x + bounds.minX).toInt()
+    val maxX = floor(anchor.x + bounds.maxX).toInt()
+    val minZ = floor(anchor.z + bounds.minZ).toInt()
+    val maxZ = floor(anchor.z + bounds.maxZ).toInt()
+    if (maxX < minX || maxZ < minZ) return emptyList()
+
+    val span = scanSpan(shape, transform, world) ?: return emptyList()
+    val scanTop = span.top
+    val scanBottom = span.bottom
+
+    val stride = strideFor((maxX - minX + 1).toLong() * (maxZ - minZ + 1))
+    val columns = HashMap<Long, ColumnSample>()
+    var x = minX
+    while (x <= maxX) {
+        var z = minZ
+        while (z <= maxZ) {
+            sampleColumn(shape, transform, terrain, x, z, scanTop, scanBottom)?.let { columns[packColumn(x, z)] = it }
+            z += stride
+        }
+        x += stride
+    }
+
+    val points = mutableListOf<GroundOutlinePoint>()
+    for ((key, column) in columns) {
+        if (!column.inside) continue
+        val columnX = unpackColumnX(key)
+        val columnZ = unpackColumnZ(key)
+
+        var outwardX = 0.0
+        var outwardZ = 0.0
+        var boundary = false
+        for ((dx, dz) in NEIGHBOR_STEPS) {
+            val nx = columnX + dx * stride
+            val nz = columnZ + dz * stride
+            val neighbor = if (nx in minX..maxX && nz in minZ..maxZ) {
+                columns[packColumn(nx, nz)] ?: continue
+            } else {
+                OUTSIDE_FOOTPRINT
+            }
+            if (neighbor.inside) continue
+            boundary = true
+            outwardX += dx
+            outwardZ += dz
+        }
+        if (!boundary) continue
+
+        val outwardLength = sqrt(outwardX * outwardX + outwardZ * outwardZ)
+        val outward =
+            if (outwardLength > 1e-9) Vector(outwardX / outwardLength, 0.0, outwardZ / outwardLength) else Vector.ZERO
+        points += GroundOutlinePoint(
+            Vector(columnX + 0.5, column.surfaceY + SURFACE_LIFT, columnZ + 0.5),
+            outward,
+        )
+    }
+
+    val refined = points.map { refineOntoSilhouette(it, shape, transform, terrain, scanTop, scanBottom) }
+        .sortedBy { atan2(it.point.position.z - anchor.z, it.point.position.x - anchor.x) }
+    return markCornerApexes(insertSilhouetteCorners(refined, shape, transform, terrain, scanTop, scanBottom))
+}
+
+/**
+ * Distributes points evenly along the outline loop, [spacing] blocks apart. Corner points
+ * stay exactly where they are and every stretch between them is divided into equal arc
+ * steps, so a box gets a point on each corner and identical gaps along each edge, and a
+ * cornerless loop becomes one uniform ring whose closing seam is spaced like everywhere
+ * else. Gaps wider than [RESAMPLE_BREAK] mark holes in the line, like unloaded chunks or
+ * the footprint leaving the terrain, and are never bridged with fabricated points.
+ *
+ * Every generated point is pulled onto the silhouette (chords sag inward on curved
+ * footprints) and draped onto the walkable surface; a point whose column has no valid
+ * surface is dropped.
+ */
+internal fun resampleBySpacing(
+    points: List<GroundOutlinePoint>,
+    spacing: Double,
+    shape: Shape,
+    transform: ResolvedTransform,
+    world: World,
+    terrain: GroundTerrain = SnapshotTerrain(world),
+): List<GroundOutlinePoint> {
+    if (points.size < 2) return points
+    val step = spacing.coerceAtLeast(MIN_RESAMPLE_SPACING)
+    val span = scanSpan(shape, transform, world) ?: return points
+
+    val breaks = BooleanArray(points.size) { index ->
+        horizontalDistanceSquared(points[index].position, points[(index + 1) % points.size].position) >
+                RESAMPLE_BREAK * RESAMPLE_BREAK
+    }
+
+    val result = mutableListOf<GroundOutlinePoint>()
+    fun emitRun(run: List<GroundOutlinePoint>, endsAtBreak: Boolean) {
+        result += run.first()
+        if (run.size < 2) return
+        val lengths = DoubleArray(run.size - 1) {
+            sqrt(horizontalDistanceSquared(run[it].position, run[it + 1].position))
+        }
+        val total = lengths.sum()
+        if (total > 1e-6) {
+            val count = (total / step).roundToInt().coerceAtLeast(1)
+            for (notch in 1 until count) {
+                pointAtArcDistance(run, lengths, notch * total / count, shape, transform, terrain, span)
+                    ?.let { result += it }
+            }
+        }
+        if (endsAtBreak) result += run.last()
+    }
+
+    val start = points.indices.firstOrNull { index ->
+        points[index].corner || breaks[(index + points.size - 1) % points.size]
+    }
+    if (start == null) {
+        // No corners and no holes: one closed ring, resampled seamlessly across the wrap.
+        val run = points + points.first()
+        val lengths = DoubleArray(run.size - 1) {
+            sqrt(horizontalDistanceSquared(run[it].position, run[it + 1].position))
+        }
+        val total = lengths.sum()
+        if (total < 1e-6) return listOf(points.first())
+        val count = (total / step).roundToInt().coerceAtLeast(1)
+        return (0 until count).mapNotNull { notch ->
+            pointAtArcDistance(run, lengths, notch * total / count, shape, transform, terrain, span)
+        }
+    }
+
+    var run = mutableListOf(points[start])
+    for (offset in 1..points.size) {
+        val index = (start + offset) % points.size
+        val closesLoop = offset == points.size
+        if (breaks[(start + offset - 1) % points.size]) {
+            emitRun(run, endsAtBreak = true)
+            if (closesLoop) break
+            run = mutableListOf(points[index])
+            continue
+        }
+        run.add(points[index])
+        if (closesLoop) {
+            // The loop closed back onto the starting vertex, which the first run emitted.
+            emitRun(run, endsAtBreak = false)
+            break
+        }
+        if (points[index].corner) {
+            emitRun(run, endsAtBreak = false)
+            run = mutableListOf(points[index])
+        }
+    }
+    return result
+}
+
+/** The vertical block range a sampling scans for walkable surfaces. */
+private class ScanSpan(val top: Int, val bottom: Int)
+
+private fun scanSpan(shape: Shape, transform: ResolvedTransform, world: World): ScanSpan? {
+    val bounds = shape.localBounds.rotated(transform.yawDegrees, transform.pitchDegrees, transform.rollDegrees)
+    val anchor = transform.worldOrigin
+    val top = min(floor(anchor.y + bounds.maxY).toInt(), world.maxHeight - 1)
+    val bottom = max(floor(anchor.y + bounds.minY).toInt() - 1, world.minHeight)
+    if (top < bottom) return null
+    return ScanSpan(top, bottom)
+}
+
+/** The point [distance] blocks along [run]'s polyline, draped and pulled onto the silhouette. */
+private fun pointAtArcDistance(
+    run: List<GroundOutlinePoint>,
+    lengths: DoubleArray,
+    distance: Double,
+    shape: Shape,
+    transform: ResolvedTransform,
+    terrain: GroundTerrain,
+    span: ScanSpan,
+): GroundOutlinePoint? {
+    var remaining = distance
+    var index = 0
+    while (index < lengths.size - 1 && remaining > lengths[index]) {
+        remaining -= lengths[index]
+        index++
+    }
+    val segment = lengths[index]
+    val fraction = if (segment < 1e-9) 0.0 else (remaining / segment).coerceIn(0.0, 1.0)
+    return interpolatedPoint(run[index], run[index + 1], fraction, shape, transform, terrain, span)
+}
+
+private fun interpolatedPoint(
+    a: GroundOutlinePoint,
+    b: GroundOutlinePoint,
+    fraction: Double,
+    shape: Shape,
+    transform: ResolvedTransform,
+    terrain: GroundTerrain,
+    span: ScanSpan,
+): GroundOutlinePoint? {
+    val chordX = a.position.x + (b.position.x - a.position.x) * fraction
+    val chordZ = a.position.z + (b.position.z - a.position.z) * fraction
+    val y = a.position.y + (b.position.y - a.position.y) * fraction
+    val chordOutward = lerpOutward(a.outward, b.outward, fraction)
+
+    var x = chordX
+    var z = chordZ
+    var outward = chordOutward
+    val local = transform.toLocal(Vector(chordX, y, chordZ))
+    if (shape.signedDistanceHorizontal(local) > -DEEP_INSIDE) {
+        projectToSilhouette(local, shape)?.let { projection ->
+            val target = transform.toWorld(projection.local)
+            val movedX = target.x - chordX
+            val movedZ = target.z - chordZ
+            if (movedX * movedX + movedZ * movedZ <= MAX_CHORD_CORRECTION * MAX_CHORD_CORRECTION) {
+                x = target.x
+                z = target.z
+                worldOutward(transform, projection.outwardLocal)?.let { outward = it }
+            }
+        }
+    }
+
+    resampledSurfaceY(shape, transform, terrain, x, z, span)?.let { surface ->
+        return GroundOutlinePoint(Vector(x, surface + SURFACE_LIFT, z), outward)
+    }
+    if (x == chordX && z == chordZ) return null
+    val surface = resampledSurfaceY(shape, transform, terrain, chordX, chordZ, span) ?: return null
+    return GroundOutlinePoint(Vector(chordX, surface + SURFACE_LIFT, chordZ), chordOutward)
+}
+
+/**
+ * The walkable surface under a resampled point. Like [drapedSurfaceY], but a point whose
+ * own spot the region does not reach still counts when its block column's center is
+ * inside: refined silhouette points overhang their column the same way when the widest
+ * slice sits above the ground, and the generated points must not be stricter than the
+ * samples they interpolate.
+ */
+private fun resampledSurfaceY(
+    shape: Shape,
+    transform: ResolvedTransform,
+    terrain: GroundTerrain,
+    x: Double,
+    z: Double,
+    span: ScanSpan,
+): Double? {
+    val columnX = floor(x).toInt()
+    val columnZ = floor(z).toInt()
+    if (!terrain.isColumnLoaded(columnX, columnZ)) return null
+    val surface = groundSurfaceY(terrain, columnX, columnZ, span.top, span.bottom) ?: return null
+    if (shape.contains(transform.toLocal(Vector(x, surface + PROBE_HEIGHT, z)))) return surface
+    if (shape.contains(transform.toLocal(Vector(columnX + 0.5, surface + PROBE_HEIGHT, columnZ + 0.5)))) return surface
+    return null
+}
+
+private fun lerpOutward(a: Vector, b: Vector, fraction: Double): Vector {
+    if (a == Vector.ZERO) return b
+    if (b == Vector.ZERO) return a
+    val x = a.x + (b.x - a.x) * fraction
+    val z = a.z + (b.z - a.z) * fraction
+    val length = sqrt(x * x + z * z)
+    if (length < 1e-9) return a
+    return Vector(x / length, 0.0, z / length)
+}
+
+/**
+ * Marks points where the outline's outward direction bends sharply on both sides, like the
+ * corner column of an unrotated box or of a cliff cut. Corners recovered between columns
+ * arrive already marked by [cornerBetween].
+ */
+private fun markCornerApexes(points: List<GroundOutlinePoint>): List<GroundOutlinePoint> {
+    if (points.size < 3) return points
+    return points.mapIndexed { index, point ->
+        if (point.corner || point.outward == Vector.ZERO) return@mapIndexed point
+        val previous = points[(index + points.size - 1) % points.size].outward
+        val next = points[(index + 1) % points.size].outward
+        if (previous == Vector.ZERO || next == Vector.ZERO) return@mapIndexed point
+        val bendsBefore = previous.x * point.outward.x + previous.z * point.outward.z <= CORNER_APEX_COSINE
+        val bendsAfter = next.x * point.outward.x + next.z * point.outward.z <= CORNER_APEX_COSINE
+        if (bendsBefore && bendsAfter) point.copy(corner = true) else point
+    }
+}
+
+private data class ColumnSample(val surfaceY: Double, val inside: Boolean)
+
+/** An outline point plus whether it sits on the footprint silhouette or a terrain break. */
+private class OutlineSample(val point: GroundOutlinePoint, val onSilhouette: Boolean)
+
+private class SilhouetteProjection(val local: Vector, val outwardLocal: Vector)
+
+/**
+ * Moves an outline point from its block column center onto the footprint silhouette, kept
+ * [SILHOUETTE_INSET] inside so the point's column stays part of the footprint. Points deep
+ * inside the footprint mark a terrain break, not the silhouette, and stay where they are;
+ * so does any point whose projection cannot be draped back onto valid ground.
+ */
+private fun refineOntoSilhouette(
+    point: GroundOutlinePoint,
+    shape: Shape,
+    transform: ResolvedTransform,
+    terrain: GroundTerrain,
+    scanTop: Int,
+    scanBottom: Int,
+): OutlineSample {
+    val local = transform.toLocal(point.position)
+    if (shape.signedDistanceHorizontal(local) <= -DEEP_INSIDE) return OutlineSample(point, onSilhouette = false)
+
+    val projection = projectToSilhouette(local, shape) ?: return OutlineSample(point, onSilhouette = false)
+    val target = transform.toWorld(projection.local)
+    val movedX = target.x - point.position.x
+    val movedZ = target.z - point.position.z
+    if (movedX * movedX + movedZ * movedZ > MAX_REFINE_DISTANCE * MAX_REFINE_DISTANCE) {
+        return OutlineSample(point, onSilhouette = false)
+    }
+
+    val sameColumn = floor(target.x).toInt() == floor(point.position.x).toInt() &&
+            floor(target.z).toInt() == floor(point.position.z).toInt()
+    val y = if (sameColumn) {
+        point.position.y
+    } else {
+        val surface = drapedSurfaceY(shape, transform, terrain, target.x, target.z, scanTop, scanBottom)
+            ?: return OutlineSample(point, onSilhouette = false)
+        surface + SURFACE_LIFT
+    }
+
+    val outward = worldOutward(transform, projection.outwardLocal) ?: point.outward
+    return OutlineSample(GroundOutlinePoint(Vector(target.x, y, target.z), outward), onSilhouette = true)
+}
+
+/**
+ * Newton projection in the local XZ plane onto the [SILHOUETTE_INSET] level of the shape's
+ * horizontal signed distance, with a numeric gradient. `null` when the gradient vanishes
+ * or the iterations do not converge, like at the exact center of a symmetric shape.
+ */
+private fun projectToSilhouette(local: Vector, shape: Shape): SilhouetteProjection? {
+    var x = local.x
+    var z = local.z
+    var outwardX = 0.0
+    var outwardZ = 0.0
+    repeat(PROJECTION_ITERATIONS) {
+        val distance = shape.signedDistanceHorizontal(Vector(x, local.y, z))
+        // Central differences: a one sided difference reads zero on the inside of a
+        // min of faces distance whenever the step moves away from the nearest face.
+        val gradientX = shape.signedDistanceHorizontal(Vector(x + GRADIENT_EPSILON, local.y, z)) -
+                shape.signedDistanceHorizontal(Vector(x - GRADIENT_EPSILON, local.y, z))
+        val gradientZ = shape.signedDistanceHorizontal(Vector(x, local.y, z + GRADIENT_EPSILON)) -
+                shape.signedDistanceHorizontal(Vector(x, local.y, z - GRADIENT_EPSILON))
+        val length = sqrt(gradientX * gradientX + gradientZ * gradientZ)
+        if (length < 1e-9) return null
+        outwardX = gradientX / length
+        outwardZ = gradientZ / length
+        val step = distance + SILHOUETTE_INSET
+        x -= outwardX * step
+        z -= outwardZ * step
+    }
+    if (abs(
+            shape.signedDistanceHorizontal(
+                Vector(
+                    x,
+                    local.y,
+                    z
+                )
+            ) + SILHOUETTE_INSET
+        ) > PROJECTION_TOLERANCE
+    ) return null
+    return SilhouetteProjection(Vector(x, local.y, z), Vector(outwardX, 0.0, outwardZ))
+}
+
+/**
+ * Where the outward direction bends sharply between two neighboring silhouette points, the
+ * silhouette turns a corner between them whose own block column sampled as outside, like
+ * the tip of a rotated cuboid. The corner is recovered as the intersection of the two edge
+ * lines and draped onto the terrain, so every corner of the footprint gets a point. When a
+ * sample already sits on the recovered corner, that sample is marked as the corner instead
+ * of inserting a duplicate next to it.
+ */
+private fun insertSilhouetteCorners(
+    samples: List<OutlineSample>,
+    shape: Shape,
+    transform: ResolvedTransform,
+    terrain: GroundTerrain,
+    scanTop: Int,
+    scanBottom: Int,
+): List<GroundOutlinePoint> {
+    if (samples.size < 2) return samples.map { it.point }
+
+    val result = mutableListOf<GroundOutlinePoint>()
+    var flagNext = false
+    for (index in samples.indices) {
+        var point = samples[index].point
+        if (flagNext) {
+            point = point.copy(corner = true)
+            flagNext = false
+        }
+        val next = samples[(index + 1) % samples.size]
+        val corner = cornerBetween(samples[index], next, shape, transform, terrain, scanTop, scanBottom)
+        when {
+            corner == null -> result += point
+
+            horizontalDistanceSquared(corner.position, point.position) <
+                    MIN_CORNER_SEPARATION * MIN_CORNER_SEPARATION -> result += point.copy(corner = true)
+
+            horizontalDistanceSquared(corner.position, next.point.position) <
+                    MIN_CORNER_SEPARATION * MIN_CORNER_SEPARATION -> {
+                result += point
+                flagNext = true
+            }
+
+            else -> {
+                result += point
+                result += corner
+            }
+        }
+    }
+    if (flagNext) result[0] = result[0].copy(corner = true)
+    return result
+}
+
+private fun cornerBetween(
+    first: OutlineSample,
+    second: OutlineSample,
+    shape: Shape,
+    transform: ResolvedTransform,
+    terrain: GroundTerrain,
+    scanTop: Int,
+    scanBottom: Int,
+): GroundOutlinePoint? {
+    if (!first.onSilhouette || !second.onSilhouette) return null
+    val a = first.point
+    val b = second.point
+    if (horizontalDistanceSquared(a.position, b.position) > CORNER_GAP_MAX * CORNER_GAP_MAX) return null
+
+    val n1 = a.outward
+    val n2 = b.outward
+    if (n1 == Vector.ZERO || n2 == Vector.ZERO) return null
+    if (n1.x * n2.x + n1.z * n2.z > CORNER_BEND_COSINE) return null
+
+    // The edge through each point is the line x·n = p·n; the corner is where the two meet.
+    val determinant = n1.x * n2.z - n1.z * n2.x
+    if (abs(determinant) < 1e-6) return null
+    val c1 = n1.x * a.position.x + n1.z * a.position.z
+    val c2 = n2.x * b.position.x + n2.z * b.position.z
+    val cornerX = (c1 * n2.z - c2 * n1.z) / determinant
+    val cornerZ = (n1.x * c2 - n2.x * c1) / determinant
+
+    val corner = Vector(cornerX, a.position.y, cornerZ)
+    val fromFirst = horizontalDistanceSquared(corner, a.position)
+    val fromSecond = horizontalDistanceSquared(corner, b.position)
+    if (fromFirst > CORNER_GAP_MAX * CORNER_GAP_MAX || fromSecond > CORNER_GAP_MAX * CORNER_GAP_MAX) return null
+
+    val local = transform.toLocal(corner)
+    if (abs(shape.signedDistanceHorizontal(local) + SILHOUETTE_INSET) > PROJECTION_TOLERANCE) return null
+
+    val surface = drapedSurfaceY(shape, transform, terrain, cornerX, cornerZ, scanTop, scanBottom) ?: return null
+    val outward = averageOutward(n1, n2) ?: return null
+    return GroundOutlinePoint(Vector(cornerX, surface + SURFACE_LIFT, cornerZ), outward, corner = true)
+}
+
+/**
+ * The walkable surface under the exact position, checked to actually lie inside the
+ * region. `null` for unloaded chunks, columns without a surface in the scan span, and
+ * surfaces the region does not reach.
+ */
+private fun drapedSurfaceY(
+    shape: Shape,
+    transform: ResolvedTransform,
+    terrain: GroundTerrain,
+    x: Double,
+    z: Double,
+    scanTop: Int,
+    scanBottom: Int,
+): Double? {
+    val columnX = floor(x).toInt()
+    val columnZ = floor(z).toInt()
+    if (!terrain.isColumnLoaded(columnX, columnZ)) return null
+    val surface = groundSurfaceY(terrain, columnX, columnZ, scanTop, scanBottom) ?: return null
+    if (!shape.contains(transform.toLocal(Vector(x, surface + PROBE_HEIGHT, z)))) return null
+    return surface
+}
+
+private fun worldOutward(transform: ResolvedTransform, outwardLocal: Vector): Vector? {
+    val rotated = transform.rotateLocalToWorld(outwardLocal)
+    val length = sqrt(rotated.x * rotated.x + rotated.z * rotated.z)
+    if (length < 1e-9) return null
+    return Vector(rotated.x / length, 0.0, rotated.z / length)
+}
+
+private fun averageOutward(first: Vector, second: Vector): Vector? {
+    val x = first.x + second.x
+    val z = first.z + second.z
+    val length = sqrt(x * x + z * z)
+    if (length < 1e-9) return null
+    return Vector(x / length, 0.0, z / length)
+}
+
+private fun horizontalDistanceSquared(a: Vector, b: Vector): Double {
+    val dx = a.x - b.x
+    val dz = a.z - b.z
+    return dx * dx + dz * dz
+}
+
+private val OUTSIDE_FOOTPRINT = ColumnSample(0.0, inside = false)
+
+private val NEIGHBOR_STEPS = listOf(1 to 0, -1 to 0, 0 to 1, 0 to -1)
+
+private const val SURFACE_LIFT = 0.05
+private const val PROBE_HEIGHT = 0.1
+private const val MAX_COLUMNS = 4096.0
+private const val DEEP_INSIDE = 1.0
+private const val SILHOUETTE_INSET = 0.05
+private const val PROJECTION_ITERATIONS = 3
+private const val GRADIENT_EPSILON = 0.01
+private const val PROJECTION_TOLERANCE = 0.15
+private const val MAX_REFINE_DISTANCE = 1.5
+private const val CORNER_GAP_MAX = 3.0
+private const val CORNER_BEND_COSINE = 0.87
+private const val MIN_CORNER_SEPARATION = 0.3
+private const val CORNER_APEX_COSINE = 0.9
+private const val RESAMPLE_BREAK = 2.0
+private const val MIN_RESAMPLE_SPACING = 0.5
+private const val MAX_CHORD_CORRECTION = 0.5
+
+private fun strideFor(footprintColumns: Long): Int =
+    max(1.0, ceil(sqrt(footprintColumns / MAX_COLUMNS))).toInt()
+
+private fun sampleColumn(
+    shape: Shape,
+    transform: ResolvedTransform,
+    terrain: GroundTerrain,
+    x: Int,
+    z: Int,
+    scanTop: Int,
+    scanBottom: Int,
+): ColumnSample? {
+    if (!terrain.isColumnLoaded(x, z)) return null
+    val surface = groundSurfaceY(terrain, x, z, scanTop, scanBottom)
+        ?: return ColumnSample(0.0, inside = false)
+    val local = transform.toLocal(Vector(x + 0.5, surface + PROBE_HEIGHT, z + 0.5))
+    return ColumnSample(surface, shape.contains(local))
+}
+
+/**
+ * The top of the lowest solid block with a non solid block above, within the scan span.
+ * The lowest walkable surface is the ground the player actually walks on: anything solid
+ * higher in the region's vertical span, like a tree canopy, an overhang or a roof, sits
+ * above the ground and must not capture the line.
+ */
+private fun groundSurfaceY(terrain: GroundTerrain, x: Int, z: Int, scanTop: Int, scanBottom: Int): Double? {
+    // A region's vertical span is whatever a builder drew, often hundreds of blocks of open air
+    // above the terrain. The heightmap bounds the walk to the ground below it.
+    val highest = terrain.highestBlockY(x, z)
+    if (highest < scanBottom) return null
+    val top = min(scanTop, highest)
+
+    var solid = terrain.isSolid(x, scanBottom, z)
+    for (y in scanBottom until top) {
+        val aboveSolid = terrain.isSolid(x, y + 1, z)
+        if (solid && !aboveSolid) return y + 1.0
+        solid = aboveSolid
+    }
+    val aboveTop = top + 1 <= terrain.maxHeight - 1 && terrain.isSolid(x, top + 1, z)
+    if (solid && !aboveTop) return top + 1.0
+    return null
+}
+
+private fun packColumn(x: Int, z: Int): Long = (x.toLong() shl 32) or (z.toLong() and 0xFFFFFFFFL)
+
+private fun unpackColumnX(key: Long): Int = (key shr 32).toInt()
+
+private fun unpackColumnZ(key: Long): Int = key.toInt()

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/display/GroundTerrain.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/display/GroundTerrain.kt
@@ -1,0 +1,67 @@
+package com.typewritermc.region.entries.display
+
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap
+import org.bukkit.ChunkSnapshot
+import org.bukkit.World
+
+/** The block reads a ground sampling makes. */
+internal interface GroundTerrain {
+    val maxHeight: Int
+
+    fun isColumnLoaded(x: Int, z: Int): Boolean
+
+    fun highestBlockY(x: Int, z: Int): Int
+
+    fun isSolid(x: Int, y: Int, z: Int): Boolean
+}
+
+/**
+ * Reads the terrain from chunk snapshots.
+ *
+ * A column scan reads every block between the region's floor and the terrain, and a tall region
+ * over a wide footprint reads hundreds of thousands of them per refresh. Each read through
+ * [World.getBlockAt] allocates a block handle and looks its chunk up again, while a snapshot is
+ * copied once per chunk and answers from an array.
+ *
+ * It is created and read on the main thread, since the snapshots are taken on first use.
+ */
+internal class SnapshotTerrain(private val world: World) : GroundTerrain {
+    private val snapshots = Long2ObjectOpenHashMap<ChunkSnapshot?>()
+
+    override val maxHeight: Int get() = world.maxHeight
+
+    override fun isColumnLoaded(x: Int, z: Int): Boolean = snapshot(x shr 4, z shr 4) != null
+
+    override fun highestBlockY(x: Int, z: Int): Int = world.getHighestBlockYAt(x, z)
+
+    override fun isSolid(x: Int, y: Int, z: Int): Boolean =
+        snapshot(x shr 4, z shr 4)?.getBlockType(x and 15, y, z and 15)?.isSolid ?: false
+
+    private fun snapshot(chunkX: Int, chunkZ: Int): ChunkSnapshot? {
+        val key = (chunkX.toLong() shl 32) or (chunkZ.toLong() and 0xFFFFFFFFL)
+        if (snapshots.containsKey(key)) return snapshots.get(key)
+        val snapshot = if (world.isChunkLoaded(chunkX, chunkZ)) {
+            world.getChunkAt(chunkX, chunkZ).getChunkSnapshot(false, false, false)
+        } else {
+            null
+        }
+        snapshots.put(key, snapshot)
+        return snapshot
+    }
+}
+
+/**
+ * Reads the terrain block by block from the world.
+ *
+ * The specs use it: MockBukkit's chunk snapshot stores blocks under world coordinates and looks
+ * them up under chunk local ones, so it answers air for every block.
+ */
+internal class WorldTerrain(private val world: World) : GroundTerrain {
+    override val maxHeight: Int get() = world.maxHeight
+
+    override fun isColumnLoaded(x: Int, z: Int): Boolean = world.isChunkLoaded(x shr 4, z shr 4)
+
+    override fun highestBlockY(x: Int, z: Int): Int = world.getHighestBlockYAt(x, z)
+
+    override fun isSolid(x: Int, y: Int, z: Int): Boolean = world.getBlockAt(x, y, z).type.isSolid
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/display/RegionBoundaryDisplay.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/display/RegionBoundaryDisplay.kt
@@ -1,0 +1,93 @@
+package com.typewritermc.region.entries.display
+
+import com.typewritermc.engine.paper.entry.entries.AudienceDisplay
+import com.typewritermc.engine.paper.entry.entries.TickableDisplay
+import com.typewritermc.region.RegionEngine
+import com.typewritermc.region.content.RegionEditRegistry
+import com.typewritermc.region.data.RegionData
+import com.typewritermc.region.data.ResolvedTransform
+import com.typewritermc.region.handler.LazyInsideQueryHandler
+import com.typewritermc.region.tracker.RegionTracker
+import org.bukkit.entity.Player
+import org.koin.java.KoinJavaComponent
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Shared base for the region boundary [AudienceDisplay]s. Each audience player holds an
+ * observation on the region's tracker, so [tick] reads the tracker's cached transform
+ * instead of resolving again variables per player per tick. The engine keeps the cached
+ * transform fresh for dynamic regions.
+ *
+ * While a player edits the region in a content mode, the display is suppressed for them
+ * and its artifacts are cleaned up, so the editor's preview is the only boundary they see.
+ * Rendering resumes when the editor closes.
+ *
+ * Subclasses clean up their per player artifacts in [onDisplayPlayerRemoved].
+ */
+abstract class RegionBoundaryDisplay(
+    protected val region: RegionData,
+    private val area: BoundaryRenderArea,
+    private val entryId: String?,
+) : AudienceDisplay(), TickableDisplay {
+    protected val engine: RegionEngine by KoinJavaComponent.inject(RegionEngine::class.java)
+    private val editRegistry: RegionEditRegistry by KoinJavaComponent.inject(RegionEditRegistry::class.java)
+    private val subscriptions = ConcurrentHashMap<UUID, RegionEngine.Subscription>()
+
+    final override fun onPlayerAdd(player: Player) {
+        engine.observe(region, player, LazyInsideQueryHandler(this, player.uniqueId))
+            ?.also { subscriptions[player.uniqueId] = it }
+    }
+
+    final override fun onPlayerRemove(player: Player) {
+        subscriptions.remove(player.uniqueId)?.cancel()
+        onDisplayPlayerRemoved(player)
+    }
+
+    /**
+     * Called after the player's region observation is cancelled, so subclasses can restore
+     * fake blocks or dispose fake entities. Must be idempotent; suppression during content
+     * mode editing calls it every tick.
+     */
+    protected open fun onDisplayPlayerRemoved(player: Player) {}
+
+    final override fun tick() {
+        for (player in players) {
+            if (editRegistry.isSuppressed(player.uniqueId, entryId, region)) {
+                onDisplayPlayerRemoved(player)
+                continue
+            }
+            val tracker = subscriptions[player.uniqueId]?.tracker ?: continue
+            val transform = tracker.lastTransform ?: continue
+            // Every artifact these displays send carries raw coordinates and no world, so a
+            // viewer in another world would be shown the boundary at the same coordinates
+            // where they stand. Their artifacts are cleaned up rather than left behind,
+            // because the restore paths refuse to touch a player who is elsewhere.
+            if (transform.world.identifier != player.world.uid.toString()) {
+                onDisplayPlayerRemoved(player)
+                continue
+            }
+            renderForPlayer(player, tracker, transform)
+        }
+    }
+
+    /**
+     * The window to filter samples with, or `null` when the display renders the full
+     * boundary.
+     */
+    protected fun nearWindow(player: Player): NearWindow? = area.window(player)
+
+    override fun dispose() {
+        subscriptions.values.forEach(RegionEngine.Subscription::cancel)
+        subscriptions.clear()
+        super.dispose()
+    }
+
+    /**
+     * Render the boundary for [player]. Implementations may call
+     * `tracker.shape.sampleBoundary(density)` to obtain local frame samples and map them
+     * through [transform] to world space, or sample the world directly like the ground
+     * outline displays.
+     */
+    protected abstract fun renderForPlayer(player: Player, tracker: RegionTracker, transform: ResolvedTransform)
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/display/RegionBoundaryEntityDisplayEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/display/RegionBoundaryEntityDisplayEntry.kt
@@ -1,0 +1,237 @@
+package com.typewritermc.region.entries.display
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.entries.emptyRef
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.engine.paper.entry.entity.*
+import com.typewritermc.engine.paper.entry.entries.*
+import com.typewritermc.region.data.RegionData
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionReferenceData
+import com.typewritermc.region.data.ResolvedTransform
+import com.typewritermc.region.shape.Shape
+import com.typewritermc.region.shape.averageUnitDirection
+import com.typewritermc.region.tracker.RegionTracker
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.math.asin
+import kotlin.math.atan2
+import org.bukkit.entity.Player
+
+@Entry("region_boundary_entity", "Renders a region's boundary as fake entities", Colors.GREEN, "mdi:account-multiple")
+/**
+ * Spawns one [FakeEntity], built from the configured [entityDefinition], at every sampled
+ * point on the region's boundary, per audience player. The definition's data (skin,
+ * equipment, pose) is applied and kept up to date, and each entity faces along the
+ * boundary's outward normal at its point, looking away from the region.
+ *
+ * The default density is much lower than for particle or fake block displays because each
+ * sample is a network tracked fake entity, and the spawn rate is the dominant cost. The
+ * default 0.05 puts fifteen entities on a 5 block sphere.
+ *
+ * The display caches the entities per player and diffs them against the samples visible in
+ * the window. Each entity's position is fed through its property collector pipeline at top
+ * priority, so a static boundary costs only the initial spawn and a moving boundary sends
+ * only the packets the position diff requires.
+ *
+ * ## How could this be used?
+ *
+ * Visualize a safe zone with floating marker NPCs along the boundary, or hint at a hidden
+ * trigger by sprinkling crystal entities along its perimeter.
+ */
+class RegionBoundaryEntityDisplayEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("The region whose boundary to populate with entities.")
+    @Default(RegionDefaults.REGION_REFERENCE)
+    val region: RegionData = RegionReferenceData(),
+    @Help("Samples per unit boundary area. Entity displays cost more than particles, so keep this low. Zero is not off: every boundary gets at least eight samples.")
+    @Default("0.05")
+    val density: Var<Double> = ConstVar(0.05),
+    @Help("The entity definition to spawn at each boundary sample.")
+    val entityDefinition: Ref<EntityDefinitionEntry> = emptyRef(),
+    @Help("Render the full boundary, or only a window near the player.")
+    val area: BoundaryRenderArea = FullBoundary(),
+) : AudienceEntry {
+    override suspend fun display(): AudienceDisplay =
+        RegionBoundaryEntityDisplay(region, density, area, id, entityDefinition)
+}
+
+class RegionBoundaryEntityDisplay(
+    region: RegionData,
+    private val density: Var<Double>,
+    area: BoundaryRenderArea,
+    entryId: String?,
+    private val entityDefinition: Ref<EntityDefinitionEntry>,
+) : RegionBoundaryDisplay(region, area, entryId) {
+    private val boundaries = ConcurrentHashMap<UUID, PlayerBoundary>()
+
+    @Volatile
+    private var disposed = false
+
+    override fun onDisplayPlayerRemoved(player: Player) {
+        boundaries.remove(player.uniqueId)?.disposeEntities()
+    }
+
+    override fun renderForPlayer(player: Player, tracker: RegionTracker, transform: ResolvedTransform) {
+        val definition = entityDefinition.get() ?: return
+        // compute so a render in flight during teardown cannot install a boundary the sweep
+        // has already walked past. Its entities would be fakes nobody owns and nobody can
+        // despawn, since the display is out of the audience manager by then.
+        val state = boundaries.compute(player.uniqueId) { _, previous ->
+            if (disposed) return@compute null
+            if (previous != null && previous.definition === definition) return@compute previous
+            previous?.disposeEntities()
+            PlayerBoundary(definition)
+        } ?: return
+
+        val density = density.get(player)
+        if (state.density != density) {
+            state.localSamples = localSamples(tracker.shape, density)
+            state.density = density
+            state.transformHash = null
+        }
+        val transformHash = transform.hashCode()
+        if (state.transformHash != transformHash) {
+            state.samples = state.localSamples.map { it.toWorld(transform) }
+            state.transformHash = transformHash
+        }
+
+        state.window = nearWindow(player)
+        reconcile(player, state)
+
+        for (entity in state.entities.values) {
+            entity.consumeProperties(entity.collectors.mapNotNull { it.collect(player) })
+            entity.entity.tick()
+        }
+    }
+
+    /**
+     * Diffs the entities against the samples visible in the window, keyed by sample index.
+     * Removed samples dispose their entity and new samples spawn one. Position updates for
+     * surviving samples flow through each entity's collector pipeline, which diffs
+     * internally and sends nothing when the sample did not move.
+     */
+    private fun reconcile(player: Player, state: PlayerBoundary) {
+        val window = state.window
+        val samples = state.samples
+        val active = IntOpenHashSet()
+        for (index in samples.indices) {
+            val position = samples[index].position
+            if (window == null || window.contains(position.x, position.y, position.z)) active.add(index)
+        }
+
+        val iterator = state.entities.entries.iterator()
+        while (iterator.hasNext()) {
+            val entry = iterator.next()
+            if (entry.key in active) continue
+            entry.value.entity.dispose()
+            iterator.remove()
+        }
+
+        val activeIterator = active.intIterator()
+        while (activeIterator.hasNext()) {
+            val index = activeIterator.nextInt()
+            if (state.entities.containsKey(index)) continue
+            val entity = state.definition.create(player)
+            entity.spawn(samples[index].positionProperty())
+            if (!state.track(index, BoundEntity(entity, state.collectorsFor(index)))) entity.dispose()
+        }
+    }
+
+    /**
+     * The boundary samples in the region's own frame, each with its outward normal. Sampling the
+     * shape is the expensive half of placing the entities and depends on the density alone, so a
+     * region that moves every tick only pays for turning these into world positions.
+     */
+    private fun localSamples(shape: Shape, density: Double): List<LocalSample> =
+        shape.sampleBoundary(density).map { local ->
+            LocalSample(local, averageUnitDirection(shape.outwardNormals(local)) ?: Vector(0.0, 0.0, 1.0))
+        }.toList()
+
+    override fun dispose() {
+        disposed = true
+        val iterator = boundaries.entries.iterator()
+        while (iterator.hasNext()) {
+            iterator.next().value.disposeEntities()
+            iterator.remove()
+        }
+        super.dispose()
+    }
+
+    /**
+     * A fake entity together with its collector pipeline: the definition's data plus a
+     * [FakeProvider] that supplies the entity's boundary sample position at top priority.
+     */
+    private class BoundEntity(
+        val entity: FakeEntity,
+        val collectors: List<PropertyCollector<EntityProperty>>,
+    ) {
+        fun consumeProperties(properties: List<EntityProperty>) = entity.consumeProperties(properties)
+    }
+
+    /**
+     * One player's ring of fake entities.
+     *
+     * Rendering runs off the main thread while removal from the audience and a reload both
+     * dispose from another, so the map is concurrent and disposal is one way: once swept,
+     * the boundary never accepts another entity. Without that, an entity spawned just after
+     * the sweep survives as a fake nobody owns and nobody can despawn.
+     */
+    private class PlayerBoundary(val definition: EntityDefinitionEntry) {
+        var transformHash: Int? = null
+        var density: Double? = null
+        var localSamples: List<LocalSample> = emptyList()
+        var samples: List<OrientedSample> = emptyList()
+        var window: NearWindow? = null
+        val entities = ConcurrentHashMap<Int, BoundEntity>()
+
+        @Volatile
+        private var disposed = false
+
+        fun collectorsFor(index: Int): List<PropertyCollector<EntityProperty>> {
+            val position = FakeProvider(PositionProperty::class) { samples.getOrNull(index)?.positionProperty() }
+            return (definition.data.withPriority() + (position to Int.MAX_VALUE)).toCollectors()
+        }
+
+        /** `false` when the boundary was already disposed, leaving [entity] to the caller. */
+        fun track(index: Int, entity: BoundEntity): Boolean {
+            var accepted = false
+            entities.compute(index) { _, previous ->
+                previous?.entity?.dispose()
+                if (disposed) return@compute null
+                accepted = true
+                entity
+            }
+            return accepted
+        }
+
+        fun disposeEntities() {
+            disposed = true
+            val iterator = entities.entries.iterator()
+            while (iterator.hasNext()) {
+                iterator.next().value.entity.dispose()
+                iterator.remove()
+            }
+        }
+    }
+
+    private class LocalSample(val local: Vector, val normal: Vector) {
+        fun toWorld(transform: ResolvedTransform): OrientedSample {
+            val direction = transform.rotateLocalToWorld(normal)
+            val yaw = Math.toDegrees(atan2(-direction.x, direction.z)).toFloat()
+            val pitch = Math.toDegrees(asin(-direction.y.coerceIn(-1.0, 1.0))).toFloat()
+            return OrientedSample(transform.toWorldPosition(local), yaw, pitch)
+        }
+    }
+
+    private data class OrientedSample(val position: Position, val yaw: Float, val pitch: Float) {
+        fun positionProperty() = PositionProperty(position.world, position.x, position.y, position.z, yaw, pitch)
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/display/RegionBoundaryFakeBlockDisplayEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/display/RegionBoundaryFakeBlockDisplayEntry.kt
@@ -1,0 +1,342 @@
+package com.typewritermc.region.entries.display
+
+import com.github.retrooper.packetevents.protocol.packettype.PacketType
+import com.github.retrooper.packetevents.protocol.player.DiggingAction
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerBlockPlacement
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerDigging
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerAcknowledgeBlockChanges
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerBlockChange
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.*
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.utils.launch
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.engine.paper.entry.entries.AudienceDisplay
+import com.typewritermc.engine.paper.entry.entries.AudienceEntry
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.extensions.packetevents.sendPacketTo
+import com.typewritermc.engine.paper.interaction.InterceptionBundle
+import com.typewritermc.engine.paper.interaction.interceptPackets
+import com.typewritermc.engine.paper.plugin
+import com.typewritermc.engine.paper.utils.Sync
+import com.typewritermc.engine.paper.utils.server
+import com.typewritermc.engine.paper.utils.toBukkitLocation
+import com.typewritermc.engine.paper.utils.toPacketVector3i
+import com.typewritermc.region.data.RegionData
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionReferenceData
+import com.typewritermc.region.data.ResolvedTransform
+import com.typewritermc.region.tracker.RegionTracker
+import io.github.retrooper.packetevents.util.SpigotConversionUtil
+import io.papermc.paper.event.packet.PlayerChunkLoadEvent
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.Dispatchers
+import org.bukkit.Location
+import org.bukkit.Material
+import org.bukkit.block.data.BlockData
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+
+@Entry(
+    "region_boundary_fake_block",
+    "Renders a region's boundary as client-side fake blocks",
+    Colors.GREEN,
+    "mingcute:cube-3d-fill"
+)
+/**
+ * Sends client side fake block packets at boundary samples. Only audience players see the
+ * wall. Only blocks a player could pass through are replaced: air, liquids, plants and
+ * other non solid blocks. Solid blocks stay visible, so the wall never swallows terrain.
+ *
+ * Clicking a fake block cannot make it disappear: the dig and place packets aimed at one
+ * are intercepted, the client's block prediction is acknowledged, and the block is
+ * sent again, so the wall holds up under punching.
+ *
+ * Packets are cached per player and sent again only when the resolved shape, the material, or
+ * the near window changes; the world is also only sampled at those moments. When the
+ * server sends a chunk again after it left the client's render distance, the wall inside it
+ * is sent again too. When a player leaves the audience, the original blocks are restored
+ * client side.
+ *
+ * ## How could this be used?
+ *
+ * Show a barrier wall to players who have not finished the quest that opens an area, while
+ * everyone else walks through empty air. Pair it with a Region Barrier Audience so the wall
+ * a player sees is the same one that actually holds them back.
+ */
+class RegionBoundaryFakeBlockDisplayEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("The region whose boundary to render.")
+    @Default(RegionDefaults.REGION_REFERENCE)
+    val region: RegionData = RegionReferenceData(),
+    @Help("Samples per unit boundary area. Zero is not off: every boundary gets at least eight samples.")
+    @Default("0.5")
+    val density: Var<Double> = ConstVar(0.5),
+    @MaterialProperties(MaterialProperty.BLOCK)
+    @Help("The block the wall is built from on the player's client.")
+    @Default("\"BARRIER\"")
+    val block: Var<Material> = ConstVar(Material.BARRIER),
+    @Help("Render the full boundary, or only a window near the player.")
+    @Default("""{"case":"near_boundary","value":{"radius":6.0}}""")
+    val area: BoundaryRenderArea = NearBoundary(),
+) : AudienceEntry {
+    override suspend fun display(): AudienceDisplay =
+        RegionBoundaryFakeBlockDisplay(region, density, area, id, block)
+}
+
+private data class CachedBlocks(
+    val transformHash: Int,
+    val window: NearWindow?,
+    val material: Material,
+    val density: Double,
+    val sent: ObjectOpenHashSet<Position>,
+    val sentKeys: LongOpenHashSet,
+    val worldId: String?,
+)
+
+class RegionBoundaryFakeBlockDisplay(
+    region: RegionData,
+    private val density: Var<Double>,
+    area: BoundaryRenderArea,
+    entryId: String?,
+    private val block: Var<Material>,
+) : RegionBoundaryDisplay(region, area, entryId) {
+    private val cached = ConcurrentHashMap<UUID, CachedBlocks>()
+    private val protections = ConcurrentHashMap<UUID, InterceptionBundle>()
+    private val rebuilding = ConcurrentHashMap.newKeySet<UUID>()
+
+    @Volatile
+    private var disposed = false
+
+    override fun onDisplayPlayerRemoved(player: Player) {
+        protections.remove(player.uniqueId)?.cancel()
+        cached.remove(player.uniqueId)?.let { state -> Dispatchers.Sync.launch { restore(player, state) } }
+    }
+
+    /**
+     * Choosing which blocks the wall may replace, and reading the real blocks back to restore
+     * them, are world reads, and this display ticks off the main thread. The rebuild therefore
+     * runs on the main thread, guarded so the next tick does not start a second one on top.
+     */
+    override fun renderForPlayer(player: Player, tracker: RegionTracker, transform: ResolvedTransform) {
+        val transformHash = transform.hashCode()
+        val material = block.get(player)
+        val window = nearWindow(player)
+        val density = density.get(player)
+        val existing = cached[player.uniqueId]
+        if (existing != null &&
+            existing.transformHash == transformHash &&
+            existing.material == material &&
+            existing.window == window &&
+            existing.density == density
+        ) return
+
+        if (disposed) return
+        if (!rebuilding.add(player.uniqueId)) return
+        Dispatchers.Sync.launch {
+            try {
+                // The membership is checked again after the hop: the player can leave the audience, or the whole
+                // display can be torn down, while it is queued. A rebuild landing after that
+                // leaves a wall on their client that nothing restores, since teardown only
+                // walks the blocks it knew about at the time.
+                if (!disposed && player.isOnline && player in this@RegionBoundaryFakeBlockDisplay) {
+                    rebuild(player, tracker, transform, transformHash, material, window, density)
+                }
+            } finally {
+                rebuilding.remove(player.uniqueId)
+            }
+        }
+    }
+
+    /** Samples the world and diffs the sent blocks against the new set. Main thread only. */
+    private fun rebuild(
+        player: Player,
+        tracker: RegionTracker,
+        transform: ResolvedTransform,
+        transformHash: Int,
+        material: Material,
+        window: NearWindow?,
+        density: Double,
+    ) {
+        val existing = cached[player.uniqueId]
+        val desired = ObjectOpenHashSet<Position>()
+        val desiredKeys = LongOpenHashSet()
+        for (local in tracker.shape.sampleBoundary(density)) {
+            val pos = transform.toWorldPosition(local).toBlockPosition()
+            if (pos in desired) continue
+            if (window != null && !window.contains(pos.x + 0.5, pos.y + 0.5, pos.z + 0.5)) continue
+            if (!isReplaceable(pos)) continue
+            desired.add(pos)
+            desiredKeys.add(packBlockKey(pos.blockX, pos.blockY, pos.blockZ))
+        }
+
+        val materialChanged = existing == null || existing.material != material
+        val previous: Set<Position> = existing?.sent ?: emptySet()
+        for (pos in desired) {
+            if (materialChanged || pos !in previous) sendBlockChange(player, pos, material)
+        }
+        for (pos in previous) {
+            if (pos !in desired) restoreBlock(player, pos)
+        }
+        cached[player.uniqueId] =
+            CachedBlocks(transformHash, window, material, density, desired, desiredKeys, transform.world.identifier)
+        if (desired.isNotEmpty()) ensureClickProtection(player)
+    }
+
+    /**
+     * The client predicts breaking and placing against the blocks it has been sent, and while
+     * a prediction is pending it buffers server block updates for that position instead of
+     * applying them, until the server acknowledges the action's sequence number. Cancelling
+     * the packet alone would suppress that acknowledgement and the hole would stay, so the
+     * protection acknowledges the sequence itself and then sends the fake block again.
+     */
+    private fun ensureClickProtection(player: Player) {
+        protections.computeIfAbsent(player.uniqueId) { playerId ->
+            player.interceptPackets {
+                PacketType.Play.Client.PLAYER_DIGGING { event ->
+                    val packet = WrapperPlayClientPlayerDigging(event)
+                    if (packet.action !in DIG_ACTIONS) return@PLAYER_DIGGING
+                    val target = packet.blockPosition
+                    val state = fakeBlockState(playerId, player, target.x, target.y, target.z) ?: return@PLAYER_DIGGING
+                    event.isCancelled = true
+                    acknowledgeSequence(player, packet.sequence)
+                    resendFakeBlock(player, target.x, target.y, target.z, state.material)
+                }
+                PacketType.Play.Client.PLAYER_BLOCK_PLACEMENT { event ->
+                    val packet = WrapperPlayClientPlayerBlockPlacement(event)
+                    val target = packet.blockPosition
+                    val state =
+                        fakeBlockState(playerId, player, target.x, target.y, target.z) ?: return@PLAYER_BLOCK_PLACEMENT
+                    event.isCancelled = true
+                    acknowledgeSequence(player, packet.sequence)
+                    resendFakeBlock(player, target.x, target.y, target.z, state.material)
+                    resyncNeighborhood(playerId, player, target.x, target.y, target.z, state.material)
+                }
+            }
+        }
+    }
+
+    private fun acknowledgeSequence(player: Player, sequence: Int) {
+        if (sequence == 0) return
+        WrapperPlayServerAcknowledgeBlockChanges(sequence).sendPacketTo(player)
+    }
+
+    /**
+     * A chunk leaving the client's render distance drops its fake blocks with it; when the
+     * server sends the chunk again, the wall inside it is sent again on top. Fired off the main
+     * thread by Paper, which is fine: this only reads the cache and sends packets.
+     */
+    @EventHandler
+    private fun onChunkLoad(event: PlayerChunkLoadEvent) {
+        val state = cached[event.player.uniqueId] ?: return
+        if (state.worldId != event.world.uid.toString()) return
+        val chunkX = event.chunk.x
+        val chunkZ = event.chunk.z
+        for (pos in state.sent) {
+            if (pos.blockX shr 4 != chunkX || pos.blockZ shr 4 != chunkZ) continue
+            resendFakeBlock(event.player, pos.blockX, pos.blockY, pos.blockZ, state.material)
+        }
+    }
+
+    private fun fakeBlockState(playerId: UUID, player: Player, x: Int, y: Int, z: Int): CachedBlocks? {
+        val state = cached[playerId] ?: return null
+        if (state.worldId != player.world.uid.toString()) return null
+        if (packBlockKey(x, y, z) !in state.sentKeys) return null
+        return state
+    }
+
+    private fun resendFakeBlock(player: Player, x: Int, y: Int, z: Int, material: Material) {
+        WrapperPlayServerBlockChange(
+            com.github.retrooper.packetevents.util.Vector3i(x, y, z),
+            SpigotConversionUtil.fromBukkitBlockData(material.createBlockData()),
+        ).sendPacketTo(player)
+    }
+
+    /**
+     * A cancelled placement leaves the client's predicted block floating next to the fake
+     * block. The neighbors are sent again with the server truth (or the fake material when the
+     * neighbor is part of the wall) on the main thread, where world state may be read.
+     */
+    private fun resyncNeighborhood(playerId: UUID, player: Player, x: Int, y: Int, z: Int, material: Material) {
+        server.scheduler.runTask(plugin) { ->
+            val state = cached[playerId] ?: return@runTask
+            for ((dx, dy, dz) in NEIGHBOR_OFFSETS) {
+                val nx = x + dx
+                val ny = y + dy
+                val nz = z + dz
+                if (packBlockKey(nx, ny, nz) in state.sentKeys) {
+                    resendFakeBlock(player, nx, ny, nz, material)
+                    continue
+                }
+                val location = Location(player.world, nx.toDouble(), ny.toDouble(), nz.toDouble())
+                if (!location.isChunkLoaded) continue
+                player.sendBlockChange(location, location.block.blockData)
+            }
+        }
+    }
+
+    private fun isReplaceable(pos: Position): Boolean {
+        val location = pos.toBukkitLocation()
+        return location.isChunkLoaded && !location.block.type.isSolid
+    }
+
+    private fun restore(player: Player, cached: CachedBlocks) {
+        // A player who left the region's world already lost the wall with the chunks it stood
+        // in, and every block change below carries coordinates without a world: sending them
+        // now would paint the region's blocks into the world the player moved to.
+        if (cached.worldId != player.world.uid.toString()) return
+        for (pos in cached.sent) restoreBlock(player, pos)
+    }
+
+    private fun restoreBlock(player: Player, pos: Position) {
+        val location = pos.toBukkitLocation()
+        if (!location.isChunkLoaded) return
+        sendBlockData(player, pos, location.block.blockData)
+    }
+
+    private fun sendBlockChange(player: Player, pos: Position, material: Material) =
+        sendBlockData(player, pos, material.createBlockData())
+
+    private fun sendBlockData(player: Player, pos: Position, data: BlockData) {
+        WrapperPlayServerBlockChange(
+            pos.toPacketVector3i(),
+            SpigotConversionUtil.fromBukkitBlockData(data),
+        ).sendPacketTo(player)
+    }
+
+    override fun dispose() {
+        disposed = true
+        protections.values.forEach(InterceptionBundle::cancel)
+        protections.clear()
+        val pending = players.mapNotNull { p -> cached.remove(p.uniqueId)?.let { p to it } }
+        if (pending.isNotEmpty()) {
+            Dispatchers.Sync.launch { for ((p, state) in pending) restore(p, state) }
+        }
+        super.dispose()
+    }
+
+    companion object {
+        private val DIG_ACTIONS = setOf(
+            DiggingAction.START_DIGGING,
+            DiggingAction.CANCELLED_DIGGING,
+            DiggingAction.FINISHED_DIGGING,
+        )
+        private val NEIGHBOR_OFFSETS = listOf(
+            Triple(1, 0, 0), Triple(-1, 0, 0),
+            Triple(0, 1, 0), Triple(0, -1, 0),
+            Triple(0, 0, 1), Triple(0, 0, -1),
+        )
+    }
+}
+
+private fun Position.toBlockPosition(): Position {
+    return Position(world, blockX.toDouble(), blockY.toDouble(), blockZ.toDouble(), 0f, 0f)
+}
+
+private fun packBlockKey(x: Int, y: Int, z: Int): Long =
+    (x.toLong() and 0x3FFFFFF shl 38) or (z.toLong() and 0x3FFFFFF shl 12) or (y.toLong() and 0xFFF)

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/display/RegionBoundaryGroundEntityDisplayEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/display/RegionBoundaryGroundEntityDisplayEntry.kt
@@ -1,0 +1,283 @@
+package com.typewritermc.region.entries.display
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.entries.emptyRef
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.engine.paper.entry.entity.*
+import com.typewritermc.engine.paper.entry.entries.*
+import com.typewritermc.region.content.resolveBukkitWorld
+import com.typewritermc.region.data.RegionData
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionReferenceData
+import com.typewritermc.region.data.ResolvedTransform
+import com.typewritermc.region.shape.Shape
+import com.typewritermc.region.tracker.RegionTracker
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet
+import java.time.Duration
+import java.time.Instant
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.math.roundToInt
+import org.bukkit.World
+import org.bukkit.entity.Player
+
+@Entry("region_boundary_ground_entity", "Renders where a region meets the ground as fake entities", Colors.GREEN, "mdi:fence")
+/**
+ * Spawns one [FakeEntity], built from the configured [entityDefinition], along the line
+ * where the region intersects the ground: on the walkable surface inside the region's
+ * vertical span, right where the footprint ends. Each entity stands on the terrain and
+ * faces away from the region. A hovering region, or one whose span holds no surface,
+ * spawns nothing.
+ *
+ * Entities are distributed evenly along the line, one per [spacing] blocks with identical
+ * gaps in between, and every corner of the footprint gets its own entity. Keep the spacing
+ * generous, every entity is network tracked. The terrain is resampled every couple of
+ * seconds, and immediately when the region moves.
+ *
+ * With an [animation] the entities walk the line at the configured speed instead of standing
+ * still, and the corner points give way to even gaps, since a moving entity cannot stay on a
+ * corner.
+ *
+ * ## How could this be used?
+ *
+ * Fence off a ritual circle with candle or crystal entities standing on the grass, or line
+ * the border of a contested zone with banner carriers that follow the hills.
+ */
+class RegionBoundaryGroundEntityDisplayEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("The region whose ground line to populate with entities.")
+    @Default(RegionDefaults.REGION_REFERENCE)
+    val region: RegionData = RegionReferenceData(),
+    @Help("Blocks between entities along the ground line.")
+    @Default("3.0")
+    val spacing: Var<Double> = ConstVar(3.0),
+    @Help("The entity definition to spawn along the ground line.")
+    val entityDefinition: Ref<EntityDefinitionEntry> = emptyRef(),
+    @Help("Whether the entities stand still or flow around the region, and how fast.")
+    @Default("""{"case":"static","value":{}}""")
+    val animation: GroundLineAnimation = StaticGroundLine(),
+    @Help("Which way the entities look.")
+    @Default("""{"case":"outward","value":{}}""")
+    val facing: GroundLineFacing = FaceOutward(),
+    @Help("Render the full ground line, or only a window near the player.")
+    val area: BoundaryRenderArea = FullBoundary(),
+) : AudienceEntry {
+    override suspend fun display(): AudienceDisplay =
+        RegionBoundaryGroundEntityDisplay(region, area, id, spacing, entityDefinition, animation, facing)
+}
+
+class RegionBoundaryGroundEntityDisplay(
+    region: RegionData,
+    area: BoundaryRenderArea,
+    entryId: String?,
+    private val spacing: Var<Double>,
+    private val entityDefinition: Ref<EntityDefinitionEntry>,
+    private val animation: GroundLineAnimation,
+    private val facing: GroundLineFacing,
+) : RegionBoundaryDisplay(region, area, entryId) {
+    private val lines = ConcurrentHashMap<UUID, PlayerGroundLine>()
+    private val caches = GroundCachePool()
+    private val startedAt: Instant = Instant.now()
+
+    @Volatile
+    private var disposed = false
+
+    override fun onDisplayPlayerRemoved(player: Player) {
+        lines.remove(player.uniqueId)?.disposeEntities()
+        caches.forget(player.uniqueId)
+    }
+
+    override fun renderForPlayer(player: Player, tracker: RegionTracker, transform: ResolvedTransform) {
+        val definition = entityDefinition.get() ?: return
+        // compute so a render in flight during teardown cannot install a line the sweep has
+        // already walked past. Its entities would be fakes nobody owns and nobody can
+        // despawn, since the display is out of the audience manager by then.
+        val state = lines.compute(player.uniqueId) { _, previous ->
+            if (disposed) return@compute null
+            if (previous != null && previous.definition === definition) return@compute previous
+            previous?.disposeEntities()
+            PlayerGroundLine(definition)
+        } ?: return
+
+        val world = resolveBukkitWorld(transform.world.identifier)
+        if (world == null || world.uid != player.world.uid) {
+            // The line leaves the map as well as being disposed: disposal is one way, and a line left in the map
+            // would refuse every entity for the rest of the player's membership while still
+            // spawning and destroying one per sample per tick.
+            lines.remove(player.uniqueId)?.disposeEntities()
+            return
+        }
+
+        val now = Instant.now()
+        val cache = caches.cacheFor(tracker, player.uniqueId)
+        val samples = if (animation is StaticGroundLine) {
+            val step = spacing.get(player)
+            val sampled = cache.resampledFor(tracker.shape, transform, world, now, step)
+            // The spacing belongs in the key as much as the sampling does. It is a per player
+            // variable, and the cache hands back the unspaced outline while another player's
+            // sampling is still being built, so a stamp on its own would pin one player to a line
+            // built at somebody else's spacing until the terrain is walked again.
+            if (state.samplesStamp != sampled.stamp || state.samplesSpacing != step) {
+                state.samplesStamp = sampled.stamp
+                state.samplesSpacing = step
+                GroundLinePath(sampled.points).vertices.map { GroundSample(transform, it, facing, 1) }
+            } else {
+                state.samples
+            }
+        } else {
+            animatedSamples(player, cache, tracker.shape, transform, world, now)
+        }
+        state.samples = samples
+
+        reconcile(player, state)
+
+        for (entity in state.entities.values) {
+            entity.consumeProperties(entity.collectors.mapNotNull { it.collect(player) })
+            entity.entity.tick()
+        }
+    }
+
+    /**
+     * The entities spread evenly around the loop by arc length and walked along it. Slots keep
+     * their index as they wrap, so an entity keeps its identity all the way around, and a slot
+     * whose arc falls in a hole in the line has no sample until it walks out of it.
+     */
+    private fun animatedSamples(
+        player: Player,
+        cache: GroundOutlineCache,
+        shape: Shape,
+        transform: ResolvedTransform,
+        world: World,
+        now: Instant,
+    ): List<GroundSample?> {
+        val path = cache.pathFor(shape, transform, world, now)
+        if (path.totalArc < 1e-6) return emptyList()
+
+        val gap = spacing.get(player).coerceAtLeast(MIN_SPACING)
+        val slots = (path.totalArc / gap).roundToInt().coerceAtLeast(1)
+        val phase = groundLinePhase(animation, path, player, Duration.between(startedAt, now))
+        val travel = animation.direction(path)
+
+        return (0 until slots).map { slot ->
+            val arc = slot * path.totalArc / slots + phase
+            path.pointAt(arc)?.let { GroundSample(transform, it, facing, travel) }
+        }
+    }
+
+    /**
+     * Diffs the entities against the samples visible in the window, keyed by sample index.
+     * On the static path the index is ordered by angle around the region, so unchanged
+     * terrain keeps every index at the same spot and resampling sends no packets. On the
+     * animated path the index is a fixed slot on the loop instead, and its position changes
+     * every tick.
+     */
+    private fun reconcile(player: Player, state: PlayerGroundLine) {
+        val window = nearWindow(player)
+        val samples = state.samples
+        val active = IntOpenHashSet()
+        for (index in samples.indices) {
+            val position = samples[index]?.position ?: continue
+            if (window == null || window.contains(position.x, position.y, position.z)) active.add(index)
+        }
+
+        val iterator = state.entities.entries.iterator()
+        while (iterator.hasNext()) {
+            val entry = iterator.next()
+            if (entry.key in active) continue
+            entry.value.entity.dispose()
+            iterator.remove()
+        }
+
+        val activeIterator = active.intIterator()
+        while (activeIterator.hasNext()) {
+            val index = activeIterator.nextInt()
+            if (state.entities.containsKey(index)) continue
+            val sample = samples[index] ?: continue
+            val entity = state.definition.create(player)
+            entity.spawn(sample.positionProperty())
+            if (!state.track(index, BoundEntity(entity, state.collectorsFor(index)))) entity.dispose()
+        }
+    }
+
+    override fun dispose() {
+        disposed = true
+        val iterator = lines.entries.iterator()
+        while (iterator.hasNext()) {
+            iterator.next().value.disposeEntities()
+            iterator.remove()
+        }
+        caches.clear()
+        super.dispose()
+    }
+
+    private class BoundEntity(
+        val entity: FakeEntity,
+        val collectors: List<PropertyCollector<EntityProperty>>,
+    ) {
+        fun consumeProperties(properties: List<EntityProperty>) = entity.consumeProperties(properties)
+    }
+
+    /**
+     * One player's line of fake entities.
+     *
+     * Rendering runs off the main thread while removal from the audience and a reload both
+     * dispose from another, so the map is concurrent and disposal is one way: once swept,
+     * the line never accepts another entity. Without that, an entity spawned just after the
+     * sweep survives as a fake nobody owns and nobody can despawn.
+     */
+    private class PlayerGroundLine(val definition: EntityDefinitionEntry) {
+        var samples: List<GroundSample?> = emptyList()
+        var samplesStamp: Instant = Instant.EPOCH
+        var samplesSpacing: Double? = null
+        val entities = ConcurrentHashMap<Int, BoundEntity>()
+
+        @Volatile
+        private var disposed = false
+
+        fun collectorsFor(index: Int): List<PropertyCollector<EntityProperty>> {
+            val position = FakeProvider(PositionProperty::class) { samples.getOrNull(index)?.positionProperty() }
+            return (definition.data.withPriority() + (position to Int.MAX_VALUE)).toCollectors()
+        }
+
+        /** `false` when the line was already disposed, leaving [entity] to the caller. */
+        fun track(index: Int, entity: BoundEntity): Boolean {
+            var accepted = false
+            entities.compute(index) { _, previous ->
+                previous?.entity?.dispose()
+                if (disposed) return@compute null
+                accepted = true
+                entity
+            }
+            return accepted
+        }
+
+        fun disposeEntities() {
+            disposed = true
+            val iterator = entities.entries.iterator()
+            while (iterator.hasNext()) {
+                iterator.next().value.entity.dispose()
+                iterator.remove()
+            }
+        }
+    }
+
+    private class GroundSample(
+        transform: ResolvedTransform,
+        point: PathPoint,
+        facing: GroundLineFacing,
+        travelDirection: Int,
+    ) {
+        private val world = transform.world
+        val position: Vector = point.position
+        private val yaw: Float = facing.yaw(point, travelDirection)
+
+        fun positionProperty() = PositionProperty(world, position.x, position.y, position.z, yaw, 0f)
+    }
+}
+
+private const val MIN_SPACING = 0.5

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/display/RegionBoundaryGroundParticleDisplayEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/display/RegionBoundaryGroundParticleDisplayEntry.kt
@@ -1,0 +1,150 @@
+package com.typewritermc.region.entries.display
+
+import com.github.retrooper.packetevents.protocol.particle.Particle as PacketParticle
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerParticle
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.engine.paper.entry.entries.AudienceDisplay
+import com.typewritermc.engine.paper.entry.entries.AudienceEntry
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.extensions.packetevents.sendPacketTo
+import com.typewritermc.engine.paper.utils.toPacketVector3d
+import com.typewritermc.engine.paper.utils.toPacketVector3f
+import com.typewritermc.region.content.resolveBukkitWorld
+import com.typewritermc.region.data.RegionData
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionReferenceData
+import com.typewritermc.region.data.ResolvedTransform
+import com.typewritermc.region.tracker.RegionTracker
+import io.github.retrooper.packetevents.util.SpigotConversionUtil
+import java.time.Duration
+import java.time.Instant
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+import org.bukkit.Particle
+import org.bukkit.entity.Player
+
+@Entry(
+    "region_boundary_ground_particle",
+    "Renders where a region meets the ground as particles",
+    Colors.GREEN,
+    "mdi:vector-polyline"
+)
+/**
+ * Emits the configured particle along the line where the region intersects the ground: the
+ * walkable surface inside the region's vertical span, right where the footprint ends. A
+ * hovering region, or one whose span holds no surface, shows nothing.
+ *
+ * Unlike the full boundary displays, this draws only the ring players can actually walk
+ * across, so it marks the border on the terrain itself and follows hills and floors.
+ * Emission points are spread evenly along the line, one per block, with a point on every
+ * corner. The terrain is resampled every couple of seconds, and immediately when the
+ * region moves.
+ *
+ * Particles do not persist between emissions, so a solid line under an [animation] renders
+ * identical to a still one; only a dashed [pattern] makes the flow visible, as its lit
+ * stretches move along the line.
+ *
+ * ## How could this be used?
+ *
+ * Draw the edge of a claim or arena on the ground, or mark how far a quest area stretches
+ * across hilly terrain without filling the air with particles.
+ */
+class RegionBoundaryGroundParticleDisplayEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("The region whose ground line to render.")
+    @Default(RegionDefaults.REGION_REFERENCE)
+    val region: RegionData = RegionReferenceData(),
+    @Help("The particle to draw the ground line with.")
+    @Default("\"ELECTRIC_SPARK\"")
+    val particle: Var<Particle> = ConstVar(Particle.ELECTRIC_SPARK),
+    @Help("Particles emitted per point, per emission.")
+    @Default("1")
+    val count: Var<Int> = ConstVar(1),
+    @Help("Random offset the client applies to each particle.")
+    val offset: Var<Vector> = ConstVar(Vector.ZERO),
+    @Help("Extra particle data. For most particles this is the speed.")
+    val speed: Var<Double> = ConstVar(0.0),
+    @Help("Delay between emissions, per player.")
+    @Default("50")
+    val delay: Var<Duration> = ConstVar(Duration.ofMillis(50)),
+    @Help("Whether the line flows around the region, and how fast. A solid line shows no motion; pick a dashed pattern to see it flow.")
+    @Default("""{"case":"static","value":{}}""")
+    val animation: GroundLineAnimation = StaticGroundLine(),
+    @Help("Whether the line is drawn solid or as marching dashes.")
+    @Default("""{"case":"solid","value":{}}""")
+    val pattern: GroundLinePattern = SolidLine(),
+    @Help("Render the full ground line, or only a window near the player.")
+    val area: BoundaryRenderArea = FullBoundary(),
+) : AudienceEntry {
+    override suspend fun display(): AudienceDisplay =
+        RegionBoundaryGroundParticleDisplay(region, area, id, particle, count, offset, speed, delay, animation, pattern)
+}
+
+class RegionBoundaryGroundParticleDisplay(
+    region: RegionData,
+    area: BoundaryRenderArea,
+    entryId: String?,
+    private val particle: Var<Particle>,
+    private val count: Var<Int>,
+    private val offset: Var<Vector>,
+    private val speed: Var<Double>,
+    private val delay: Var<Duration>,
+    private val animation: GroundLineAnimation,
+    private val pattern: GroundLinePattern,
+) : RegionBoundaryDisplay(region, area, entryId) {
+    private val nextEmissions = ConcurrentHashMap<UUID, Instant>()
+    private val caches = GroundCachePool()
+    private val startedAt: Instant = Instant.now()
+
+    override fun onDisplayPlayerRemoved(player: Player) {
+        nextEmissions.remove(player.uniqueId)
+        caches.forget(player.uniqueId)
+    }
+
+    override fun renderForPlayer(player: Player, tracker: RegionTracker, transform: ResolvedTransform) {
+        val now = Instant.now()
+        val next = nextEmissions[player.uniqueId]
+        if (next != null && now.isBefore(next)) return
+        nextEmissions[player.uniqueId] = now.plus(delay.get(player))
+
+        val world = resolveBukkitWorld(transform.world.identifier) ?: return
+        if (world.uid != player.world.uid) return
+        val path = caches.cacheFor(tracker, player.uniqueId)
+            .pathFor(tracker.shape, transform, world, now)
+        if (path.totalArc < 1e-6) return
+
+        val phase = groundLinePhase(animation, path, player, Duration.between(startedAt, now))
+        val window = nearWindow(player)
+        val packetParticle = PacketParticle(SpigotConversionUtil.fromBukkitParticle(particle.get(player)))
+        val emitCount = count.get(player)
+        val packetOffset = offset.get(player).toPacketVector3f()
+        val extra = speed.get(player).toFloat()
+
+        for ((index, vertex) in path.vertices.withIndex()) {
+            if (!pattern.emitsAt(path.arcOf(index) - phase, player)) continue
+            val position = vertex.position
+            if (window != null && !window.contains(position.x, position.y, position.z)) continue
+            WrapperPlayServerParticle(
+                packetParticle,
+                true,
+                position.toPacketVector3d(),
+                packetOffset,
+                extra,
+                emitCount,
+                true,
+            ) sendPacketTo player
+        }
+    }
+
+    override fun dispose() {
+        nextEmissions.clear()
+        caches.clear()
+        super.dispose()
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/display/RegionBoundaryParticleDisplayEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/display/RegionBoundaryParticleDisplayEntry.kt
@@ -1,0 +1,125 @@
+package com.typewritermc.region.entries.display
+
+import com.github.retrooper.packetevents.protocol.particle.Particle as PacketParticle
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerParticle
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.engine.paper.entry.entries.AudienceDisplay
+import com.typewritermc.engine.paper.entry.entries.AudienceEntry
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.extensions.packetevents.sendPacketTo
+import com.typewritermc.engine.paper.utils.toPacketVector3d
+import com.typewritermc.engine.paper.utils.toPacketVector3f
+import com.typewritermc.region.data.RegionData
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionReferenceData
+import com.typewritermc.region.data.ResolvedTransform
+import com.typewritermc.region.tracker.RegionTracker
+import io.github.retrooper.packetevents.util.SpigotConversionUtil
+import java.time.Duration
+import java.time.Instant
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+import org.bukkit.Particle
+import org.bukkit.entity.Player
+
+@Entry(
+    "region_boundary_particle",
+    "Renders a region's boundary as particles",
+    Colors.GREEN,
+    "fa6-solid:fire-flame-simple"
+)
+/**
+ * Emits the configured particle at samples along the region's boundary, once per [delay],
+ * for each player in the audience. Particles fade on their own, so nothing is cached.
+ *
+ * Wrap this in an [com.typewritermc.region.entries.audience.InRegionAudienceEntry] or a
+ * [com.typewritermc.region.entries.audience.BoundaryProximityAudienceEntry] to show the
+ * boundary only to players inside, outside, or near it.
+ *
+ * ## How could this be used?
+ *
+ * Outline a quest area in soul fire so players can see where it starts, or trace the edge of
+ * a safe zone in sparks that only appears once a player walks close to it.
+ */
+class RegionBoundaryParticleDisplayEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("The region whose boundary to render.")
+    @Default(RegionDefaults.REGION_REFERENCE)
+    val region: RegionData = RegionReferenceData(),
+    @Help("Particles per unit boundary area. Zero is not off: every boundary gets at least eight samples.")
+    @Default("0.5")
+    val density: Var<Double> = ConstVar(0.5),
+    @Help("The particle to draw the boundary with.")
+    @Default("\"ELECTRIC_SPARK\"")
+    val particle: Var<Particle> = ConstVar(Particle.ELECTRIC_SPARK),
+    @Help("Particles emitted per sample, per emission.")
+    @Default("1")
+    val count: Var<Int> = ConstVar(1),
+    @Help("Random offset the client applies to each particle.")
+    val offset: Var<Vector> = ConstVar(Vector.ZERO),
+    @Help("Extra particle data. For most particles this is the speed.")
+    val speed: Var<Double> = ConstVar(0.0),
+    @Help("Delay between emissions, per player.")
+    @Default("50")
+    val delay: Var<Duration> = ConstVar(Duration.ofMillis(50)),
+    @Help("Render the full boundary, or only a window near the player.")
+    val area: BoundaryRenderArea = FullBoundary(),
+) : AudienceEntry {
+    override suspend fun display(): AudienceDisplay =
+        RegionBoundaryParticleDisplay(region, density, area, id, particle, count, offset, speed, delay)
+}
+
+class RegionBoundaryParticleDisplay(
+    region: RegionData,
+    private val density: Var<Double>,
+    area: BoundaryRenderArea,
+    entryId: String?,
+    private val particle: Var<Particle>,
+    private val count: Var<Int>,
+    private val offset: Var<Vector>,
+    private val speed: Var<Double>,
+    private val delay: Var<Duration>,
+) : RegionBoundaryDisplay(region, area, entryId) {
+    private val nextEmissions = ConcurrentHashMap<UUID, Instant>()
+
+    override fun onDisplayPlayerRemoved(player: Player) {
+        nextEmissions.remove(player.uniqueId)
+    }
+
+    override fun renderForPlayer(player: Player, tracker: RegionTracker, transform: ResolvedTransform) {
+        val now = Instant.now()
+        val next = nextEmissions[player.uniqueId]
+        if (next != null && now.isBefore(next)) return
+        nextEmissions[player.uniqueId] = now.plus(delay.get(player))
+
+        val window = nearWindow(player)
+        val packetParticle = PacketParticle(SpigotConversionUtil.fromBukkitParticle(particle.get(player)))
+        val emitCount = count.get(player)
+        val packetOffset = offset.get(player).toPacketVector3f()
+        val extra = speed.get(player).toFloat()
+        for (local in tracker.shape.sampleBoundary(density.get(player))) {
+            val worldPos = transform.toWorld(local)
+            if (window != null && !window.contains(worldPos.x, worldPos.y, worldPos.z)) continue
+            WrapperPlayServerParticle(
+                packetParticle,
+                true,
+                worldPos.toPacketVector3d(),
+                packetOffset,
+                extra,
+                emitCount,
+                true,
+            ) sendPacketTo player
+        }
+    }
+
+    override fun dispose() {
+        nextEmissions.clear()
+        super.dispose()
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/event/RegionEnterEventEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/event/RegionEnterEventEntry.kt
@@ -1,0 +1,42 @@
+package com.typewritermc.region.entries.event
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.engine.paper.entry.TriggerableEntry
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.region.data.CrossingCause
+import com.typewritermc.region.data.RegionData
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionReferenceData
+
+@Entry("region_enter_event", "When a player enters a region", Colors.YELLOW, "mdi:location-enter")
+/**
+ * Fires when a player becomes a member of the configured region. The cause is `Teleported`
+ * when the player teleported across the boundary. When [cancel] evaluates true, the
+ * underlying [org.bukkit.event.player.PlayerMoveEvent] or
+ * [org.bukkit.event.player.PlayerTeleportEvent] is halted. Engulf crossings, where the
+ * region moves into a stationary player, have no event to cancel. The flag does nothing
+ * there, but the other actions still run.
+ *
+ * ## How could this be used?
+ *
+ * Welcome a player into a town with a chat message and a sound. Or block low rank players
+ * from approaching the king by pairing the cancel flag with a criteria gate.
+ */
+class RegionEnterEventEntry(
+    override val id: String = "",
+    override val name: String = "",
+    override val triggers: List<Ref<TriggerableEntry>> = emptyList(),
+    @Help("The region whose entries to observe.")
+    @Default(RegionDefaults.REGION_REFERENCE)
+    override val region: RegionData = RegionReferenceData(),
+    @Help("Restrict to these crossing causes. Empty list means all causes match.")
+    override val causes: List<CrossingCause> = emptyList(),
+    @Help("How far clear of the region a player must move before this can fire again. The enter itself always fires the moment the boundary is crossed.")
+    override val boundaryInset: Var<Double> = ConstVar(0.0),
+    override val cancel: Var<Boolean> = ConstVar(false),
+) : RegionEventEntry

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/event/RegionEventDispatch.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/event/RegionEventDispatch.kt
@@ -1,0 +1,29 @@
+package com.typewritermc.region.entries.event
+
+import com.typewritermc.core.interaction.context
+import com.typewritermc.engine.paper.entry.entries.shouldCancel
+import com.typewritermc.engine.paper.entry.triggerAllFor
+import com.typewritermc.region.data.CrossingCause
+import org.bukkit.entity.Player
+
+/**
+ * Centralizes trigger dispatch for region event entries. Filters by cause, then triggers
+ * the configured pipeline and reports whether the underlying Bukkit event should cancel.
+ */
+internal object RegionEventDispatch {
+    fun fireEnter(entry: RegionEnterEventEntry, player: Player, cause: CrossingCause): Boolean =
+        dispatch(entry, player, cause)
+
+    fun fireExit(entry: RegionExitEventEntry, player: Player, cause: CrossingCause): Boolean =
+        dispatch(entry, player, cause)
+
+    fun fireProximity(entry: RegionProximityEventEntry, player: Player, cause: CrossingCause): Boolean =
+        dispatch(entry, player, cause)
+
+    private fun <E : RegionEventEntry> dispatch(entry: E, player: Player, cause: CrossingCause): Boolean {
+        if (!entry.causes.matches(cause)) return false
+        val list = listOf(entry)
+        list.triggerAllFor(player, context())
+        return list.shouldCancel(player)
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/event/RegionEventEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/event/RegionEventEntry.kt
@@ -1,0 +1,42 @@
+package com.typewritermc.region.entries.event
+
+import com.typewritermc.engine.paper.entry.entries.CancelableEventEntry
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.region.data.CrossingCause
+import com.typewritermc.region.data.RegionData
+
+/**
+ * Base interface for the region event entries. Each carries a [region], a [causes] filter
+ * limiting which crossing kinds fire, and a [boundaryInset] hysteresis.
+ *
+ * Concrete entries also extend [CancelableEventEntry] so users can halt the underlying
+ * Bukkit event when the crossing is player driven.
+ */
+interface RegionEventEntry : CancelableEventEntry {
+    val region: RegionData
+
+    /**
+     * The crossing causes this entry reacts to. An empty list reacts to any cause. To
+     * split behavior across causes, use two entries with different cause filters on the
+     * same region.
+     */
+    val causes: List<CrossingCause>
+
+    /**
+     * Hysteresis distance in blocks. The enter fires the moment the boundary is crossed;
+     * a member must then move more than this distance clear of the region before the
+     * leave fires. This prevents repeat fires from a player walking along the boundary
+     * without ever delaying the enter. A value of `0.0` fires the leave on the exact
+     * boundary.
+     *
+     * The inset belongs to the entry rather than the region, so two entries on the same
+     * region can use different values.
+     */
+    val boundaryInset: Var<Double>
+}
+
+/**
+ * An empty cause list matches any cause.
+ */
+internal fun List<CrossingCause>.matches(cause: CrossingCause): Boolean =
+    isEmpty() || contains(cause)

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/event/RegionExitEventEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/event/RegionExitEventEntry.kt
@@ -1,0 +1,42 @@
+package com.typewritermc.region.entries.event
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.engine.paper.entry.TriggerableEntry
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.region.data.CrossingCause
+import com.typewritermc.region.data.RegionData
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionReferenceData
+
+@Entry("region_exit_event", "When a player exits a region", Colors.YELLOW, "mdi:location-exit")
+/**
+ * Fires when a player stops being a member of the configured region. Cancellation and
+ * teleport semantics are the same as [RegionEnterEventEntry], so a player can also be
+ * blocked from exiting a region.
+ *
+ * Deleting the region, or pointing this entry at another one, does not fire an exit for the
+ * players who were inside it. Their membership simply ends with the old region.
+ *
+ * ## How could this be used?
+ *
+ * Lock players inside the boss arena until the fight ends, using a criteria gated cancel
+ * on this entry.
+ */
+class RegionExitEventEntry(
+    override val id: String = "",
+    override val name: String = "",
+    override val triggers: List<Ref<TriggerableEntry>> = emptyList(),
+    @Help("The region whose exits to observe.")
+    @Default(RegionDefaults.REGION_REFERENCE)
+    override val region: RegionData = RegionReferenceData(),
+    @Help("Restrict to these crossing causes. Empty list means all causes match.")
+    override val causes: List<CrossingCause> = emptyList(),
+    @Help("How far clear of the boundary a player must move before the exit fires. Raise it so someone pacing the edge does not fire it repeatedly.")
+    override val boundaryInset: Var<Double> = ConstVar(0.0),
+    override val cancel: Var<Boolean> = ConstVar(false),
+) : RegionEventEntry

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/event/RegionProximityEventEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/event/RegionProximityEventEntry.kt
@@ -1,0 +1,56 @@
+package com.typewritermc.region.entries.event
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.engine.paper.entry.TriggerableEntry
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.region.data.CrossingCause
+import com.typewritermc.region.data.DistanceMode
+import com.typewritermc.region.data.RegionData
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionReferenceData
+
+@Entry("region_proximity_event", "When a player crosses the proximity band", Colors.YELLOW, "mdi:radar")
+/**
+ * Fires when a player crosses into or out of the band around the configured region's
+ * boundary. It fires once when the player enters the band and once when they leave it.
+ * Filter by [causes] to distinguish moves, teleports, and engulfs.
+ *
+ * Both crossings run the same triggers, and nothing on the entry tells them apart, so what they
+ * do has to make sense in both directions. Use a Region Enter Event on a larger region where
+ * only the approach should count. For the same reason [cancel] holds a player inside the band:
+ * it refuses the crossing whichever way they were going.
+ *
+ * [distance] may be bound to a variable, and the band is then measured against whatever the
+ * variable says at the moment the player is classified. Around a region whose placement is
+ * constant, that moment is a move: a band that shrinks while the player stands still does not
+ * catch them until they take a step. Give the region a variable placement, which puts it on the
+ * refresh loop, to have a band close on a player who is not moving.
+ *
+ * ## How could this be used?
+ *
+ * Play a coronation tune when the player comes within 5 blocks of the king, with a small
+ * sphere around the king and [distance] left at its default.
+ */
+class RegionProximityEventEntry(
+    override val id: String = "",
+    override val name: String = "",
+    override val triggers: List<Ref<TriggerableEntry>> = emptyList(),
+    @Help("The region whose boundary band to observe.")
+    @Default(RegionDefaults.REGION_REFERENCE)
+    override val region: RegionData = RegionReferenceData(),
+    @Help("Width of the proximity band (absolute signed-distance to the boundary).")
+    @Default("3.0")
+    val distance: Var<Double> = ConstVar(3.0),
+    @Help("How the distance is measured. Horizontal ignores the floor and ceiling faces and measures against the region's vertical silhouette.")
+    val distanceMode: DistanceMode = DistanceMode.FULL,
+    @Help("Restrict to these crossing causes. Empty list means all causes match.")
+    override val causes: List<CrossingCause> = emptyList(),
+    @Help("How far a player must move outside the band before the leave fires. Entering the band is never delayed.")
+    override val boundaryInset: Var<Double> = ConstVar(0.0),
+    override val cancel: Var<Boolean> = ConstVar(false),
+) : RegionEventEntry

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/fact/BoundaryDistanceFact.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/fact/BoundaryDistanceFact.kt
@@ -1,0 +1,74 @@
+package com.typewritermc.region.entries.fact
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.entries.emptyRef
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.engine.paper.entry.entries.GroupEntry
+import com.typewritermc.engine.paper.entry.entries.ReadableFactEntry
+import com.typewritermc.engine.paper.facts.FactData
+import com.typewritermc.engine.paper.utils.position
+import com.typewritermc.region.RegionEngine
+import com.typewritermc.region.data.DistanceMode
+import com.typewritermc.region.data.RegionData
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionReferenceData
+import kotlin.math.roundToInt
+import org.bukkit.entity.Player
+import org.koin.java.KoinJavaComponent
+
+@Entry("region_boundary_distance_fact", "Signed distance from a region boundary, in centimeters", Colors.PURPLE, "mdi:ruler")
+/**
+ * The value is the player's signed distance from the region boundary in centimeters, so
+ * the block distance times 100, rounded to an int. The value is negative inside the
+ * region, positive outside, and zero on the boundary. A single fact can therefore drive
+ * both inside effects (negative values) and outside effects (positive values).
+ *
+ * The unit is centimeters because Typewriter facts store an Int. Use the
+ * `BoundaryDistanceVariable` for full precision.
+ *
+ * A fact holds a number and nothing else, so a region that cannot be measured at all reads
+ * as zero, the same as standing exactly on the boundary. That happens when the region entry
+ * is missing, when its placement variable does not resolve, or when the player is in another
+ * world. Pair a criteria on this fact with the In Region fact when the difference matters.
+ * The console warns at startup about a region whose shape cannot be built.
+ *
+ * With a region face on the ground, the inside distance is dominated by the floor
+ * underfoot. Set [distanceMode] to horizontal to measure against the walls only.
+ *
+ * The distance is measured from where the player stands, so a `Group` does not change it. A
+ * group shares one stored value between its members, and this fact has nothing stored to
+ * share: summing it over a group would add up everyone's distances.
+ *
+ * The measurement is a single point at the player's feet, while the In Region fact and the
+ * enter and leave events go by the whole body. In the roughly 0.3 block shell around the
+ * boundary the two disagree, and a player the region already counts as inside can still read
+ * a small positive distance here.
+ *
+ * ## How could this be used?
+ *
+ * Damage players outside the safe zone with the criteria `BoundaryDistanceFact > 0` on a
+ * damage action. Require more than 5 blocks outside with `BoundaryDistanceFact > 500`.
+ */
+class BoundaryDistanceFact(
+    override val id: String = "",
+    override val name: String = "",
+    override val comment: String = "",
+    override val group: Ref<GroupEntry> = emptyRef(),
+    @Help("The region whose boundary distance to publish.")
+    @Default(RegionDefaults.REGION_REFERENCE)
+    val region: RegionData = RegionReferenceData(),
+    @Help("How the distance is measured. Horizontal ignores the floor and ceiling faces and measures against the region's vertical silhouette.")
+    val distanceMode: DistanceMode = DistanceMode.FULL,
+) : ReadableFactEntry {
+    override fun readForPlayersGroup(player: Player): FactData = readSinglePlayer(player)
+
+    override fun readSinglePlayer(player: Player): FactData {
+        val engine: RegionEngine = KoinJavaComponent.get(RegionEngine::class.java)
+        val tracker = engine.query(region, player) ?: return FactData(0)
+        val distance = tracker.signedDistance(player.position, distanceMode) ?: return FactData(0)
+        return FactData((distance * 100.0).roundToInt())
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/fact/InRegionCountFact.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/fact/InRegionCountFact.kt
@@ -1,0 +1,55 @@
+package com.typewritermc.region.entries.fact
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.entries.emptyRef
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.engine.paper.entry.entries.GroupEntry
+import com.typewritermc.engine.paper.entry.entries.ReadableFactEntry
+import com.typewritermc.engine.paper.facts.FactData
+import com.typewritermc.region.RegionEngine
+import com.typewritermc.region.data.RegionData
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionReferenceData
+import org.bukkit.entity.Player
+import org.koin.java.KoinJavaComponent
+
+@Entry("region_player_count_fact", "Number of players currently inside a region", Colors.PURPLE, "mdi:account-group")
+/**
+ * The value is the number of online players currently inside the configured region. A
+ * player counts as inside as soon as any part of their body overlaps the region.
+ *
+ * The count is taken from the perspective of the reading player. For viewer independent
+ * regions every reader sees the same value. For viewer anchored regions the value is the
+ * number of players inside the reader's own region.
+ *
+ * The value is counted in the world for the asking player, so a `Group` does not change it.
+ * A group shares one stored value between its members, and this fact has nothing stored to
+ * share: summing it over a group would count everyone inside once per member.
+ *
+ * ## How could this be used?
+ *
+ * Open the boss door when at least 3 players are in the pre boss room, with the criteria
+ * `InRegionCountFact >= 3` on the door's open action.
+ */
+class InRegionCountFact(
+    override val id: String = "",
+    override val name: String = "",
+    override val comment: String = "",
+    override val group: Ref<GroupEntry> = emptyRef(),
+    @Help("The region whose population to count.")
+    @Default(RegionDefaults.REGION_REFERENCE)
+    val region: RegionData = RegionReferenceData(),
+) : ReadableFactEntry {
+    override fun readForPlayersGroup(player: Player): FactData = readSinglePlayer(player)
+
+    override fun readSinglePlayer(player: Player): FactData {
+        val engine: RegionEngine = KoinJavaComponent.get(RegionEngine::class.java)
+        val tracker = engine.query(region, player) ?: return FactData(0)
+        // The engine's own list, not the server's: this runs wherever a fact is read, which is
+        // not always the main thread, and the server's is a live view over a list it mutates.
+        return FactData(tracker.countInside(engine.onlinePlayers()))
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/fact/InRegionFact.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/fact/InRegionFact.kt
@@ -1,0 +1,54 @@
+package com.typewritermc.region.entries.fact
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.entries.emptyRef
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.engine.paper.entry.entries.GroupEntry
+import com.typewritermc.engine.paper.entry.entries.ReadableFactEntry
+import com.typewritermc.engine.paper.facts.FactData
+import com.typewritermc.region.RegionEngine
+import com.typewritermc.region.data.RegionData
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionReferenceData
+import org.bukkit.entity.Player
+import org.koin.java.KoinJavaComponent
+
+@Entry("region_inside_fact", "Whether the player is inside a region", Colors.PURPLE, "mdi:map-marker-check")
+/**
+ * The value is `1` when the player is inside the configured region and `0` otherwise.
+ * A player counts as inside as soon as any part of their body overlaps the region, the
+ * same rule the enter and leave events use. Region membership is a fact rather than a
+ * custom criteria type because Typewriter's
+ * [com.typewritermc.engine.paper.entry.Criteria] compares a fact against an Int.
+ *
+ * The value is read from the world for the asking player, so a `Group` does not change it.
+ * A group shares one stored value between its members; there is nothing stored here to share,
+ * and summing this fact over a group would answer how many of them are inside rather than
+ * whether this one is.
+ *
+ * ## How could this be used?
+ *
+ * Gate a `GiveItemAction` with the criteria `InRegionFact == 1` to only give the item
+ * when the player is inside the merchant zone.
+ */
+class InRegionFact(
+    override val id: String = "",
+    override val name: String = "",
+    override val comment: String = "",
+    override val group: Ref<GroupEntry> = emptyRef(),
+    @Help("The region whose membership produces the fact's value.")
+    @Default(RegionDefaults.REGION_REFERENCE)
+    val region: RegionData = RegionReferenceData(),
+) : ReadableFactEntry {
+    override fun readForPlayersGroup(player: Player): FactData = readSinglePlayer(player)
+
+    override fun readSinglePlayer(player: Player): FactData {
+        val engine: RegionEngine = KoinJavaComponent.get(RegionEngine::class.java)
+        val tracker = engine.query(region, player) ?: return FactData(0)
+        val value = if (tracker.isInside(player)) 1 else 0
+        return FactData(value)
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/group/RegionGroupEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/group/RegionGroupEntry.kt
@@ -1,0 +1,62 @@
+package com.typewritermc.region.entries.group
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.engine.paper.entry.entries.Group
+import com.typewritermc.engine.paper.entry.entries.GroupEntry
+import com.typewritermc.engine.paper.entry.entries.GroupId
+import com.typewritermc.region.RegionEngine
+import com.typewritermc.region.data.RegionDefinitionEntry
+import com.typewritermc.region.data.RegionReferenceData
+import org.bukkit.entity.Player
+import org.koin.java.KoinJavaComponent
+
+@Entry("region_members_group", "All players grouped by the region they are in", Colors.MYRTLE_GREEN, "fa6-solid:object-group")
+/**
+ * Groups players by the region they are currently inside, so facts using this group are
+ * shared by everyone in the same region. A player counts as inside as soon as any part of
+ * their body overlaps the region.
+ *
+ * Membership is answered from where the player stands at the moment the fact is read, with
+ * none of the boundary inset the enter and leave events use. Somebody standing exactly on the
+ * edge can therefore flip in and out of the group between two reads, and while they are out
+ * their reads answer zero and their writes go nowhere. Draw the region so its boundary is not
+ * where players stand still.
+ *
+ * A player inside none of the configured regions has no group, and fact reads and writes
+ * do nothing for them. A player inside several configured regions belongs to the first one
+ * in the list.
+ *
+ * ## How could this be used?
+ *
+ * Store the state of a boss fight per arena, so every player inside sees the same phase.
+ * Or count lever pulls in a puzzle room as one shared fact for the party inside.
+ */
+class RegionGroupEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("Regions to group by. A player inside several belongs to the first match.")
+    val definitions: List<Ref<RegionDefinitionEntry>> = emptyList(),
+) : GroupEntry {
+    override fun groupId(player: Player): GroupId? {
+        val engine: RegionEngine = KoinJavaComponent.get(RegionEngine::class.java)
+        for (definition in definitions) {
+            val tracker = engine.query(RegionReferenceData(definition), player) ?: continue
+            if (tracker.isInside(player)) return GroupId(definition.id)
+        }
+        return null
+    }
+
+    /**
+     * The engine's roster rather than the server's own list, which is a live view over the list
+     * the server mutates when someone joins or leaves. A fact is read wherever a criteria is
+     * evaluated, which is not always the main thread, and walking that view from another one
+     * throws as soon as anybody connects.
+     */
+    override fun group(id: GroupId): Group {
+        val engine: RegionEngine = KoinJavaComponent.get(RegionEngine::class.java)
+        return Group(engine.onlinePlayers().filter { groupId(it) == id })
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/BlockBreakModifierEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/BlockBreakModifierEntry.kt
@@ -1,0 +1,98 @@
+package com.typewritermc.region.entries.modifier
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.region.flag.RegionFlagIndex
+import com.typewritermc.region.flag.allows
+import com.typewritermc.region.flag.centerPosition
+import org.bukkit.Material
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.block.BlockBreakEvent
+import org.bukkit.event.block.BlockEvent
+import org.bukkit.event.block.BlockFadeEvent
+import org.bukkit.event.block.LeavesDecayEvent
+
+@Entry("region_block_break_modifier", "Decide who may break the blocks in a region", Colors.PURPLE, "mdi:pickaxe")
+/**
+ * Decides whether the blocks inside the region may be broken.
+ *
+ * The BLOCK's location decides, not the player's, so a player standing outside the region cannot
+ * mine their way in.
+ *
+ * Blocks that vanish on their own count too: ice or snow melting, farmland drying out, and leaves
+ * decaying once the logs holding them are cut.
+ *
+ * A region carrying this flag decides for the blocks inside it. Where regions overlap, the one with
+ * the highest priority decides, so an arena inside a protected city can allow what the city forbids
+ * by carrying this flag with [allowed] set.
+ *
+ * ## How could this be used?
+ *
+ * Protect a town from griefing, and give its quarry a higher priority region that allows mining
+ * again.
+ */
+class BlockBreakModifierEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("Whether the blocks inside the region may be broken.")
+    @Default("false")
+    override val allowed: Var<Boolean> = ConstVar(false),
+) : AllowanceModifierEntry
+
+class BlockBreakModifierHandler(private val index: RegionFlagIndex) : Listener {
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onBreak(event: BlockBreakEvent) {
+        if (index.allows(BlockBreakModifierEntry::class, event.block.centerPosition(), event.player)) return
+        event.isCancelled = true
+    }
+
+    /**
+     * Blocks that disappear on their own: ice and snow melting, farmland drying out, leaves
+     * decaying once their logs are gone. Every one of them can be provoked from outside the
+     * region, by placing a torch or by cutting the tree the canopy hangs from.
+     *
+     * Blocks whose fade is not a break are exempt. A fire burning out is a fade, and refusing it
+     * would hold the fire there forever, damaging anyone who walks through: the flag meant to
+     * preserve the build would keep the fire burning. Redstone ore uses a
+     * fade to stop glowing, and eggs use one to hatch, neither of which takes anything away.
+     */
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onFade(event: BlockFadeEvent) {
+        if (event.block.type in SELF_CLEARING) return
+        if (isAllowed(event)) return
+        event.isCancelled = true
+    }
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onLeavesDecay(event: LeavesDecayEvent) {
+        if (isAllowed(event)) return
+        event.isCancelled = true
+    }
+
+    private fun isAllowed(event: BlockEvent): Boolean =
+        index.allows(BlockBreakModifierEntry::class, event.block.centerPosition(), null)
+
+    companion object {
+        /**
+         * The dried ghast is looked up by name. Its constant only exists from 1.21.6 on, and a
+         * direct reference stops this whole handler from loading on the older servers the
+         * extension supports.
+         */
+        private val SELF_CLEARING = setOfNotNull(
+            Material.FIRE,
+            Material.SOUL_FIRE,
+            Material.REDSTONE_ORE,
+            Material.DEEPSLATE_REDSTONE_ORE,
+            Material.TURTLE_EGG,
+            Material.SNIFFER_EGG,
+            Material.FROGSPAWN,
+            Material.matchMaterial("DRIED_GHAST"),
+        )
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/BlockInteractModifierEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/BlockInteractModifierEntry.kt
@@ -1,0 +1,168 @@
+package com.typewritermc.region.entries.modifier
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.region.flag.RegionFlagIndex
+import com.typewritermc.region.flag.allows
+import com.typewritermc.region.flag.centerPosition
+import org.bukkit.Material
+import org.bukkit.block.DoubleChest
+import org.bukkit.entity.Player
+import org.bukkit.event.Event
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.block.Action
+import org.bukkit.event.entity.EntityInteractEvent
+import org.bukkit.event.inventory.InventoryMoveItemEvent
+import org.bukkit.inventory.BlockInventoryHolder
+import org.bukkit.inventory.Inventory
+import org.bukkit.event.player.PlayerInteractEvent
+
+@Entry(
+    "region_block_interact_modifier",
+    "Decide who may use the blocks in a region",
+    Colors.PURPLE,
+    "mdi:hand-back-right"
+)
+/**
+ * Decides whether the blocks inside the region may be used: chests, doors, buttons, levers and
+ * anything else a right click opens or toggles.
+ *
+ * Entities are not blocks. Rotating an item frame, stripping an armour stand or opening a chest
+ * minecart is the Entity Interact flag's business.
+ *
+ * Denying this refuses the use of the block, and of a block held against it, since a refused click
+ * otherwise falls through to placing what is in hand. You can still eat, drink or draw a bow while
+ * looking at a locked door.
+ *
+ * Hoppers and droppers are covered too, in both directions, so a container inside the region cannot
+ * be drained or filled from outside it.
+ *
+ * The BLOCK's location decides, not the player's.
+ *
+ * ## How could this be used?
+ *
+ * Lock a vault's chests to everyone outside the guild, or keep visitors from pulling the levers in
+ * a puzzle room they have not unlocked yet.
+ */
+class BlockInteractModifierEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("Whether the blocks inside the region may be used.")
+    @Default("false")
+    override val allowed: Var<Boolean> = ConstVar(false),
+) : AllowanceModifierEntry
+
+class BlockInteractModifierHandler(private val index: RegionFlagIndex) : Listener {
+    /**
+     * Stepping on a pressure plate or a tripwire is a use of the block that no click carries, and
+     * a puzzle whose levers are locked is not locked at all while its plates still fire. Farmland
+     * and turtle eggs are stepped on too, and those belong to the trample flag, so they are left
+     * to it rather than being decided twice.
+     */
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onPhysical(event: PlayerInteractEvent) {
+        if (event.action != Action.PHYSICAL) return
+        val block = event.clickedBlock ?: return
+        if (block.type in TRAMPLED_BLOCKS) return
+        if (isAllowed(block.centerPosition(), event.player)) return
+        event.isCancelled = true
+    }
+
+    /**
+     * A plate fires for an arrow, a dropped item and a wandering mob through this event instead,
+     * and a puzzle whose levers are locked is not locked while anyone can shoot its plates.
+     */
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onEntityPhysical(event: EntityInteractEvent) {
+        val block = event.block
+        if (block.type in TRAMPLED_BLOCKS) return
+        if (isAllowed(block.centerPosition(), event.entity as? Player)) return
+        event.isCancelled = true
+    }
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onInteract(event: PlayerInteractEvent) {
+        if (event.action != Action.RIGHT_CLICK_BLOCK) return
+        val block = event.clickedBlock ?: return
+        if (isAllowed(block.centerPosition(), event.player)) return
+
+        // Not setCancelled, which also denies the item in hand: that would stop a player eating,
+        // drinking or firing a bow whenever their crosshair rested on the region.
+        event.setUseInteractedBlock(Event.Result.DENY)
+
+        // A denied block still lets the item run, and for a block in hand that means placing it
+        // against the face that was just refused. Only what attaches to that face is taken away;
+        // everything a player can consume or aim keeps working.
+        if (event.material.isBlock || event.material in ATTACHED_TO_BLOCK) {
+            event.setUseItemInHand(Event.Result.DENY)
+        }
+    }
+
+    /**
+     * A hopper or dropper pointed at a container in the region moves its items without anyone
+     * touching it, which is the whole point of locking the container in the first place.
+     */
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onItemMove(event: InventoryMoveItemEvent) {
+        if (event.source.decidingPositions().any { !isAllowed(it, null) }) {
+            event.isCancelled = true
+            return
+        }
+        if (event.destination.decidingPositions().any { !isAllowed(it, null) }) event.isCancelled = true
+    }
+
+    /**
+     * Every block a container occupies, by its center, which is where a click on it decides too.
+     *
+     * An inventory's location is the block's corner, and a boundary cutting through a chest would
+     * otherwise refuse the player who right clicks it, whose click is decided by the center, and
+     * allow the hopper underneath it.
+     */
+    private fun Inventory.decidingPositions(): List<Position> {
+        // The snapshotless holder: the plain accessor copies the whole container and every item
+        // in it into a fresh block state, and this runs for every hopper transfer on the server.
+        val holder = getHolder(false)
+        if (holder is BlockInventoryHolder) return listOf(holder.block.centerPosition())
+        // A double chest is the common case that is not a BlockInventoryHolder: it holds its two
+        // halves rather than a block. Both are asked, because a boundary can run between them and
+        // a chest half anyone can reach into is a chest that is not protected.
+        if (holder is DoubleChest) {
+            val halves = listOfNotNull(holder.getLeftSide(false), holder.getRightSide(false))
+                .filterIsInstance<BlockInventoryHolder>()
+                .map { it.block.centerPosition() }
+            if (halves.isNotEmpty()) return halves
+        }
+        // Everything else answers by its own location, which a container reports as the block's
+        // lowest corner. Read back as a block so it decides where a click on it would.
+        return listOfNotNull(location?.block?.centerPosition())
+    }
+
+    private fun isAllowed(position: Position, player: Player?): Boolean =
+        index.allows(BlockInteractModifierEntry::class, position, player)
+
+    companion object {
+        /** Stepped on, but the trample flag's business rather than this one's. */
+        private val TRAMPLED_BLOCKS = setOf(Material.FARMLAND, Material.TURTLE_EGG)
+
+        /**
+         * Items that hang on the face a click was just refused for. `Material.isBlock` is false
+         * for every one of them, so without this a locked museum wall still takes frames and
+         * paintings. What lands on the ground rather than on the clicked face, like a boat or a
+         * planted seed, is the build flag's business.
+         */
+        private val ATTACHED_TO_BLOCK = setOf(
+            Material.ITEM_FRAME,
+            Material.GLOW_ITEM_FRAME,
+            Material.PAINTING,
+            Material.ARMOR_STAND,
+            Material.END_CRYSTAL,
+        )
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/BlockPlaceModifierEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/BlockPlaceModifierEntry.kt
@@ -1,0 +1,144 @@
+package com.typewritermc.region.entries.modifier
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.engine.paper.utils.toPosition
+import com.typewritermc.region.flag.centerPosition
+import com.typewritermc.region.flag.RegionFlagIndex
+import com.typewritermc.region.flag.allows
+import org.bukkit.entity.FallingBlock
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.block.BlockFertilizeEvent
+import org.bukkit.event.block.BlockFormEvent
+import org.bukkit.event.block.BlockGrowEvent
+import org.bukkit.event.block.BlockMultiPlaceEvent
+import org.bukkit.event.block.BlockPlaceEvent
+import org.bukkit.event.block.BlockSpreadEvent
+import org.bukkit.event.block.EntityBlockFormEvent
+import org.bukkit.event.entity.EntityChangeBlockEvent
+import org.bukkit.event.entity.EntityPlaceEvent
+import org.bukkit.event.hanging.HangingPlaceEvent
+import org.bukkit.event.world.StructureGrowEvent
+
+@Entry("region_block_place_modifier", "Decide who may build in a region", Colors.PURPLE, "mdi:cube-outline")
+/**
+ * Decides whether blocks may be placed inside the region.
+ *
+ * Entities placed like blocks count as well: item frames, paintings, armour stands, boats,
+ * minecarts and end crystals. So do blocks that arrive without anyone placing them: a tree
+ * growing into the region, vines and sculk spreading in, ice and snow forming, and sand or
+ * anvils falling in from above.
+ *
+ * The placed BLOCK's location decides, not the player's, so a player standing outside cannot build
+ * their way in.
+ *
+ * ## How could this be used?
+ *
+ * Keep a cathedral's skyline clear, or stop players from towering into an arena from outside it.
+ */
+class BlockPlaceModifierEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("Whether blocks may be placed inside the region.")
+    @Default("false")
+    override val allowed: Var<Boolean> = ConstVar(false),
+) : AllowanceModifierEntry
+
+class BlockPlaceModifierHandler(private val index: RegionFlagIndex) : Listener {
+    /**
+     * A bed, a door and a tall flower are one placement of two blocks, and only the half the
+     * player clicked is the event's own block. Both halves are tested, or a player standing
+     * outside could lay a bed whose head lands inside a region that denies building.
+     *
+     * [BlockMultiPlaceEvent] declares no handler list of its own, so it arrives here.
+     */
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onPlace(event: BlockPlaceEvent) {
+        val placed = (event as? BlockMultiPlaceEvent)?.replacedBlockStates?.map { it.block }
+            ?: listOf(event.blockPlaced)
+        if (placed.all { isAllowed(it.centerPosition(), event.player) }) return
+        event.isCancelled = true
+    }
+
+    /**
+     * Item frames, paintings, armour stands, boats, minecarts, end crystals and TNT minecarts
+     * are placed as entities, not blocks. Without this a region that denies building can still
+     * be furnished with all of them.
+     *
+     * The entity's own location decides. `event.block` is the block that was clicked, which is
+     * one step away from where the entity lands, and every face of a region has a block just
+     * outside it whose inward face aims in.
+     */
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onEntityPlace(event: EntityPlaceEvent) {
+        if (isAllowed(event.entity.location.toPosition(), event.player)) return
+        event.isCancelled = true
+    }
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onHangingPlace(event: HangingPlaceEvent) {
+        if (isAllowed(event.entity.location.toPosition(), event.player)) return
+        event.isCancelled = true
+    }
+
+    /**
+     * Blocks that appear on their own: a tree grown from a sapling, spreading vines, grass and
+     * sculk, ice and snow forming, and anything bonemealed into existence. They are placements
+     * as far as a protected build is concerned, and every one of them can be started from a
+     * block just outside the boundary.
+     */
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onStructureGrow(event: StructureGrowEvent) {
+        if (event.blocks.all { isAllowed(it.block.centerPosition(), event.player) }) return
+        event.isCancelled = true
+    }
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onGrow(event: BlockGrowEvent) {
+        if (isAllowed(event.block.centerPosition(), null)) return
+        event.isCancelled = true
+    }
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onSpread(event: BlockSpreadEvent) {
+        if (isAllowed(event.block.centerPosition(), null)) return
+        event.isCancelled = true
+    }
+
+    // EntityBlockFormEvent declares no handler list of its own, so this covers frost walker
+    // and snow golems as well as ice and snow forming on their own.
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onForm(event: BlockFormEvent) {
+        val cause = (event as? EntityBlockFormEvent)?.entity as? Player
+        if (isAllowed(event.block.centerPosition(), cause)) return
+        event.isCancelled = true
+    }
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onFertilize(event: BlockFertilizeEvent) {
+        if (event.blocks.all { isAllowed(it.block.centerPosition(), event.player) }) return
+        event.isCancelled = true
+    }
+
+    /**
+     * Sand, gravel, anvils and concrete powder land as real blocks wherever they come to rest,
+     * and the region they land in need not be the one they were dropped from.
+     */
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onFallingBlockLand(event: EntityChangeBlockEvent) {
+        if (event.entity !is FallingBlock) return
+        if (isAllowed(event.block.centerPosition(), null)) return
+        event.isCancelled = true
+    }
+
+    private fun isAllowed(position: Position, player: Player?): Boolean =
+        index.allows(BlockPlaceModifierEntry::class, position, player)
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/BucketModifierEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/BucketModifierEntry.kt
@@ -1,0 +1,113 @@
+package com.typewritermc.region.entries.modifier
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.utils.toPosition
+import com.typewritermc.region.flag.centerPosition
+import com.typewritermc.region.flag.RegionFlagIndex
+import com.typewritermc.region.flag.allows
+import org.bukkit.Material
+import org.bukkit.block.Block
+import org.bukkit.block.BlockFace
+import org.bukkit.block.data.Directional
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.block.BlockDispenseEvent
+import org.bukkit.event.player.PlayerBucketEmptyEvent
+import org.bukkit.event.player.PlayerBucketEntityEvent
+import org.bukkit.event.player.PlayerBucketFillEvent
+
+@Entry("region_bucket_modifier", "Decide who may empty or fill buckets in a region", Colors.PURPLE, "mdi:bucket")
+/**
+ * Decides whether the players inside the region may empty or fill buckets: lava, water, milk and
+ * powder snow alike.
+ *
+ * Emptying a bucket is not a block place, and filling one is not a block break, so those two flags
+ * never see a bucket: a player denied Block Place could still flood a region with lava. This flag
+ * closes that hole. A dispenser emptying a bucket is covered too, since a dispenser just outside
+ * the boundary is the easy way around a flag that only watches players. The mob buckets count as
+ * buckets here: each one leaves a water source behind. What comes out of them swimming is the mob
+ * spawn flag's business, so a region that allows buckets and denies spawning gets the water and no
+ * fish.
+ *
+ * The BLOCK's location decides, not the player's.
+ *
+ * ## How could this be used?
+ *
+ * Keep a lava bucket out of a protected build without having to also lock down every block a player
+ * might otherwise place.
+ */
+class BucketModifierEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("Whether the players inside the region may empty or fill buckets.")
+    @Default("false")
+    override val allowed: Var<Boolean> = ConstVar(false),
+) : AllowanceModifierEntry
+
+class BucketModifierHandler(private val index: RegionFlagIndex) : Listener {
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onEmpty(event: PlayerBucketEmptyEvent) {
+        if (index.allows(BucketModifierEntry::class, event.block.centerPosition(), event.player)) return
+        event.isCancelled = true
+    }
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onFill(event: PlayerBucketFillEvent) {
+        if (index.allows(BucketModifierEntry::class, event.block.centerPosition(), event.player)) return
+        event.isCancelled = true
+    }
+
+    /**
+     * Scooping a fish, an axolotl or a tadpole is a bucket fill that no block event sees, and
+     * the entity is not damaged either, so without this the aquarium of a region that denies
+     * every kind of damage can still be carried out one bucket at a time.
+     *
+     * The ENTITY's location decides, the same way the block does for the other two.
+     */
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onBucketEntity(event: PlayerBucketEntityEvent) {
+        if (index.allows(BucketModifierEntry::class, event.entity.location.toPosition(), event.player)) return
+        event.isCancelled = true
+    }
+
+    /**
+     * A dispenser empties a bucket without ever firing the player events, so a dispenser one
+     * block outside a protected region could pour lava into it all day. The dispenser fires
+     * with nobody behind it, so only a constant flag can decide.
+     */
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onDispense(event: BlockDispenseEvent) {
+        if (event.item.type !in BUCKETS) return
+        // A dropper fires the same event and throws the bucket on the floor rather than emptying
+        // it, so denying that is refusing a player the right to drop an item.
+        if (event.block.type != Material.DISPENSER) return
+        val target = event.block.getRelative(dispenseFace(event.block) ?: return)
+        if (index.allows(BucketModifierEntry::class, target.centerPosition(), null)) return
+        event.isCancelled = true
+    }
+
+    private fun dispenseFace(block: Block): BlockFace? = (block.blockData as? Directional)?.facing
+
+    companion object {
+        // The mob buckets belong here as much as the water bucket does: a dispenser empties one
+        // the same way, leaving a water source block behind and a fish swimming in it.
+        private val BUCKETS = setOf(
+            Material.BUCKET,
+            Material.WATER_BUCKET,
+            Material.LAVA_BUCKET,
+            Material.POWDER_SNOW_BUCKET,
+            Material.COD_BUCKET,
+            Material.SALMON_BUCKET,
+            Material.PUFFERFISH_BUCKET,
+            Material.TROPICAL_FISH_BUCKET,
+            Material.AXOLOTL_BUCKET,
+            Material.TADPOLE_BUCKET,
+        )
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/CombatModifierHandler.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/CombatModifierHandler.kt
@@ -1,0 +1,42 @@
+package com.typewritermc.region.entries.modifier
+
+import com.typewritermc.engine.paper.entry.entries.get
+import com.typewritermc.engine.paper.utils.toPosition
+import com.typewritermc.region.flag.RegionFlagIndex
+import com.typewritermc.region.flag.allowsDamage
+import com.typewritermc.region.flag.specificDecision
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.entity.EntityDamageEvent
+
+/**
+ * Enforces the three flags that decide about a player being hurt: PvP, Mob Damage and Player
+ * Damage.
+ *
+ * One handler for the three, because every hit weighs the specific flag against the general one
+ * before it can be refused, and a listener per flag resolved both decisions per hit and then
+ * reached the same answer three times.
+ */
+class CombatModifierHandler(private val index: RegionFlagIndex) : Listener {
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onDamage(event: EntityDamageEvent) {
+        val victim = event.entity as? Player ?: return
+        val position = victim.location.toPosition()
+
+        val general = index.resolveDecision(PlayerDamageModifierEntry::class, position, victim) {
+            it.decidesAbout(event.cause)
+        }
+        val specific = specificDecision(index, event, victim, position)
+
+        val allowed = allowsDamage(
+            specific = specific?.decision,
+            general = general,
+            allowedBySpecific = specific?.allowed ?: false,
+            allowedByGeneral = general?.flag?.allowed?.get(victim) ?: false,
+        ) ?: return
+        if (allowed) return
+        event.isCancelled = true
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/EntityDamageModifierEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/EntityDamageModifierEntry.kt
@@ -1,0 +1,93 @@
+package com.typewritermc.region.entries.modifier
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.utils.toPosition
+import com.typewritermc.region.flag.RegionFlagIndex
+import com.typewritermc.region.flag.allows
+import com.typewritermc.region.flag.responsibleAttacker
+import com.typewritermc.region.flag.responsiblePlayer
+import org.bukkit.entity.Player
+import org.bukkit.event.Cancellable
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.entity.EntityDamageEvent
+import org.bukkit.event.hanging.HangingBreakByEntityEvent
+import org.bukkit.event.hanging.HangingBreakEvent
+import org.bukkit.event.vehicle.VehicleDestroyEvent
+
+@Entry(
+    "region_entity_damage_modifier",
+    "Decide who may damage or destroy the entities in a region",
+    Colors.PURPLE,
+    "mdi:image-frame"
+)
+/**
+ * Decides whether the entities inside the region may be damaged or destroyed.
+ *
+ * This covers every entity that is not a player: item frames, paintings, armour stands, boats
+ * and minecarts, and mobs too. A region carrying this flag makes the mobs inside it
+ * unkillable along with its decorations.
+ *
+ * Every source counts, not just a player's fist: an arrow, an explosion, another mob, and the
+ * world itself. A protected armour stand does not burn in lava and a protected mob does not
+ * fall to its death.
+ *
+ * These are entities, not blocks, so Block Break never protects them: a player denied it could
+ * still punch an item frame off a fully protected region's wall. This flag closes that hole.
+ *
+ * A player hurting another player is the PvP and Mob Damage flags' business, not this one.
+ *
+ * The VICTIM's location decides, not the attacker's.
+ *
+ * This usually has a player behind it (someone punching an item frame), but not always. On a
+ * region with a variable placement, which only exists per viewer, damage with nobody behind it
+ * cannot resolve the region at all, and this denies it rather than letting it through.
+ *
+ * ## How could this be used?
+ *
+ * Protect the item frames and paintings in a museum, or the minecarts on a scripted rail ride, from
+ * being punched apart.
+ */
+class EntityDamageModifierEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("Whether the entities inside the region may be damaged or destroyed.")
+    @Default("false")
+    override val allowed: Var<Boolean> = ConstVar(false),
+) : AllowanceModifierEntry
+
+class EntityDamageModifierHandler(private val index: RegionFlagIndex) : Listener {
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onDamage(event: EntityDamageEvent) {
+        if (event.entity is Player) return
+        decide(event, event.entity.location.toPosition(), event.responsibleAttacker())
+    }
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onHangingBreak(event: HangingBreakEvent) {
+        val remover = (event as? HangingBreakByEntityEvent)?.remover
+        decide(event, event.entity.location.toPosition(), responsiblePlayer(remover))
+    }
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onVehicleDestroy(event: VehicleDestroyEvent) {
+        decide(event, event.vehicle.location.toPosition(), responsiblePlayer(event.attacker))
+    }
+
+    /**
+     * Cancels [event] unless the flag deciding for [position] allows it.
+     *
+     * [player] is the player answerable for the damage, `null` when nobody is.
+     */
+    private fun decide(event: Cancellable, position: Position, player: Player?) {
+        if (index.allows(EntityDamageModifierEntry::class, position, player)) return
+        event.isCancelled = true
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/EntityInteractModifierEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/EntityInteractModifierEntry.kt
@@ -1,0 +1,65 @@
+package com.typewritermc.region.entries.modifier
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.utils.toPosition
+import com.typewritermc.region.flag.RegionFlagIndex
+import com.typewritermc.region.flag.allows
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerArmorStandManipulateEvent
+import org.bukkit.event.player.PlayerInteractEntityEvent
+
+@Entry(
+    "region_entity_interact_modifier",
+    "Decide who may use the entities in a region",
+    Colors.PURPLE,
+    "mdi:hand-pointing-up"
+)
+/**
+ * Decides whether the entities inside the region may be used: taking the armour off an armour
+ * stand, rotating an item frame, opening a chest minecart, trading with a villager, mounting a
+ * horse, feeding an animal, leashing or name tagging one.
+ *
+ * Block Interact never sees an entity, so a museum that only denies it still has its frames
+ * turned and its stands stripped. This flag covers those, and every other right click on an
+ * entity with them.
+ *
+ * The ENTITY's location decides, not the player's.
+ *
+ * ## How could this be used?
+ *
+ * Keep visitors from emptying the armour stands in a museum, or from riding off on the stable's
+ * horses.
+ */
+class EntityInteractModifierEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("Whether the entities inside the region may be used.")
+    @Default("false")
+    override val allowed: Var<Boolean> = ConstVar(false),
+) : AllowanceModifierEntry
+
+class EntityInteractModifierHandler(private val index: RegionFlagIndex) : Listener {
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onInteractEntity(event: PlayerInteractEntityEvent) {
+        if (isAllowed(event.rightClicked.location.toPosition(), event.player)) return
+        event.isCancelled = true
+    }
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onManipulateArmorStand(event: PlayerArmorStandManipulateEvent) {
+        if (isAllowed(event.rightClicked.location.toPosition(), event.player)) return
+        event.isCancelled = true
+    }
+
+    private fun isAllowed(position: Position, player: Player): Boolean =
+        index.allows(EntityInteractModifierEntry::class, position, player)
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/ExplosionModifierEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/ExplosionModifierEntry.kt
@@ -1,0 +1,60 @@
+package com.typewritermc.region.entries.modifier
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.region.flag.centerPosition
+import com.typewritermc.region.flag.RegionFlagIndex
+import org.bukkit.block.Block
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.block.BlockExplodeEvent
+import org.bukkit.event.entity.EntityExplodeEvent
+
+@Entry("region_explosion_modifier", "Decide whether explosions may break the blocks in a region", Colors.PURPLE, "mdi:bomb-off")
+/**
+ * Decides whether an explosion may break the blocks inside the region. Creepers, TNT, beds in the
+ * nether and anything else that explodes.
+ *
+ * The blocks inside the region are taken out of the explosion, and the rest still break. A creeper
+ * on the border of a protected town craters the field outside it and leaves the town standing.
+ *
+ * No player is behind an explosion, so this flag cannot apply to a region whose placement follows a
+ * variable. Attaching it to one logs a warning on startup.
+ *
+ * ## How could this be used?
+ *
+ * Make a town creeper proof without turning mob griefing off for the whole server.
+ */
+class ExplosionModifierEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("Whether explosions may break the blocks inside the region.")
+    @Default("false")
+    val allowed: Boolean = false,
+) : RegionModifierEntry
+
+class ExplosionModifierHandler(private val index: RegionFlagIndex) : Listener {
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onEntityExplode(event: EntityExplodeEvent) {
+        spareProtectedBlocks(event.blockList())
+    }
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onBlockExplode(event: BlockExplodeEvent) {
+        spareProtectedBlocks(event.blockList())
+    }
+
+    private fun spareProtectedBlocks(blocks: MutableList<Block>) {
+        blocks.removeAll { block ->
+            val flag = index.resolve(
+                ExplosionModifierEntry::class,
+                block.centerPosition(),
+                null,
+            ) ?: return@removeAll false
+            !flag.allowed
+        }
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/FireSpreadModifierEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/FireSpreadModifierEntry.kt
@@ -1,0 +1,86 @@
+package com.typewritermc.region.entries.modifier
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.region.flag.centerPosition
+import com.typewritermc.region.flag.RegionFlagIndex
+import com.typewritermc.region.flag.responsiblePlayer
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.block.BlockBurnEvent
+import org.bukkit.event.block.BlockIgniteEvent
+
+@Entry("region_fire_spread_modifier", "Decide whether fire may spread in a region", Colors.PURPLE, "mdi:fire-off")
+/**
+ * Decides whether fire may spread to, and burn, the blocks inside the region.
+ *
+ * This is about fire spreading on its own, not about a player with a flint and steel. A player
+ * lighting a fire is a block interact question, so use the block interact flag for that.
+ *
+ * No player is behind spreading fire, so this flag cannot apply to a region whose placement follows
+ * a variable. Attaching it to one logs a warning on startup.
+ *
+ * ## How could this be used?
+ *
+ * Keep a wooden village from burning down after a lightning strike, without turning fire off for the
+ * whole world.
+ */
+class FireSpreadModifierEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("Whether fire may spread to the blocks inside the region.")
+    @Default("false")
+    val allowed: Boolean = false,
+) : RegionModifierEntry
+
+class FireSpreadModifierHandler(private val index: RegionFlagIndex) : Listener {
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onIgnite(event: BlockIgniteEvent) {
+        if (event.cause !in SPREAD_CAUSES) return
+        // A fire charge thrown by a player carries the same cause as a ghast's, and an end crystal
+        // a player placed the same one as a leftover from the dragon fight. When somebody is
+        // answerable, the fire is deliberate and the ignite flag decides it, not this one.
+        if (event.cause in SHARED_WITH_IGNITE && answerableFor(event) != null) return
+        if (isAllowed(event.block.centerPosition())) return
+        event.isCancelled = true
+    }
+
+    private fun answerableFor(event: BlockIgniteEvent): Player? =
+        event.player ?: responsiblePlayer(event.ignitingEntity)
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onBurn(event: BlockBurnEvent) {
+        if (isAllowed(event.block.centerPosition())) return
+        event.isCancelled = true
+    }
+
+    private fun isAllowed(position: Position): Boolean {
+        val flag = index.resolve(FireSpreadModifierEntry::class, position, null) ?: return true
+        return flag.allowed
+    }
+
+    companion object {
+        private val SPREAD_CAUSES = setOf(
+            BlockIgniteEvent.IgniteCause.SPREAD,
+            BlockIgniteEvent.IgniteCause.LAVA,
+            BlockIgniteEvent.IgniteCause.LIGHTNING,
+            BlockIgniteEvent.IgniteCause.EXPLOSION,
+            // A ghast's fireball and an end crystal left over from the dragon fight have no player
+            // behind them, so the Ignite flag never sees them and this is the only flag that can
+            // keep them out.
+            BlockIgniteEvent.IgniteCause.FIREBALL,
+            BlockIgniteEvent.IgniteCause.ENDER_CRYSTAL,
+        )
+
+        /** The causes the ignite flag also claims, which it owns whenever a player is behind them. */
+        private val SHARED_WITH_IGNITE = setOf(
+            BlockIgniteEvent.IgniteCause.FIREBALL,
+            BlockIgniteEvent.IgniteCause.ENDER_CRYSTAL,
+        )
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/FluidFlowModifierEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/FluidFlowModifierEntry.kt
@@ -1,0 +1,47 @@
+package com.typewritermc.region.entries.modifier
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.region.flag.centerPosition
+import com.typewritermc.region.flag.RegionFlagIndex
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.block.BlockFromToEvent
+
+@Entry("region_fluid_flow_modifier", "Decide whether water and lava may flow into a region", Colors.PURPLE, "mdi:water-off")
+/**
+ * Decides whether water and lava may flow into the region.
+ *
+ * The block the fluid flows INTO decides, so a source outside the region is stopped at its border.
+ *
+ * No player is behind a flowing fluid, so this flag cannot apply to a region whose placement follows
+ * a variable. Attaching it to one logs a warning on startup.
+ *
+ * ## How could this be used?
+ *
+ * Keep someone from flooding a shop from the plot next door, or hold lava out of a build without
+ * walling it in.
+ */
+class FluidFlowModifierEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("Whether water and lava may flow into the region.")
+    @Default("false")
+    val allowed: Boolean = false,
+) : RegionModifierEntry
+
+class FluidFlowModifierHandler(private val index: RegionFlagIndex) : Listener {
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onFlow(event: BlockFromToEvent) {
+        val flag = index.resolve(
+            FluidFlowModifierEntry::class,
+            event.toBlock.centerPosition(),
+            null,
+        ) ?: return
+        if (flag.allowed) return
+        event.isCancelled = true
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/IgniteModifierEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/IgniteModifierEntry.kt
@@ -1,0 +1,69 @@
+package com.typewritermc.region.entries.modifier
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.region.flag.centerPosition
+import com.typewritermc.region.flag.RegionFlagIndex
+import com.typewritermc.region.flag.allows
+import com.typewritermc.region.flag.responsiblePlayer
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.block.BlockIgniteEvent
+
+@Entry("region_ignite_modifier", "Decide who may light fires in a region", Colors.PURPLE, "mdi:fire")
+/**
+ * Decides whether the players inside the region may light fires with flint and steel or fire
+ * charges.
+ *
+ * The only flag that covers it. Block Interact refuses the block that was clicked and the item held
+ * against it, and flint and steel is neither a block nor something that attaches to one, so it goes
+ * on working on a locked wall.
+ *
+ * A flaming arrow, an end crystal and a dispenser holding flint and steel count too. All three are
+ * somebody lighting a fire with a step in between, and all three arrive with no player attached to
+ * the event.
+ *
+ * Fire arriving on its own is the Fire Spread flag's business, not this one: fire from a neighbouring
+ * block, from lava, from lightning, or the fireball of a ghast nobody is answerable for.
+ *
+ * The BLOCK's location decides, not the player's.
+ *
+ * ## How could this be used?
+ *
+ * Keep flint and steel out of a protected wooden build without locking its doors as well.
+ */
+class IgniteModifierEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("Whether the players inside the region may light fires.")
+    @Default("false")
+    override val allowed: Var<Boolean> = ConstVar(false),
+) : AllowanceModifierEntry
+
+class IgniteModifierHandler(private val index: RegionFlagIndex) : Listener {
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onIgnite(event: BlockIgniteEvent) {
+        if (event.cause !in DELIBERATE_CAUSES) return
+
+        // `event.player` is null for a flaming arrow and for a dispenser's flint and steel,
+        // both of which are somebody lighting a fire with an extra step in between.
+        val player = event.player ?: responsiblePlayer(event.ignitingEntity)
+        if (index.allows(IgniteModifierEntry::class, event.block.centerPosition(), player)) return
+        event.isCancelled = true
+    }
+
+    companion object {
+        /** Lighting a fire on purpose, as opposed to fire arriving on its own. */
+        private val DELIBERATE_CAUSES = setOf(
+            BlockIgniteEvent.IgniteCause.FLINT_AND_STEEL,
+            BlockIgniteEvent.IgniteCause.FIREBALL,
+            BlockIgniteEvent.IgniteCause.ARROW,
+            BlockIgniteEvent.IgniteCause.ENDER_CRYSTAL,
+        )
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/MobDamageModifierEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/MobDamageModifierEntry.kt
@@ -1,0 +1,35 @@
+package com.typewritermc.region.entries.modifier
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.region.flag.responsibleAttacker
+
+@Entry("region_mob_damage_modifier", "Decide whether mobs may hurt players in a region", Colors.PURPLE, "mdi:shield-bug")
+/**
+ * Decides whether the players inside the region may be hurt by anything that is not another
+ * player: mobs, but also falling anvils, dispenser arrows and every other entity that deals
+ * damage with nobody behind it.
+ *
+ * The VICTIM's location decides, so a skeleton outside cannot shoot a player standing inside a
+ * protected region.
+ *
+ * A player hurting a player is the PvP flag's business, and so is anything that player set in
+ * motion: their TNT, their lingering potion, their pet. Damage with no entity behind it at all,
+ * like falling or drowning, is the Player Damage flag's.
+ *
+ * ## How could this be used?
+ *
+ * Let players walk through a monster infested cave unharmed during a scripted escort, without
+ * removing the mobs.
+ */
+class MobDamageModifierEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("Whether mobs may hurt the players inside the region.")
+    @Default("false")
+    override val allowed: Var<Boolean> = ConstVar(false),
+) : AllowanceModifierEntry

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/MobGriefModifierEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/MobGriefModifierEntry.kt
@@ -1,0 +1,56 @@
+package com.typewritermc.region.entries.modifier
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.region.flag.centerPosition
+import com.typewritermc.region.flag.RegionFlagIndex
+import org.bukkit.entity.FallingBlock
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.entity.EntityChangeBlockEvent
+
+@Entry("region_mob_grief_modifier", "Decide whether mobs may change the blocks in a region", Colors.PURPLE, "mdi:cow-off")
+/**
+ * Decides whether mobs may change the blocks inside the region: endermen picking blocks up, sheep
+ * eating grass, zombies breaking doors.
+ *
+ * Explosions are a separate flag, because a creeper's crater is decided per block rather than by the
+ * mob that caused it.
+ *
+ * No player is behind a mob, so this flag cannot apply to a region whose placement follows a
+ * variable. Attaching it to one logs a warning on startup.
+ *
+ * ## How could this be used?
+ *
+ * Keep endermen from picking blocks out of a build, or protect a farm's crops from being
+ * trampled.
+ */
+class MobGriefModifierEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("Whether mobs may change the blocks inside the region.")
+    @Default("false")
+    val allowed: Boolean = false,
+) : RegionModifierEntry
+
+class MobGriefModifierHandler(private val index: RegionFlagIndex) : Listener {
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onChangeBlock(event: EntityChangeBlockEvent) {
+        if (event.entity is Player) return
+        // Sand and concrete powder settling fire this event too, and a plot that denies griefing
+        // did not mean to stop its own builders from placing a block that has to fall first. The
+        // build flag decides where a falling block may land.
+        if (event.entity is FallingBlock) return
+        val flag = index.resolve(
+            MobGriefModifierEntry::class,
+            event.block.centerPosition(),
+            null,
+        ) ?: return
+        if (flag.allowed) return
+        event.isCancelled = true
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/MobSpawnModifierEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/MobSpawnModifierEntry.kt
@@ -1,0 +1,64 @@
+package com.typewritermc.region.entries.modifier
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.engine.paper.utils.toPosition
+import com.typewritermc.region.flag.RegionFlagIndex
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.entity.CreatureSpawnEvent
+
+@Entry("region_mob_spawn_modifier", "Decide whether mobs may spawn in a region", Colors.PURPLE, "mdi:spider-web")
+/**
+ * Decides whether mobs may spawn inside the region. Every spawn reason counts: natural spawns,
+ * spawners, breeding, spawn eggs and the rest.
+ *
+ * A mob placed by a command is the one exception, since that is somebody with operator rights
+ * asking for it on purpose.
+ *
+ * The spawn LOCATION decides, so a mob wandering in from outside is untouched. This stops them
+ * appearing, not entering.
+ *
+ * No player is behind a natural spawn, so this flag cannot apply to a region whose placement follows
+ * a variable. Attaching it to one logs a warning on startup.
+ *
+ * ## How could this be used?
+ *
+ * Keep a hub free of monsters without lighting every corner of it.
+ */
+class MobSpawnModifierEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("Whether mobs may spawn inside the region. Only /summon is always allowed.")
+    @Default("false")
+    val allowed: Boolean = false,
+) : RegionModifierEntry
+
+/**
+ * Spawns an operator asked for on purpose.
+ *
+ * Only the command. A spawn egg is obtainable from any creative player, a kit or a shop, so
+ * exempting it hands every one of them a way through the flag. `CUSTOM` is what CraftBukkit
+ * stamps on any plugin's `World.spawn`, which is a whole category, not a deliberate act by the
+ * owner. Typewriter's own NPCs are packet entities and never reach this event at all.
+ */
+private val DELIBERATE_SPAWNS = setOf(
+    CreatureSpawnEvent.SpawnReason.COMMAND,
+)
+
+class MobSpawnModifierHandler(private val index: RegionFlagIndex) : Listener {
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onSpawn(event: CreatureSpawnEvent) {
+        if (event.spawnReason in DELIBERATE_SPAWNS) return
+        val flag = index.resolve(
+            MobSpawnModifierEntry::class,
+            event.location.toPosition(),
+            null,
+        ) ?: return
+        if (flag.allowed) return
+        event.isCancelled = true
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/PistonModifierEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/PistonModifierEntry.kt
@@ -1,0 +1,72 @@
+package com.typewritermc.region.entries.modifier
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.region.flag.centerPosition
+import com.typewritermc.region.flag.RegionFlagIndex
+import org.bukkit.block.Block
+import org.bukkit.block.BlockFace
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.block.BlockPistonExtendEvent
+import org.bukkit.event.block.BlockPistonRetractEvent
+
+@Entry("region_piston_modifier", "Decide whether pistons may move the blocks in a region", Colors.PURPLE, "mdi:arrow-expand-right")
+/**
+ * Decides whether a piston may move blocks inside the region.
+ *
+ * A piston moves all of its blocks or none of them, so a push that touches a single protected block
+ * is stopped entirely. It applies wherever the piston itself stands, including outside the region.
+ *
+ * No player is behind a piston, so this flag cannot apply to a region whose placement follows a
+ * variable. Attaching it to one logs a warning on startup.
+ *
+ * ## How could this be used?
+ *
+ * Stop a neighbour from pushing a wall of blocks into a protected build, or keep a redstone farm
+ * from pushing blocks out of the edge of a town.
+ */
+class PistonModifierEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("Whether pistons may move blocks inside the region.")
+    @Default("false")
+    val allowed: Boolean = false,
+) : RegionModifierEntry
+
+class PistonModifierHandler(private val index: RegionFlagIndex) : Listener {
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onExtend(event: BlockPistonExtendEvent) {
+        // The head takes the space in front of the piston even when there is nothing to push.
+        val head = event.block.getRelative(event.direction)
+        if (touchesProtectedBlock(event.blocks, event.direction, head)) event.isCancelled = true
+    }
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onRetract(event: BlockPistonRetractEvent) {
+        // A retraction's direction is the way its blocks travel, back towards the piston: vanilla
+        // hands this event the piston's facing already reversed, unlike the extension's.
+        if (touchesProtectedBlock(event.blocks, event.direction, null)) event.isCancelled = true
+    }
+
+    /**
+     * Whether the move touches a protected block, either by moving one out of a region or by
+     * landing one inside it.
+     *
+     * A block's destination has to be tested separately from where it stands: the event lists
+     * the blocks at their current positions, so a piston set up one block outside the boundary
+     * pushes past a check that only looks at those.
+     */
+    private fun touchesProtectedBlock(blocks: List<Block>, movement: BlockFace, head: Block?): Boolean {
+        if (head != null && isProtected(head)) return true
+        return blocks.any { isProtected(it) || isProtected(it.getRelative(movement)) }
+    }
+
+    private fun isProtected(block: Block): Boolean {
+        val flag = index.resolve(PistonModifierEntry::class, block.centerPosition(), null) ?: return false
+        return !flag.allowed
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/PlayerDamageModifierEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/PlayerDamageModifierEntry.kt
@@ -1,0 +1,35 @@
+package com.typewritermc.region.entries.modifier
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import org.bukkit.event.entity.EntityDamageEvent
+
+@Entry("region_player_damage_modifier", "Decide whether players may be hurt at all in a region", Colors.PURPLE, "mdi:shield-check")
+/**
+ * Decides whether the players inside the region may be hurt by anything at all: falling, drowning,
+ * fire, mobs and other players alike.
+ *
+ * It covers every cause at once. To allow mobs but not other players, use the PvP and mob damage
+ * flags instead.
+ *
+ * ## How could this be used?
+ *
+ * Make a hub a true safe zone where nothing can kill anyone, however hard they try.
+ */
+class PlayerDamageModifierEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("Whether the players inside the region may be hurt by anything.")
+    @Default("false")
+    override val allowed: Var<Boolean> = ConstVar(false),
+    @Help("The damage causes this decides about. Leave it empty to decide about every cause.")
+    val causes: List<EntityDamageEvent.DamageCause> = emptyList(),
+) : AllowanceModifierEntry {
+    /** Whether this flag has anything to say about damage of this [cause]. */
+    fun decidesAbout(cause: EntityDamageEvent.DamageCause): Boolean =
+        causes.isEmpty() || cause in causes
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/PvpModifierEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/PvpModifierEntry.kt
@@ -1,0 +1,33 @@
+package com.typewritermc.region.entries.modifier
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.region.flag.responsibleAttacker
+
+@Entry("region_pvp_modifier", "Decide whether players may fight each other in a region", Colors.PURPLE, "mdi:sword-cross")
+/**
+ * Decides whether players may hurt each other inside the region.
+ *
+ * Whatever the attacker used counts as theirs: a fist, an arrow, TNT they primed, a lingering
+ * potion they threw, or a pet they set on someone. Machinery counts even when the game records
+ * no owner for it, so a TNT cannon fired by a lever is still PvP. Only damage nobody set in
+ * motion falls to the Mob Damage and Player Damage flags.
+ *
+ * The VICTIM's location decides, so an attacker standing outside cannot shoot into a protected
+ * region, and an arrow loosed from inside it still lands on someone outside.
+ *
+ * ## How could this be used?
+ *
+ * Make a hub a truce, and give the arena inside it a higher priority region that allows PvP again.
+ */
+class PvpModifierEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("Whether players may hurt each other inside the region.")
+    @Default("false")
+    override val allowed: Var<Boolean> = ConstVar(false),
+) : AllowanceModifierEntry

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/RedstoneModifierEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/RedstoneModifierEntry.kt
@@ -1,0 +1,49 @@
+package com.typewritermc.region.entries.modifier
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.region.flag.centerPosition
+import com.typewritermc.region.flag.RegionFlagIndex
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.block.BlockRedstoneEvent
+
+@Entry("region_redstone_modifier", "Decide whether redstone may run in a region", Colors.PURPLE, "mdi:lightning-bolt")
+/**
+ * Decides whether redstone may change state inside the region.
+ *
+ * A redstone change is not a cancellable event, so a denied one is held at its previous current
+ * instead: the wire simply never powers on. Powering down is always allowed, so a circuit that was
+ * already live when the flag went up still settles instead of being stuck on forever.
+ *
+ * No player is behind a redstone tick, so this flag cannot apply to a region whose placement follows
+ * a variable. Attaching it to one logs a warning on startup.
+ *
+ * ## How could this be used?
+ *
+ * Kill redstone inside a puzzle room so nobody can shortcut it with a contraption, or keep a lag
+ * machine from running in a public plot.
+ */
+class RedstoneModifierEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("Whether redstone may change state inside the region.")
+    @Default("false")
+    val allowed: Boolean = false,
+) : RegionModifierEntry
+
+class RedstoneModifierHandler(private val index: RegionFlagIndex) : Listener {
+    @EventHandler(priority = EventPriority.LOW)
+    fun onRedstone(event: BlockRedstoneEvent) {
+        // Powering down is always allowed. Holding the old current in both directions freezes
+        // whatever was already live when the flag went up, and nothing can ever switch it off:
+        // a lag machine running at the moment of a publish would run forever.
+        if (event.newCurrent < event.oldCurrent) return
+        val flag = index.resolve(RedstoneModifierEntry::class, event.block.centerPosition(), null) ?: return
+        if (flag.allowed) return
+        event.newCurrent = event.oldCurrent
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/RegionModifierEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/RegionModifierEntry.kt
@@ -1,0 +1,27 @@
+package com.typewritermc.region.entries.modifier
+
+import com.typewritermc.core.extension.annotations.Tags
+import com.typewritermc.engine.paper.entry.ManifestEntry
+import com.typewritermc.engine.paper.entry.entries.Var
+
+/**
+ * A rule a region carries about what may happen inside it: who may break its blocks, whether
+ * pistons may push into it, whether mobs may spawn there.
+ *
+ * A region either carries a flag of a given kind, and then it decides, or it does not, and then
+ * the next region down in priority decides. Flags have no priority of their own: they inherit the
+ * priority of the region that lists them, so a region's rules always move together.
+ */
+@Tags("region_modifier")
+interface RegionModifierEntry : ManifestEntry
+
+/**
+ * A flag whose whole rule is one allowance, which a variable may drive.
+ *
+ * A variable needs a player to resolve. Events with no player behind them, like a crop growing or
+ * sand coming to rest, have none, and [allowed] answers `null` for them. Such a flag has nothing to
+ * say about those events and abstains, rather than reading as a denial.
+ */
+interface AllowanceModifierEntry : RegionModifierEntry {
+    val allowed: Var<Boolean>
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/TrampleModifierEntry.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/modifier/TrampleModifierEntry.kt
@@ -1,0 +1,83 @@
+package com.typewritermc.region.entries.modifier
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.region.flag.centerPosition
+import com.typewritermc.region.flag.RegionFlagIndex
+import com.typewritermc.region.flag.allows
+import com.typewritermc.region.flag.responsiblePlayer
+import org.bukkit.block.Block
+import org.bukkit.entity.Entity
+import org.bukkit.entity.Player
+import org.bukkit.Material
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.block.Action
+import org.bukkit.event.entity.EntityInteractEvent
+import org.bukkit.event.player.PlayerInteractEvent
+
+@Entry("region_trample_modifier", "Decide who may trample the farmland in a region", Colors.PURPLE, "mdi:sprout")
+/**
+ * Decides whether farmland and turtle eggs inside the region may be trampled by walking or jumping
+ * on them. Mobs and mounted players count too, which is how a protected farm otherwise survives
+ * every visitor on foot and falls to the first one on a horse.
+ *
+ * Trampling is a PHYSICAL interaction, which the Block Interact flag does not cover since that only
+ * decides about right clicks. Without this flag, a player denied Block Interact could still trample
+ * every crop in a protected farm.
+ *
+ * The BLOCK's location decides, not the player's.
+ *
+ * ## How could this be used?
+ *
+ * Protect a farm's crops from being trampled without locking its gates and levers too.
+ */
+class TrampleModifierEntry(
+    override val id: String = "",
+    override val name: String = "",
+    @Help("Whether farmland and turtle eggs inside the region may be trampled.")
+    @Default("false")
+    override val allowed: Var<Boolean> = ConstVar(false),
+) : AllowanceModifierEntry
+
+class TrampleModifierHandler(private val index: RegionFlagIndex) : Listener {
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onPhysical(event: PlayerInteractEvent) {
+        if (event.action != Action.PHYSICAL) return
+        val block = event.clickedBlock ?: return
+        if (block.type !in TRAMPLEABLE) return
+        if (isAllowed(block, event.player)) return
+        event.isCancelled = true
+    }
+
+    /**
+     * A player on a horse, and any mob at all, trample through this event instead. Without it a
+     * protected farm survives every visitor on foot and is flattened by the first one who rides
+     * in, and nothing whatsoever protects turtle eggs.
+     */
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onEntityInteract(event: EntityInteractEvent) {
+        val block = event.block
+        if (block.type !in TRAMPLEABLE) return
+        if (isAllowed(block, riderOf(event.entity) ?: responsiblePlayer(event.entity))) return
+        event.isCancelled = true
+    }
+
+    /**
+     * The rider before the owner: a horse's owner may be a farm's owner and half the map away,
+     * while the visitor in the saddle is the one flattening the crops.
+     */
+    private fun riderOf(entity: Entity): Player? = entity.passengers.firstNotNullOfOrNull { it as? Player }
+
+    private fun isAllowed(block: Block, player: Player?): Boolean =
+        index.allows(TrampleModifierEntry::class, block.centerPosition(), player)
+
+    companion object {
+        private val TRAMPLEABLE = setOf(Material.FARMLAND, Material.TURTLE_EGG)
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/variable/BoundaryDistanceVariable.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/entries/variable/BoundaryDistanceVariable.kt
@@ -1,0 +1,61 @@
+package com.typewritermc.region.entries.variable
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.exceptions.ContextDataNotFoundException
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Entry
+import com.typewritermc.core.extension.annotations.GenericConstraint
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.core.extension.annotations.VariableData
+import com.typewritermc.engine.paper.entry.entries.VarContext
+import com.typewritermc.engine.paper.entry.entries.VariableEntry
+import com.typewritermc.engine.paper.entry.entries.getData
+import com.typewritermc.engine.paper.entry.entries.safeCast
+import com.typewritermc.engine.paper.utils.position
+import com.typewritermc.region.RegionEngine
+import com.typewritermc.region.data.DistanceMode
+import com.typewritermc.region.data.RegionData
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionReferenceData
+import org.koin.java.KoinJavaComponent
+
+@Entry("region_boundary_distance_variable", "Signed distance from a region boundary (Double)", Colors.GREEN, "mdi:ruler")
+@GenericConstraint(Double::class)
+@VariableData(BoundaryDistanceVariableData::class)
+/**
+ * Full precision counterpart of `BoundaryDistanceFact`. Returns a `Double`: negative
+ * inside, positive outside, zero on the boundary. Use this in `Var<Double>` slots where
+ * the centimeter scaled fact loses precision.
+ *
+ * A region that cannot be measured at all reads as zero, the same as standing exactly on the
+ * boundary. That happens when the region entry is missing, when its placement variable does
+ * not resolve, or when the player is in another world.
+ *
+ * ## How could this be used?
+ *
+ * Drive a particle radius variable from boundary distance to create a halo effect that
+ * shrinks the closer the player is to the wall.
+ */
+class BoundaryDistanceVariable(
+    override val id: String = "",
+    override val name: String = "",
+) : VariableEntry {
+    override fun <T : Any> get(context: VarContext<T>): T {
+        val player = context.player
+        val data = context.getData<BoundaryDistanceVariableData>()
+            ?: throw ContextDataNotFoundException(context.klass, context.data)
+        val engine: RegionEngine = KoinJavaComponent.get(RegionEngine::class.java)
+        val tracker = engine.query(data.region, player)
+        val distance: Double = tracker?.signedDistance(player.position, data.distanceMode) ?: 0.0
+        return context.safeCast(distance)
+            ?: throw IllegalStateException("Could not cast Double to ${context.klass}")
+    }
+}
+
+data class BoundaryDistanceVariableData(
+    @Help("The region whose boundary distance to publish.")
+    @Default(RegionDefaults.REGION_REFERENCE)
+    val region: RegionData = RegionReferenceData(),
+    @Help("How the distance is measured. Horizontal ignores the floor and ceiling faces and measures against the region's vertical silhouette.")
+    val distanceMode: DistanceMode = DistanceMode.FULL,
+)

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/flag/BlockCenter.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/flag/BlockCenter.kt
@@ -1,0 +1,16 @@
+package com.typewritermc.region.flag
+
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.World
+import org.bukkit.block.Block
+
+/**
+ * The center of the block, where every block scoped flag decides region membership.
+ *
+ * A block's location is its lowest corner, and a region boundary crossing the block can
+ * leave that corner outside while most of the block sits inside. Deciding at the corner
+ * makes visibly covered floor blocks read as unprotected; the center matches what a
+ * builder sees covered.
+ */
+internal fun Block.centerPosition(): Position =
+    Position(World(world.uid.toString()), x + 0.5, y + 0.5, z + 0.5)

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/flag/DamageDecision.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/flag/DamageDecision.kt
@@ -1,0 +1,113 @@
+package com.typewritermc.region.flag
+
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.region.entries.modifier.MobDamageModifierEntry
+import com.typewritermc.region.entries.modifier.PvpModifierEntry
+import org.bukkit.damage.DamageSource
+import org.bukkit.entity.AreaEffectCloud
+import org.bukkit.entity.Entity
+import org.bukkit.entity.EvokerFangs
+import org.bukkit.entity.minecart.ExplosiveMinecart
+import org.bukkit.entity.Firework
+import org.bukkit.entity.Player
+import org.bukkit.entity.Projectile
+import org.bukkit.entity.TNTPrimed
+import org.bukkit.entity.Tameable
+import org.bukkit.event.entity.EntityDamageByEntityEvent
+import org.bukkit.event.entity.EntityDamageEvent
+
+/**
+ * Whether damage is allowed, given what the specific flag (PvP or mob damage) decided and what the
+ * general player damage flag decided.
+ *
+ * The higher priority decision wins. When the same region holds both, the specific one wins, because
+ * a region carrying "PvP allowed" and "player damage denied" means exactly that: fight here, but do
+ * not fall to your death.
+ *
+ * `null` when no region decided, and the damage is then nobody's business.
+ */
+internal fun allowsDamage(
+    specific: FlagDecision<*>?,
+    general: FlagDecision<*>?,
+    allowedBySpecific: Boolean,
+    allowedByGeneral: Boolean,
+): Boolean? {
+    if (specific == null && general == null) return null
+    if (specific == null) return allowedByGeneral
+    if (general == null) return allowedBySpecific
+    if (specific.priority != general.priority) {
+        return if (specific.priority > general.priority) allowedBySpecific else allowedByGeneral
+    }
+    if (specific.order != general.order) {
+        return if (specific.order > general.order) allowedBySpecific else allowedByGeneral
+    }
+    return allowedBySpecific
+}
+
+internal class SpecificDamage(val decision: FlagDecision<*>, val allowed: Boolean)
+
+/**
+ * The player answerable for [entity], or `null` when nobody is.
+ *
+ * A region flag is written about people, so damage a player set in motion has to resolve back
+ * to that player however it was delivered. TNT, a lingering potion cloud and a pet are not
+ * projectiles, so matching on [Projectile] alone lets someone kill in a region that denies PvP
+ * by priming a block of TNT instead of swinging.
+ */
+internal fun responsiblePlayer(entity: Entity?): Player? = when (entity) {
+    is Player -> entity
+    is Projectile -> entity.shooter as? Player
+    is TNTPrimed -> entity.source as? Player
+    is AreaEffectCloud -> entity.source as? Player
+    is EvokerFangs -> entity.owner as? Player
+    is Tameable -> entity.owner as? Player
+    else -> null
+}
+
+/**
+ * The player answerable for this damage. [DamageSource.getCausingEntity] already unwraps most
+ * indirect damage, and [responsiblePlayer] covers what it leaves behind.
+ */
+internal fun EntityDamageEvent.responsibleAttacker(): Player? =
+    responsiblePlayer(damageSource.causingEntity)
+        ?: responsiblePlayer((this as? EntityDamageByEntityEvent)?.damager)
+
+/**
+ * Whether [entity] is something a player built rather than something that lives in the world.
+ *
+ * Vanilla only records an owner for TNT a player lit by hand, so a cannon fired by a lever or a
+ * dispenser arrives with nobody attached. Handing that to the mob damage flag would mean a truce
+ * zone carrying only PvP does not cover the most common way to kill in one.
+ */
+private fun playerBuilt(entity: Entity?): Boolean = when (entity) {
+    is TNTPrimed, is ExplosiveMinecart, is Firework -> true
+    // A cloud is machinery only while a player is named on it. The Ender Dragon's breath is a
+    // cloud too, and handing that to the PvP flag would mean an arena denying mob damage does not
+    // cover the dragon's own attack. An owner that no longer resolves, because the mob died or
+    // its chunk went, reads as no owner at all, so the absence cannot be taken for a player.
+    is AreaEffectCloud -> entity.source is Player
+    else -> false
+}
+
+/**
+ * Whether the PvP flag owns this damage rather than the mob damage flag. Damage from a named
+ * player, and damage from the machinery players build, are both PvP's business.
+ */
+internal fun EntityDamageEvent.attributedToPlayers(): Boolean =
+    responsibleAttacker() != null || playerBuilt((this as? EntityDamageByEntityEvent)?.damager)
+
+/** The specific flag that owns this damage: PvP when a player is behind it, mob damage otherwise. */
+internal fun specificDecision(
+    index: RegionFlagIndex,
+    event: EntityDamageEvent,
+    victim: Player,
+    position: Position,
+): SpecificDamage? {
+    (event as? EntityDamageByEntityEvent)?.damager ?: return null
+    if (event.attributedToPlayers()) {
+        val decision = index.resolveDecision(PvpModifierEntry::class, position, victim) ?: return null
+        return SpecificDamage(decision, decision.flag.allowed.get(victim))
+    }
+    val decision = index.resolveDecision(MobDamageModifierEntry::class, position, victim) ?: return null
+    return SpecificDamage(decision, decision.flag.allowed.get(victim))
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/flag/FlagReport.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/flag/FlagReport.kt
@@ -1,0 +1,153 @@
+package com.typewritermc.region.flag
+
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.region.entries.modifier.BlockBreakModifierEntry
+import com.typewritermc.region.entries.modifier.BlockInteractModifierEntry
+import com.typewritermc.region.entries.modifier.BlockPlaceModifierEntry
+import com.typewritermc.region.entries.modifier.BucketModifierEntry
+import com.typewritermc.region.entries.modifier.EntityDamageModifierEntry
+import com.typewritermc.region.entries.modifier.EntityInteractModifierEntry
+import com.typewritermc.region.entries.modifier.ExplosionModifierEntry
+import com.typewritermc.region.entries.modifier.FireSpreadModifierEntry
+import com.typewritermc.region.entries.modifier.FluidFlowModifierEntry
+import com.typewritermc.region.entries.modifier.IgniteModifierEntry
+import com.typewritermc.region.entries.modifier.MobDamageModifierEntry
+import com.typewritermc.region.entries.modifier.MobGriefModifierEntry
+import com.typewritermc.region.entries.modifier.MobSpawnModifierEntry
+import com.typewritermc.region.entries.modifier.PistonModifierEntry
+import com.typewritermc.region.entries.modifier.PlayerDamageModifierEntry
+import com.typewritermc.region.entries.modifier.PvpModifierEntry
+import com.typewritermc.region.entries.modifier.RedstoneModifierEntry
+import com.typewritermc.region.entries.modifier.RegionModifierEntry
+import com.typewritermc.region.entries.modifier.TrampleModifierEntry
+import org.bukkit.entity.Player
+import kotlin.reflect.KClass
+
+/** A short, human readable name per flag type, matched one for one against [handlerFactories]. */
+internal val FLAG_LABELS: Map<KClass<out RegionModifierEntry>, String> = mapOf(
+    BlockBreakModifierEntry::class to "Block Break",
+    BlockPlaceModifierEntry::class to "Block Place",
+    BlockInteractModifierEntry::class to "Block Interact",
+    EntityInteractModifierEntry::class to "Entity Interact",
+    BucketModifierEntry::class to "Bucket",
+    PistonModifierEntry::class to "Piston",
+    RedstoneModifierEntry::class to "Redstone",
+    FireSpreadModifierEntry::class to "Fire Spread",
+    FluidFlowModifierEntry::class to "Fluid Flow",
+    ExplosionModifierEntry::class to "Explosion",
+    MobSpawnModifierEntry::class to "Mob Spawn",
+    MobGriefModifierEntry::class to "Mob Grief",
+    PvpModifierEntry::class to "PvP",
+    MobDamageModifierEntry::class to "Mob Damage",
+    PlayerDamageModifierEntry::class to "Player Damage",
+    EntityDamageModifierEntry::class to "Entity Damage",
+    TrampleModifierEntry::class to "Trample",
+    IgniteModifierEntry::class to "Ignite",
+)
+
+private fun RegionModifierEntry.label(): String =
+    FLAG_LABELS[this::class] ?: error("FlagReport has no label for ${this::class.simpleName}")
+
+private fun RegionModifierEntry.isAllowed(player: Player): Boolean = when (this) {
+    is BlockBreakModifierEntry -> allowed.get(player)
+    is BlockPlaceModifierEntry -> allowed.get(player)
+    is BlockInteractModifierEntry -> allowed.get(player)
+    is EntityInteractModifierEntry -> allowed.get(player)
+    is BucketModifierEntry -> allowed.get(player)
+    is EntityDamageModifierEntry -> allowed.get(player)
+    is TrampleModifierEntry -> allowed.get(player)
+    is IgniteModifierEntry -> allowed.get(player)
+    is PvpModifierEntry -> allowed.get(player)
+    is MobDamageModifierEntry -> allowed.get(player)
+    is PlayerDamageModifierEntry -> allowed.get(player)
+    is PistonModifierEntry -> allowed
+    is RedstoneModifierEntry -> allowed
+    is FireSpreadModifierEntry -> allowed
+    is FluidFlowModifierEntry -> allowed
+    is ExplosionModifierEntry -> allowed
+    is MobSpawnModifierEntry -> allowed
+    is MobGriefModifierEntry -> allowed
+    else -> error("FlagReport does not know how to read the value of ${this::class.simpleName}")
+}
+
+private fun Boolean.asChatValue(): String = if (this) "<green>✔ allowed</green>" else "<red>✘ denied</red>"
+
+private fun Boolean.asChatMark(): String = if (this) "<green>✔</green>" else "<red>✘</red>"
+
+/**
+ * Every flagged region containing [position], highest priority first, one line per region
+ * with the flags it carries inline. This is "what am I standing in": every region's own
+ * opinion, not just the one that wins.
+ */
+internal fun standingReport(index: RegionFlagIndex, position: Position, player: Player): List<String> {
+    val regions = index.regionsAt(position, player)
+    if (regions.isEmpty()) return listOf("<gray>No flagged region contains this position.")
+
+    return regions.map { region ->
+        val flags = region.modifiers.values.joinToString("<dark_gray> · </dark_gray>") { flag ->
+            val scope = flag.causeScope()
+            val scoped = if (scope == null) "" else "<dark_gray>($scope)</dark_gray>"
+            "<white>${flag.label()}</white>$scoped ${flag.isAllowed(player).asChatMark()}"
+        }.ifEmpty { "<dark_gray>no flags" }
+        "<blue>${region.entry.name}</blue> <dark_gray>(priority ${region.priority})</dark_gray> $flags"
+    }
+}
+
+/**
+ * The flags actually in force at [position]: one line per decided flag with its value, the
+ * deciding region and its priority. Flags no region decides collapse into one trailing
+ * counter whose names sit on its hover, so the answer is not buried in noise. This is
+ * "what am I looking at": the winner only, never every region's opinion.
+ */
+internal fun flagReport(index: RegionFlagIndex, position: Position, player: Player): List<String> {
+    val decided = mutableListOf<String>()
+    val undecided = mutableListOf<String>()
+    for (type in handlerFactories.keys) {
+        val label = FLAG_LABELS[type] ?: error("FlagReport has no label for ${type.simpleName}")
+        val lines = decisionLines(index, type, label, position, player)
+        if (lines.isEmpty()) undecided += label else decided += lines
+    }
+    if (decided.isEmpty()) return listOf("<gray>No region decides any flag at this block.")
+    if (undecided.isNotEmpty()) {
+        val names = undecided.joinToString(", ")
+        decided += "<dark_gray><hover:show_text:'$names'>+ ${undecided.size} undecided " +
+                "flag${if (undecided.size == 1) "" else "s"}</hover>"
+    }
+    return decided
+}
+
+private fun <M : RegionModifierEntry> decisionLines(
+    index: RegionFlagIndex,
+    type: KClass<M>,
+    label: String,
+    position: Position,
+    player: Player,
+): List<String> {
+    val decision = index.resolveDecision(type, position, player) ?: return emptyList()
+    val winner = decisionLine(decision, label, decision.flag.causeScope(), player)
+    if (decision.flag.causeScope() == null) return listOf(winner)
+
+    // A Player Damage flag that names its causes decides about those and abstains from the rest,
+    // so the winner is not the whole answer. Whatever blanket flag sits below it is what a builder
+    // needs when they ask why damage still gets through, and stopping at the winner hides it.
+    val blanket = index.resolveDecision(PlayerDamageModifierEntry::class, position, player) {
+        it.causes.isEmpty()
+    } ?: return listOf(winner)
+    return listOf(winner, decisionLine(blanket, label, "every other cause", player))
+}
+
+private fun decisionLine(
+    decision: FlagDecision<out RegionModifierEntry>,
+    label: String,
+    scope: String?,
+    player: Player,
+): String {
+    val value = decision.flag.isAllowed(player).asChatValue()
+    val scoped = if (scope == null) "" else " <dark_gray>for <white>$scope</white></dark_gray>"
+    return "<white>$label</white> $value$scoped <dark_gray>← <blue>${decision.regionName}</blue> priority ${decision.priority}</dark_gray>"
+}
+
+/** The causes a flag limits itself to, or `null` when it decides about all of them. */
+private fun RegionModifierEntry.causeScope(): String? = (this as? PlayerDamageModifierEntry)?.causes
+    ?.takeIf { it.isNotEmpty() }
+    ?.joinToString(", ") { it.name.lowercase() }

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/flag/RegionFlagIndex.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/flag/RegionFlagIndex.kt
@@ -1,0 +1,259 @@
+package com.typewritermc.region.flag
+
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.World
+import com.typewritermc.engine.paper.entry.entries.get
+import com.typewritermc.region.RegionEngine
+import com.typewritermc.region.data.RegionDefinitionEntry
+import com.typewritermc.region.data.RegionReferenceData
+import com.typewritermc.region.entries.modifier.AllowanceModifierEntry
+import com.typewritermc.region.entries.modifier.RegionModifierEntry
+import com.typewritermc.region.tracker.RegionTracker
+import com.typewritermc.region.tracker.WorldAabb
+import com.typewritermc.core.entries.ref
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap
+import org.bukkit.entity.Player
+import kotlin.reflect.KClass
+
+/** How many chunks a region may span before it is scanned instead of indexed. */
+const val MAX_INDEXED_CHUNKS = 1024L
+
+/**
+ * One region that carries flags, resolved once at load.
+ *
+ * [tracker] and [aabb] are `null` for a variable placement region: it exists only per viewer and
+ * moves, so it cannot be resolved or indexed ahead of time.
+ *
+ * [order] is the region's position once the definitions are sorted by entry id. It breaks ties
+ * between equal priorities, and the region later in that order wins. Page files are read in an
+ * order the filesystem decides, so load order itself is not stable across restarts.
+ */
+internal class FlaggedRegion(
+    val entry: RegionDefinitionEntry,
+    val priority: Int,
+    val order: Int,
+    val modifiers: Map<KClass<out RegionModifierEntry>, RegionModifierEntry>,
+    val tracker: RegionTracker?,
+    val aabb: WorldAabb?,
+)
+
+/** A flag, and the region whose priority won it the decision. */
+data class FlagDecision<M : RegionModifierEntry>(
+    val flag: M,
+    val regionName: String,
+    val priority: Int,
+    val order: Int,
+)
+
+/**
+ * Which region decides about a given block.
+ *
+ * Constant placement regions are indexed by the chunks their footprint touches, so a block in a
+ * chunk no region reaches costs one hash miss. The index exists for that case: ten thousand
+ * regions on the server, with a redstone contraption running somewhere none of them reach.
+ *
+ * A region whose footprint spans more than [MAX_INDEXED_CHUNKS] would write thousands of index
+ * entries, so it goes into a bucket that is scanned instead. A handful of huge regions cost a
+ * handful of AABB tests; the ten thousand normal ones stay a hash lookup.
+ *
+ * Variable placement regions cannot be indexed and are resolved per player through the engine's
+ * query cache. Without a player they are skipped, which is why a piston or a redstone tick never
+ * sees them.
+ */
+class RegionFlagIndex internal constructor(
+    regions: List<FlaggedRegion>,
+    private val engine: RegionEngine?,
+) {
+    private val chunks = HashMap<World, Long2ObjectOpenHashMap<MutableList<FlaggedRegion>>>()
+    private val oversized = mutableListOf<FlaggedRegion>()
+    private val dynamic = mutableListOf<FlaggedRegion>()
+
+    /**
+     * Regions examined by the last [resolve] call. Diagnostics only: a test asserts that an
+     * empty chunk touches none, and a concurrent lookup may overwrite it in between. The field
+     * is plain rather than volatile because every flag lookup writes it, including the ones on
+     * a redstone tick.
+     */
+    var candidatesTouched: Int = 0
+        private set
+
+    val oversizedCount: Int get() = oversized.size
+
+    /**
+     * Every constant placement candidate whose AABB contains [position]. Inline, so a lookup
+     * allocates nothing: a piston resolves once per moved block and redstone once per state
+     * change, and a block update in a chunk no region reaches costs one hash miss.
+     */
+    private inline fun forEachPositionalCandidate(
+        position: Position,
+        action: (FlaggedRegion, RegionTracker) -> Unit,
+    ) {
+        val indexed = chunks[position.world]
+            ?.get(chunkKey(floorChunk(position.x), floorChunk(position.z)))
+        if (indexed != null) {
+            for (region in indexed) {
+                val aabb = region.aabb ?: continue
+                if (!aabb.contains(position)) continue
+                action(region, region.tracker ?: continue)
+            }
+        }
+
+        for (region in oversized) {
+            val aabb = region.aabb ?: continue
+            if (aabb.world != position.world || !aabb.contains(position)) continue
+            action(region, region.tracker ?: continue)
+        }
+    }
+
+    private fun positionalCandidates(position: Position): List<Pair<FlaggedRegion, RegionTracker>> {
+        val result = mutableListOf<Pair<FlaggedRegion, RegionTracker>>()
+        forEachPositionalCandidate(position) { region, tracker -> result += region to tracker }
+        return result
+    }
+
+    /**
+     * Every candidate worth testing for [position]: the constant placement regions found through
+     * [positionalCandidates], plus every variable placement region resolved through the engine when
+     * a [player] is given.
+     */
+    private fun candidates(position: Position, player: Player?): List<Pair<FlaggedRegion, RegionTracker>> {
+        val result = positionalCandidates(position).toMutableList()
+        if (player != null) {
+            for (region in dynamic) {
+                val tracker = engine?.query(RegionReferenceData(region.entry.ref()), player) ?: continue
+                result += region to tracker
+            }
+        }
+        return result
+    }
+
+    init {
+        for (region in regions) {
+            val aabb = region.aabb
+            if (aabb == null || region.tracker == null) {
+                dynamic += region
+                continue
+            }
+
+            val span = (aabb.maxChunkX - aabb.minChunkX + 1).toLong() *
+                    (aabb.maxChunkZ - aabb.minChunkZ + 1).toLong()
+            if (span > MAX_INDEXED_CHUNKS) {
+                oversized += region
+                continue
+            }
+
+            val world = chunks.getOrPut(aabb.world) { Long2ObjectOpenHashMap() }
+            for (chunkX in aabb.minChunkX..aabb.maxChunkX) {
+                for (chunkZ in aabb.minChunkZ..aabb.maxChunkZ) {
+                    world.computeIfAbsent(chunkKey(chunkX, chunkZ)) { mutableListOf() }.add(region)
+                }
+            }
+        }
+    }
+
+    /**
+     * The flag of type [type] belonging to the highest priority region that both contains
+     * [position] and carries such a flag, or `null` when no region decides.
+     *
+     * A [player] is needed to resolve variable placement regions. Without one they are skipped.
+     */
+    fun <M : RegionModifierEntry> resolve(type: KClass<M>, position: Position, player: Player?): M? =
+        resolveDecision(type, position, player)?.flag
+
+    /**
+     * The flag of type [type] belonging to the highest priority region that both contains
+     * [position] and carries such a flag, together with the region that decided it.
+     *
+     * A [player] is needed to resolve variable placement regions. Without one they are skipped.
+     *
+     * [decides] filters out flags that have nothing to say about the case at hand, so a narrow
+     * flag on top of a broad one defers to it instead of nullifying it. A damage flag limited
+     * to fall damage must not switch off the hub's blanket flag for lava.
+     */
+    fun <M : RegionModifierEntry> resolveDecision(
+        type: KClass<M>,
+        position: Position,
+        player: Player?,
+        decides: (M) -> Boolean = { true },
+    ): FlagDecision<M>? {
+        val best = bestRegion(type, position, player, decides) ?: return null
+
+        @Suppress("UNCHECKED_CAST")
+        val flag = best.modifiers[type] as M
+        return FlagDecision(flag, best.entry.name, best.priority, best.order)
+    }
+
+    /** Every flagged region containing [position], highest priority first. */
+    internal fun regionsAt(position: Position, player: Player?): List<FlaggedRegion> =
+        candidates(position, player)
+            .filter { (_, tracker) -> tracker.isInside(position) }
+            .map { (region, _) -> region }
+            .sortedWith(compareByDescending<FlaggedRegion> { it.priority }.thenByDescending { it.order })
+
+    private fun <M : RegionModifierEntry> bestRegion(
+        type: KClass<M>,
+        position: Position,
+        player: Player?,
+        decides: (M) -> Boolean,
+    ): FlaggedRegion? {
+        var touched = 0
+        var best: FlaggedRegion? = null
+
+        @Suppress("UNCHECKED_CAST")
+        fun decidingFlag(region: FlaggedRegion): Boolean {
+            val flag = region.modifiers[type] as? M ?: return false
+            return decides(flag)
+        }
+
+        forEachPositionalCandidate(position) { region, tracker ->
+            touched += 1
+            if (decidingFlag(region) && tracker.isInside(position)) {
+                val current = best
+                if (current == null || beats(region, current)) best = region
+            }
+        }
+
+        if (player != null) {
+            for (region in dynamic) {
+                if (!decidingFlag(region)) continue
+                val tracker = engine?.query(RegionReferenceData(region.entry.ref()), player) ?: continue
+                touched += 1
+                if (!tracker.isInside(position)) continue
+                if (best == null || beats(region, best)) best = region
+            }
+        }
+
+        candidatesTouched = touched
+        return best
+    }
+
+    private fun beats(candidate: FlaggedRegion, current: FlaggedRegion): Boolean {
+        if (candidate.priority != current.priority) return candidate.priority > current.priority
+        return candidate.order > current.order
+    }
+}
+
+/**
+ * Whether the flag of type [type] deciding about [position] allows the event, and `true` when no
+ * region decides about it at all.
+ *
+ * A flag whose allowance is bound to a variable cannot answer without a [player], and events like a
+ * crop growing or sand coming to rest have none. Such a flag abstains and the region below it
+ * decides, the same way a region whose placement cannot resolve does. Reading the unresolved
+ * allowance as a denial instead stops every natural process inside the region, whichever way the
+ * variable would have gone, and says so nowhere.
+ */
+fun <M : AllowanceModifierEntry> RegionFlagIndex.allows(
+    type: KClass<M>,
+    position: Position,
+    player: Player?,
+): Boolean {
+    if (player != null) return resolve(type, position, player)?.allowed?.get(player) != false
+    val flag = resolveDecision(type, position, null) { it.allowed.get(null) != null }?.flag ?: return true
+    return flag.allowed.get(null) == true
+}
+
+private fun floorChunk(coordinate: Double): Int = Math.floorDiv(Math.floor(coordinate).toInt(), 16)
+
+private fun chunkKey(chunkX: Int, chunkZ: Int): Long =
+    (chunkX.toLong() shl 32) or (chunkZ.toLong() and 0xFFFFFFFFL)

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/flag/RegionFlagManager.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/flag/RegionFlagManager.kt
@@ -1,0 +1,266 @@
+package com.typewritermc.region.flag
+
+import com.typewritermc.core.entries.Query
+import com.typewritermc.core.entries.priority
+import com.typewritermc.core.entries.ref
+import com.typewritermc.core.extension.Initializable
+import com.typewritermc.core.extension.annotations.Singleton
+import com.typewritermc.engine.paper.entry.entries.get
+import com.typewritermc.engine.paper.logger
+import com.typewritermc.engine.paper.plugin
+import com.typewritermc.engine.paper.utils.server
+import com.typewritermc.region.RegionEngine
+import com.typewritermc.region.data.RegionDefinitionEntry
+import com.typewritermc.region.data.buildShapeOrNull
+import com.typewritermc.region.data.hasConstPlacement
+import com.typewritermc.region.entries.modifier.AllowanceModifierEntry
+import com.typewritermc.region.entries.modifier.BlockBreakModifierEntry
+import com.typewritermc.region.entries.modifier.BlockBreakModifierHandler
+import com.typewritermc.region.entries.modifier.BlockInteractModifierEntry
+import com.typewritermc.region.entries.modifier.BlockInteractModifierHandler
+import com.typewritermc.region.entries.modifier.BlockPlaceModifierEntry
+import com.typewritermc.region.entries.modifier.BlockPlaceModifierHandler
+import com.typewritermc.region.entries.modifier.BucketModifierEntry
+import com.typewritermc.region.entries.modifier.BucketModifierHandler
+import com.typewritermc.region.entries.modifier.CombatModifierHandler
+import com.typewritermc.region.entries.modifier.EntityDamageModifierEntry
+import com.typewritermc.region.entries.modifier.EntityDamageModifierHandler
+import com.typewritermc.region.entries.modifier.EntityInteractModifierEntry
+import com.typewritermc.region.entries.modifier.EntityInteractModifierHandler
+import com.typewritermc.region.entries.modifier.ExplosionModifierEntry
+import com.typewritermc.region.entries.modifier.ExplosionModifierHandler
+import com.typewritermc.region.entries.modifier.FireSpreadModifierEntry
+import com.typewritermc.region.entries.modifier.FireSpreadModifierHandler
+import com.typewritermc.region.entries.modifier.FluidFlowModifierEntry
+import com.typewritermc.region.entries.modifier.FluidFlowModifierHandler
+import com.typewritermc.region.entries.modifier.IgniteModifierEntry
+import com.typewritermc.region.entries.modifier.IgniteModifierHandler
+import com.typewritermc.region.entries.modifier.MobDamageModifierEntry
+import com.typewritermc.region.entries.modifier.MobGriefModifierEntry
+import com.typewritermc.region.entries.modifier.MobGriefModifierHandler
+import com.typewritermc.region.entries.modifier.MobSpawnModifierEntry
+import com.typewritermc.region.entries.modifier.MobSpawnModifierHandler
+import com.typewritermc.region.entries.modifier.PistonModifierEntry
+import com.typewritermc.region.entries.modifier.PistonModifierHandler
+import com.typewritermc.region.entries.modifier.PlayerDamageModifierEntry
+import com.typewritermc.region.entries.modifier.PvpModifierEntry
+import com.typewritermc.region.entries.modifier.RedstoneModifierEntry
+import com.typewritermc.region.entries.modifier.RedstoneModifierHandler
+import com.typewritermc.region.entries.modifier.RegionModifierEntry
+import com.typewritermc.region.entries.modifier.TrampleModifierEntry
+import com.typewritermc.region.entries.modifier.TrampleModifierHandler
+import com.typewritermc.region.tracker.RegionTracker
+import org.bukkit.event.HandlerList
+import org.bukkit.event.Listener
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import kotlin.reflect.KClass
+
+/**
+ * Owns the region flags: which regions carry which rules, and the one handler per rule that
+ * enforces them.
+ *
+ * Exactly one handler is created per flag type that is actually used, however many regions use it,
+ * and none at all for a type nobody uses. An unused redstone flag therefore costs nothing on a
+ * redstone tick: its listener is never registered.
+ */
+@Singleton
+class RegionFlagManager : Initializable, KoinComponent {
+    private val engine: RegionEngine by inject()
+
+    @Volatile
+    var index: RegionFlagIndex? = null
+        private set
+
+    private val handlers = mutableListOf<Listener>()
+
+    override suspend fun initialize() {
+        val regions = buildFlaggedRegions(Query.find<RegionDefinitionEntry>().toList())
+        val flagIndex = RegionFlagIndex(regions, engine)
+        index = flagIndex
+
+        for ((name, flag) in viewerlessFlagsOnDynamicRegions(regions, VIEWERLESS_FLAGS)) {
+            logger.warning(
+                "Region '$name' carries the flag '$flag', but its placement is bound to a variable. " +
+                        "That flag decides about events with no player behind them, which cannot resolve a " +
+                        "per viewer region, so it will never apply. Give the region a constant placement, or " +
+                        "remove the flag."
+            )
+        }
+
+        for ((name, flag) in viewerlessFlagsOnDynamicRegions(regions, PARTLY_VIEWERLESS_FLAGS)) {
+            logger.warning(
+                "Region '$name' carries the flag '$flag', but its placement is bound to a variable. " +
+                        "That flag usually decides about events with a player behind them, but not always. " +
+                        "On a per viewer region it applies only when a player is behind the event, and never " +
+                        "otherwise, because the region cannot resolve without one. Give the region a constant " +
+                        "placement to cover every case, or accept the gap."
+            )
+        }
+
+        for ((name, flag) in variableAllowancesOnViewerlessFlags(regions)) {
+            logger.warning(
+                "Region '$name' carries the flag '$flag' with its allowance bound to a variable. " +
+                        "A variable needs a player to resolve, and events like a crop growing or sand " +
+                        "coming to rest have none, so the flag abstains for those and whatever region " +
+                        "sits below it decides instead. Give the allowance a constant value to cover " +
+                        "every case, or accept the gap."
+            )
+        }
+
+        val used = regions.flatMap { it.modifiers.keys }.toSet()
+        for (factory in used.mapNotNull { handlerFactories[it] }.distinct()) {
+            val handler = factory(flagIndex)
+            server.pluginManager.registerEvents(handler, plugin)
+            handlers += handler
+        }
+    }
+
+    override suspend fun shutdown() {
+        handlers.forEach { HandlerList.unregisterAll(it) }
+        handlers.clear()
+        index = null
+    }
+}
+
+/**
+ * The regions that carry at least one flag, ordered by entry id.
+ *
+ * The order breaks ties between regions of equal priority, so it has to be the same on every
+ * server and across every restart. Load order is not: pages are read in the order the filesystem
+ * lists them, which is unspecified and shifts as pages are added. Sorting by id makes the winner
+ * of a tie arbitrary but fixed, rather than something that can flip on a restart and quietly
+ * reverse whether a region allows building.
+ *
+ * A constant placement region is resolved into a tracker right away, which gives the transform, the
+ * shape and the containment test without registering anything with the engine. A variable placement
+ * region cannot be resolved without a viewer, so it gets no tracker and no AABB and is resolved per
+ * player at lookup time.
+ */
+internal fun buildFlaggedRegions(entries: List<RegionDefinitionEntry>): List<FlaggedRegion> =
+    entries.sortedBy { it.id }.mapIndexedNotNull { order, entry ->
+        val resolved = entry.modifiers.mapNotNull { it.get() }
+        // A flag reference that no longer resolves means the entry was deleted on the web, and
+        // dropping it in silence unprotects the region without saying so anywhere. Said before the
+        // guards below, because deleting the last flag a region carried is exactly the case they
+        // drop, and the case a builder most needs to hear about.
+        val missing = entry.modifiers.size - resolved.size
+        if (missing > 0) {
+            logger.warning(
+                "Region '${entry.name}' points at $missing flag entr${if (missing == 1) "y" else "ies"} " +
+                        "that no longer exist. Whatever they protected is not protected any more."
+            )
+        }
+        val modifiers = resolved.associateBy { it::class }
+        if (modifiers.isEmpty()) return@mapIndexedNotNull null
+        if (entry.buildShapeOrNull() == null) return@mapIndexedNotNull null
+
+        // Two flags of the same type on one region cannot both decide, and the winner is
+        // whichever the builder happened to list last. Saying so beats a region that quietly
+        // ignores half of what the panel shows on it. Only worth saying for a region that
+        // enforces anything at all, which is why it sits below the guards.
+        for (duplicate in resolved.groupBy { it::class }.values.filter { it.size > 1 }) {
+            logger.warning(
+                "Region '${entry.name}' carries ${duplicate.size} flags of the same kind. " +
+                        "Only '${duplicate.last().name}' decides."
+            )
+        }
+
+        val tracker = if (entry.hasConstPlacement) RegionTracker(null, entry).also { it.refresh() } else null
+        FlaggedRegion(
+            entry = entry,
+            priority = entry.ref().priority,
+            order = order,
+            modifiers = modifiers,
+            tracker = tracker,
+            aabb = tracker?.cachedAabb,
+        )
+    }
+
+/**
+ * The (region name, flag name) pairs where a flag that decides about viewerless events sits on a
+ * region that only exists per viewer. Such a flag can never apply, and it is reported so the
+ * region does not fail in silence.
+ */
+internal fun viewerlessFlagsOnDynamicRegions(
+    regions: List<FlaggedRegion>,
+    viewerless: Set<KClass<out RegionModifierEntry>>,
+): List<Pair<String, String>> = regions
+    .filter { it.tracker == null }
+    .flatMap { region ->
+        region.modifiers
+            .filterKeys { it in viewerless }
+            .map { (_, flag) -> region.entry.name to flag.name }
+    }
+
+/**
+ * The flags that decide about events with no player behind them and whose allowance cannot resolve
+ * without one, with the region carrying them.
+ *
+ * Elsewhere a player is always there to resolve the variable, so only the partly viewerless flags
+ * are listed.
+ */
+internal fun variableAllowancesOnViewerlessFlags(regions: List<FlaggedRegion>): List<Pair<String, String>> =
+    regions.flatMap { region ->
+        region.modifiers
+            .filterKeys { it in PARTLY_VIEWERLESS_FLAGS }
+            .values
+            .filterIsInstance<AllowanceModifierEntry>()
+            .filter { it.allowed.get(null) == null }
+            .map { region.entry.name to it.name }
+    }
+
+/** The flags whose events have no player behind them, so they cannot resolve a per viewer region. */
+internal val VIEWERLESS_FLAGS: Set<KClass<out RegionModifierEntry>> = setOf(
+    PistonModifierEntry::class,
+    RedstoneModifierEntry::class,
+    FireSpreadModifierEntry::class,
+    FluidFlowModifierEntry::class,
+    ExplosionModifierEntry::class,
+    MobSpawnModifierEntry::class,
+    MobGriefModifierEntry::class,
+)
+
+/**
+ * The flags whose events usually have a player behind them, but sometimes do not: a zombie or an
+ * explosion can trigger the same event as a punch. On a per viewer region, such a flag applies
+ * only to the occurrences that do have a player behind them, and silently does not to the rest,
+ * since the region cannot resolve without one.
+ */
+internal val PARTLY_VIEWERLESS_FLAGS: Set<KClass<out RegionModifierEntry>> = setOf(
+    EntityDamageModifierEntry::class,
+    BucketModifierEntry::class,
+    IgniteModifierEntry::class,
+    BlockPlaceModifierEntry::class,
+    BlockBreakModifierEntry::class,
+    BlockInteractModifierEntry::class,
+    TrampleModifierEntry::class,
+)
+
+/** The three flags about a player being hurt share one handler, which weighs them against each other. */
+private val combatHandler: (RegionFlagIndex) -> Listener = { index -> CombatModifierHandler(index) }
+
+/**
+ * The handler for each flag type. Only the types a region actually uses are ever registered, and
+ * a handler shared by several types is registered once.
+ */
+internal val handlerFactories: Map<KClass<out RegionModifierEntry>, (RegionFlagIndex) -> Listener> = mapOf(
+    BlockBreakModifierEntry::class to { index -> BlockBreakModifierHandler(index) },
+    BlockPlaceModifierEntry::class to { index -> BlockPlaceModifierHandler(index) },
+    BlockInteractModifierEntry::class to { index -> BlockInteractModifierHandler(index) },
+    EntityInteractModifierEntry::class to { index -> EntityInteractModifierHandler(index) },
+    PistonModifierEntry::class to { index -> PistonModifierHandler(index) },
+    RedstoneModifierEntry::class to { index -> RedstoneModifierHandler(index) },
+    FireSpreadModifierEntry::class to { index -> FireSpreadModifierHandler(index) },
+    FluidFlowModifierEntry::class to { index -> FluidFlowModifierHandler(index) },
+    ExplosionModifierEntry::class to { index -> ExplosionModifierHandler(index) },
+    MobSpawnModifierEntry::class to { index -> MobSpawnModifierHandler(index) },
+    MobGriefModifierEntry::class to { index -> MobGriefModifierHandler(index) },
+    PvpModifierEntry::class to combatHandler,
+    MobDamageModifierEntry::class to combatHandler,
+    PlayerDamageModifierEntry::class to combatHandler,
+    BucketModifierEntry::class to { index -> BucketModifierHandler(index) },
+    EntityDamageModifierEntry::class to { index -> EntityDamageModifierHandler(index) },
+    TrampleModifierEntry::class to { index -> TrampleModifierHandler(index) },
+    IgniteModifierEntry::class to { index -> IgniteModifierHandler(index) },
+)

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/handler/RegionHandler.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/handler/RegionHandler.kt
@@ -1,0 +1,427 @@
+package com.typewritermc.region.handler
+
+import com.google.common.collect.Sets
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.region.data.CrossingCause
+import com.typewritermc.region.data.DistanceMode
+import org.bukkit.entity.Player
+import org.bukkit.event.player.PlayerMoveEvent
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.math.abs
+
+/**
+ * The subscription kinds a region tracker supports. The attached handlers decide what the
+ * tracker dispatches. A tracker with only [LazyInsideQueryHandler]s does no event work and
+ * only resolves geometry on demand.
+ *
+ * Each handler owns its own membership state. Two handlers on the same region can use
+ * different [boundaryInset][EnterExitHandler.boundaryInset] values without affecting each
+ * other.
+ *
+ * A handler with a non null [tracked] only reacts to that one player. Audience filters use
+ * this to keep per player state on a shared tracker. Event entry handlers pass `null` to
+ * react to all players.
+ */
+sealed interface RegionHandler {
+    val owner: Any
+
+    /**
+     * When non null, this handler only reacts to classifications of the player with this
+     * UUID. Classifications of other players are ignored.
+     */
+    val tracked: UUID?
+
+    /**
+     * Called by the tracker for every player observed during a dispatch. [signedDistance]
+     * is `null` when the player is in a different world than the tracker's resolved
+     * transform or went offline.
+     *
+     * Returns `true` when a fired callback requests cancellation of the Bukkit event. The
+     * engine only honors the request when [moveEvent] is non null. [CrossingCause.ENGULFED]
+     * dispatches have no event to cancel and the result is ignored there.
+     *
+     * [CrossingCause.PLAYER_MOVED] and [CrossingCause.TELEPORTED] dispatches run on the
+     * server main thread. [CrossingCause.ENGULFED] dispatches run on
+     * `Dispatchers.UntickedAsync`. Callbacks that touch world state or entity velocity must
+     * hop to `Dispatchers.Sync` unless already on the main thread.
+     */
+    fun onClassification(
+        player: Player,
+        signedDistance: Double?,
+        cause: CrossingCause,
+        moveEvent: PlayerMoveEvent?,
+    ): Boolean
+
+    /**
+     * Updates membership without firing callbacks. The engine calls this after cancelling
+     * a move, resyncing every touched handler against the player's pre move position so no
+     * handler is left believing the movement happened.
+     */
+    fun resync(player: Player, signedDistance: Double?)
+
+    /**
+     * Records that the crossing just dispatched was refused, so the handler stops firing for
+     * [player] until they settle on one side of the boundary again.
+     *
+     * The engine calls this on every handler it touched during a cancelled move, not only the
+     * ones that asked to cancel. A cancelled move is rolled back for all of them, and without
+     * this the rollback simply arms the same crossing again for the next move: a player leaning
+     * on the boundary would fire the whole pipeline twenty times a second.
+     *
+     * A handler refused this way keeps answering what it answered before. Answering "cancel"
+     * on behalf of a handler that never asked to would have every audience filter and every
+     * uncancelled enter event start blocking movement.
+     */
+    fun refuse(player: Player)
+
+    /**
+     * Drops any refusal recorded for [player]. The engine calls this once a move of theirs
+     * completes, since nothing is left rolled back at that point.
+     */
+    fun clearRefusal(player: Player)
+
+    /**
+     * `true` when this handler currently considers [player] a member of the region or
+     * band.
+     */
+    fun tracks(player: Player): Boolean
+}
+
+/**
+ * Reaction to a crossing. Return `true` to request cancellation of the Bukkit event that
+ * caused the crossing. The request is only honored when a move event is present.
+ */
+typealias CrossingCallback = (player: Player, cause: CrossingCause, moveEvent: PlayerMoveEvent?) -> Boolean
+
+/**
+ * Told the membership a [RegionHandler.resync] settled on, whenever that differs from what the
+ * handler was holding.
+ *
+ * A cancelled move is rolled back for every handler it touched, the ones whose callback already ran
+ * included. A subscriber that pushes state from its callback, like an audience filter, is left
+ * holding the value of a crossing that is being taken away and has no other way to hear about it:
+ * the player is put back where they came from, so no later crossing corrects it either.
+ *
+ * Enter and exit event entries pass nothing here. A crossing that was refused fires no triggers.
+ */
+typealias MembershipCallback = (player: Player, member: Boolean) -> Unit
+
+/**
+ * Fires enter and leave callbacks for one region. The enter fires the moment the boundary
+ * is crossed, matching what the visualize command and the debug command report as inside.
+ * A member must then move more than [boundaryInset] blocks clear of the region before the
+ * leave fires, which prevents repeat fires from a player walking along the boundary. A
+ * value of `0.0` fires the leave on the exact boundary.
+ */
+class EnterExitHandler(
+    override val owner: Any,
+    override val tracked: UUID? = null,
+    val boundaryInset: Var<Double> = ConstVar(0.0),
+    private val onEnter: CrossingCallback = NOOP,
+    private val onLeave: CrossingCallback = NOOP,
+    private val onResync: MembershipCallback = NO_MEMBERSHIP,
+) : RegionHandler {
+    private val members: MutableSet<UUID> = Sets.newConcurrentHashSet()
+    private val refused = RefusedCrossings()
+
+    override fun onClassification(
+        player: Player,
+        signedDistance: Double?,
+        cause: CrossingCause,
+        moveEvent: PlayerMoveEvent?,
+    ): Boolean {
+        if (tracked != null && player.uniqueId != tracked) return false
+        val uuid = player.uniqueId
+        // Only a dispatch that can be rolled back records a crossing, so only one may forget the
+        // last. An engulf landing between a move's dispatch and its resync would otherwise erase
+        // the crossing the resync is about to refuse, and the crossing fires again next tick.
+        if (rollsBack(cause, moveEvent)) refused.forgetCrossing(uuid)
+        if (signedDistance == null) {
+            refused.clear(uuid)
+            return members.remove(uuid) && onLeave(player, cause, moveEvent)
+        }
+        val wasInside = uuid in members
+        val nowInside = isInside(player, signedDistance, wasInside)
+        // The verdict is asked for before the no change test. A cancelled move puts the player back
+        // where they crossed from, and a body wide enough to overlap the region already stands
+        // there, so the attempt they are repeating does not read as a change at all. Without
+        // this the refusal holds once and the next step through is let past.
+        refused.verdictFor(uuid, cause, nowInside)?.let { return it }
+        if (nowInside == wasInside) return false
+        // A crossing nothing can undo settles the question a held refusal was keeping open: the
+        // region reached the player, so they are on the side they were being kept from whatever
+        // the handler answered. Leaving the refusal in place there cancels every move they make
+        // from inside it, the one that would carry them back out included.
+        val stands = !rollsBack(cause, moveEvent)
+        if (stands) refused.clear(uuid) else refused.crossed(uuid, nowInside)
+
+        // The membership sets decide who fires: the move listener and the async reconcile can
+        // classify the same player at once, and only one of them may call the callback.
+        //
+        // A refused crossing puts the membership back where it was, because the crossing itself
+        // is about to be undone. Only a crossing the engine can actually undo is taken back, and
+        // only that one is remembered, so a crossing that stood does not answer for the next move.
+        if (nowInside) {
+            if (!members.add(uuid)) return false
+            if (!onEnter(player, cause, moveEvent)) return false
+            if (stands) return true
+            members.remove(uuid)
+            refused.recordCancelled(uuid, attempted = true)
+            return true
+        }
+        if (!members.remove(uuid)) return false
+        if (!onLeave(player, cause, moveEvent)) return false
+        if (stands) return true
+        members.add(uuid)
+        refused.recordCancelled(uuid, attempted = false)
+        return true
+    }
+
+    override fun resync(player: Player, signedDistance: Double?) {
+        if (tracked != null && player.uniqueId != tracked) return
+        val uuid = player.uniqueId
+        if (signedDistance == null) {
+            if (members.remove(uuid)) onResync(player, false)
+            return
+        }
+        // A held refusal decides the side, not the geometry. The player is left standing where
+        // their body still overlaps the region, and deriving again membership from that would put
+        // them straight back on the side they were just refused from.
+        val refusedSide = refused.attemptedSide(uuid)
+        val wasInside = uuid in members
+        val nowInside = refusedSide?.not() ?: isInside(player, signedDistance, wasInside)
+        val changed = if (nowInside) members.add(uuid) else members.remove(uuid)
+        if (changed) onResync(player, nowInside)
+    }
+
+    override fun refuse(player: Player) {
+        if (tracked != null && player.uniqueId != tracked) return
+        refused.recordRolledBack(player.uniqueId)
+    }
+
+    override fun clearRefusal(player: Player) {
+        refused.clear(player.uniqueId)
+    }
+
+    private fun isInside(player: Player, signedDistance: Double, wasInside: Boolean): Boolean {
+        if (!wasInside) return signedDistance <= 0.0
+        return signedDistance <= boundaryInset.get(player).coerceAtLeast(0.0)
+    }
+
+    override fun tracks(player: Player): Boolean = player.uniqueId in members
+}
+
+/**
+ * Fires callbacks when a player enters or leaves the band around the region's boundary.
+ * The band is `|signedDistance| <= distance`. Entering the band fires the moment that
+ * threshold is crossed. [boundaryInset] widens the threshold to leave the band, so a
+ * player walking along the band edge does not retrigger.
+ *
+ * [distanceMode] selects how the distance to the boundary is measured. A horizontal band
+ * has no vertical bound, and neither it nor a non const [distance] can contribute to the
+ * tracker's AABB margin (see [RegionTracker.marginUnbounded][com.typewritermc.region.tracker.RegionTracker]).
+ */
+class ProximityHandler(
+    override val owner: Any,
+    override val tracked: UUID? = null,
+    val distance: Var<Double>,
+    val distanceMode: DistanceMode = DistanceMode.FULL,
+    val boundaryInset: Var<Double> = ConstVar(0.0),
+    private val onEnterBand: CrossingCallback = NOOP,
+    private val onLeaveBand: CrossingCallback = NOOP,
+    private val onResync: MembershipCallback = NO_MEMBERSHIP,
+) : RegionHandler {
+    private val members: MutableSet<UUID> = Sets.newConcurrentHashSet()
+    private val refused = RefusedCrossings()
+
+    override fun onClassification(
+        player: Player,
+        signedDistance: Double?,
+        cause: CrossingCause,
+        moveEvent: PlayerMoveEvent?,
+    ): Boolean {
+        if (tracked != null && player.uniqueId != tracked) return false
+        val uuid = player.uniqueId
+        // See EnterExitHandler: an engulf never recorded a crossing, so it must not forget one.
+        if (rollsBack(cause, moveEvent)) refused.forgetCrossing(uuid)
+        if (signedDistance == null) {
+            refused.clear(uuid)
+            return members.remove(uuid) && onLeaveBand(player, cause, moveEvent)
+        }
+        val wasInBand = uuid in members
+        val nowInBand = inBand(player, signedDistance, wasInBand)
+        // See EnterExitHandler: the position a cancelled move is rolled back to can still be one
+        // this band covers, so the attempt has to be recognised by the side it was heading for
+        // rather than by looking like a change.
+        refused.verdictFor(uuid, cause, nowInBand)?.let { return it }
+        if (nowInBand == wasInBand) return false
+        // See EnterExitHandler: a band the region moved onto the player settles the refusal it
+        // finds there, rather than holding them to a crossing that already happened to them.
+        val stands = !rollsBack(cause, moveEvent)
+        if (stands) refused.clear(uuid) else refused.crossed(uuid, nowInBand)
+
+        if (nowInBand) {
+            if (!members.add(uuid)) return false
+            if (!onEnterBand(player, cause, moveEvent)) return false
+            if (stands) return true
+            members.remove(uuid)
+            refused.recordCancelled(uuid, attempted = true)
+            return true
+        }
+        if (!members.remove(uuid)) return false
+        if (!onLeaveBand(player, cause, moveEvent)) return false
+        if (stands) return true
+        members.add(uuid)
+        refused.recordCancelled(uuid, attempted = false)
+        return true
+    }
+
+    override fun resync(player: Player, signedDistance: Double?) {
+        if (tracked != null && player.uniqueId != tracked) return
+        val uuid = player.uniqueId
+        if (signedDistance == null) {
+            if (members.remove(uuid)) onResync(player, false)
+            return
+        }
+        val refusedSide = refused.attemptedSide(uuid)
+        val wasInBand = uuid in members
+        val nowInBand = refusedSide?.not() ?: inBand(player, signedDistance, wasInBand)
+        val changed = if (nowInBand) members.add(uuid) else members.remove(uuid)
+        if (changed) onResync(player, nowInBand)
+    }
+
+    override fun refuse(player: Player) {
+        if (tracked != null && player.uniqueId != tracked) return
+        refused.recordRolledBack(player.uniqueId)
+    }
+
+    override fun clearRefusal(player: Player) {
+        refused.clear(player.uniqueId)
+    }
+
+    private fun inBand(player: Player, signedDistance: Double, wasInBand: Boolean): Boolean {
+        val band = distance.get(player).coerceAtLeast(0.0)
+        if (!wasInBand) return abs(signedDistance) <= band
+        val inset = boundaryInset.get(player).coerceAtLeast(0.0)
+        return abs(signedDistance) <= band + inset
+    }
+
+    override fun tracks(player: Player): Boolean = player.uniqueId in members
+}
+
+/**
+ * A handler that fires no events and tracks no membership. It only keeps the tracker alive
+ * so the holder can query the resolved shape and transform on demand.
+ */
+class LazyInsideQueryHandler(
+    override val owner: Any,
+    override val tracked: UUID? = null,
+) : RegionHandler {
+    override fun onClassification(
+        player: Player,
+        signedDistance: Double?,
+        cause: CrossingCause,
+        moveEvent: PlayerMoveEvent?,
+    ): Boolean = false
+
+    override fun resync(player: Player, signedDistance: Double?) = Unit
+
+    override fun refuse(player: Player) = Unit
+
+    override fun clearRefusal(player: Player) = Unit
+
+    override fun tracks(player: Player): Boolean = false
+}
+
+/**
+ * The players whose last crossing of one handler's boundary was rolled back: which side they
+ * were trying to reach, and what this handler answered at the time.
+ *
+ * The verdict is kept rather than assumed, because the engine refuses every handler it
+ * touched during a cancelled move and most of those never asked to cancel anything.
+ *
+ * The side matters as much as the answer. A cancelled move leaves the player standing where
+ * they crossed from, which for a body sized membership test is often a spot the region still
+ * counts as inside, so the refused crossing does not look like a change when they push again.
+ * Holding the side lets the handler recognise the attempt for what it is, and lets go the
+ * moment the player settles on the side they were sent back to.
+ */
+private class RefusedCrossings {
+    private val verdicts = ConcurrentHashMap<UUID, Refusal>()
+    private val crossings = ConcurrentHashMap<UUID, Boolean>()
+
+    /**
+     * What this handler should answer for a player now classified [nowInside], or `null` when
+     * it should classify afresh.
+     */
+    fun verdictFor(uuid: UUID, cause: CrossingCause, nowInside: Boolean): Boolean? {
+        // Nothing to roll back, so the crossing stands and answers for itself. The refusal
+        // stays: it belongs to the move the player is still pushing against, and the side test
+        // below decides when it is spent. Dropped here, an engulf landing mid dispatch would
+        // release the refusal with it. An engulf that does carry the player across drops it from
+        // the crossing itself, the only place the difference between the two is visible.
+        if (!cause.revocable) return null
+        val refusal = verdicts[uuid] ?: return null
+        // The player settled on the side the rollback sent them to, so the attempt is over.
+        if (nowInside != refusal.attempted) {
+            verdicts.remove(uuid)
+            return null
+        }
+        return refusal.cancel
+    }
+
+    /** The side a held refusal was trying to reach, or `null` when none is held. */
+    fun attemptedSide(uuid: UUID): Boolean? = verdicts[uuid]?.attempted
+
+    /** Remembers that this handler classified a crossing towards [nowInside] on this dispatch. */
+    fun crossed(uuid: UUID, nowInside: Boolean) {
+        crossings[uuid] = nowInside
+    }
+
+    /** Forgets the crossing of the previous dispatch, before this one classifies. */
+    fun forgetCrossing(uuid: UUID) {
+        crossings.remove(uuid)
+    }
+
+    /** This handler asked for the crossing to be cancelled, and stands by that answer. */
+    fun recordCancelled(uuid: UUID, attempted: Boolean) {
+        verdicts[uuid] = Refusal(attempted, cancel = true)
+    }
+
+    /**
+     * Another handler had the crossing cancelled, so this one's own reaction was rolled back
+     * with it. It must not fire again, and must not start cancelling moves either.
+     *
+     * Only a handler that actually crossed on this dispatch is refused. The engine refuses every
+     * handler on every tracker it touched, and a handler that saw no change has nothing to be
+     * held to: answering for its next crossing would drop a leave it never made.
+     */
+    fun recordRolledBack(uuid: UUID) {
+        val attempted = crossings[uuid] ?: return
+        verdicts.putIfAbsent(uuid, Refusal(attempted, cancel = false))
+    }
+
+    fun clear(uuid: UUID) {
+        verdicts.remove(uuid)
+        crossings.remove(uuid)
+    }
+
+    private data class Refusal(val attempted: Boolean, val cancel: Boolean)
+}
+
+/**
+ * Whether a refused crossing of [cause] will actually be undone.
+ *
+ * The cause has to be one the engine can revoke, and there has to be a Bukkit event to revoke it
+ * with. A player riding across the boundary is a [CrossingCause.PLAYER_MOVED] with no event: a
+ * vehicle's movement cannot be refused, so that crossing stands however the handler answered, and
+ * taking the membership back would leave the region believing they never came in.
+ */
+private fun rollsBack(cause: CrossingCause, moveEvent: PlayerMoveEvent?): Boolean =
+    cause.revocable && moveEvent != null
+
+private val NOOP: CrossingCallback = { _, _, _ -> false }
+
+private val NO_MEMBERSHIP: MembershipCallback = { _, _ -> }

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/shape/BoundarySampling.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/shape/BoundarySampling.kt
@@ -1,0 +1,27 @@
+package com.typewritermc.region.shape
+
+import com.typewritermc.core.utils.point.Vector
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+/**
+ * Fibonacci sphere distribution of [count] points on the unit sphere. Each point is scaled
+ * componentwise by [scale]. A scale of `(r, r, r)` samples a sphere and `(rx, ry, rz)`
+ * samples an ellipsoid.
+ */
+internal fun fibonacciSphereSamples(count: Int, scale: Vector): Sequence<Vector> = sequence {
+    if (count <= 0) {
+        yield(Vector.ZERO)
+        return@sequence
+    }
+    val golden = PI * (3.0 - sqrt(5.0))
+    val denom = (count - 1).coerceAtLeast(1).toDouble()
+    for (i in 0 until count) {
+        val y = 1.0 - (i.toDouble() / denom) * 2.0
+        val r = sqrt(1.0 - y * y)
+        val theta = golden * i
+        yield(Vector(cos(theta) * r * scale.x, y * scale.y, sin(theta) * r * scale.z))
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/shape/CapsuleShape.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/shape/CapsuleShape.kt
@@ -1,0 +1,119 @@
+package com.typewritermc.region.shape
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.AlgebraicTypeInfo
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.core.extension.annotations.Min
+import com.typewritermc.core.utils.point.Vector
+import kotlin.math.*
+
+/**
+ * Capsule aligned with the local Y axis: two hemispheres of [radius] capped on a cylinder
+ * of half height [halfHeight]. Total length along Y is `2 * (halfHeight + radius)`.
+ */
+@AlgebraicTypeInfo("capsule_shape", Colors.PURPLE, "mdi:pill")
+data class CapsuleShape(
+    @Min(0)
+    @Help("Radius of the capsule, both of its rounded ends and of the column between them.")
+    @Default("1.0")
+    val radius: Double = 1.0,
+    @Min(0)
+    @Help("Distance from the center to where each rounded end begins, before the radius is added.")
+    @Default("1.0")
+    val halfHeight: Double = 1.0,
+) : Shape {
+    init {
+        require(radius >= 0.0 && halfHeight >= 0.0) {
+            "Capsule dimensions must be non-negative, were (radius=$radius, halfHeight=$halfHeight)"
+        }
+    }
+
+    override val usable: Boolean get() = radius > 0.0
+
+    override val localBounds: LocalBounds
+        get() = LocalBounds(-radius, -(halfHeight + radius), -radius, radius, halfHeight + radius, radius)
+
+    private fun spineY(y: Double): Double = y.coerceIn(-halfHeight, halfHeight)
+
+    override fun contains(localLoc: Vector): Boolean {
+        val dy = localLoc.y - spineY(localLoc.y)
+        return localLoc.x * localLoc.x + dy * dy + localLoc.z * localLoc.z <= radius * radius
+    }
+
+    override fun signedDistance(localLoc: Vector): Double {
+        val dy = localLoc.y - spineY(localLoc.y)
+        val d = sqrt(localLoc.x * localLoc.x + dy * dy + localLoc.z * localLoc.z)
+        return d - radius
+    }
+
+    override fun signedDistanceHorizontal(localLoc: Vector): Double =
+        sqrt(localLoc.x * localLoc.x + localLoc.z * localLoc.z) - radius
+
+    override fun nearestOutside(localLoc: Vector): Vector {
+        val spine = spineRelative(localLoc)
+        if (spine.len < Vector.EPSILON) return Vector(radius, spine.sy, 0.0)
+        val scale = radius / spine.len
+        return Vector(spine.dx * scale, spine.sy + spine.dy * scale, spine.dz * scale)
+    }
+
+    override fun outwardNormals(localLoc: Vector): List<Vector> {
+        val spine = spineRelative(localLoc)
+        if (spine.len < Vector.EPSILON) return listOf(Vector(1.0, 0.0, 0.0))
+        return listOf(Vector(spine.dx / spine.len, spine.dy / spine.len, spine.dz / spine.len))
+    }
+
+    /**
+     * The offset of [localLoc] from the nearest point on the capsule's spine segment,
+     * together with the length of that offset.
+     */
+    private fun spineRelative(localLoc: Vector): SpineProjection {
+        val sy = spineY(localLoc.y)
+        val dx = localLoc.x
+        val dy = localLoc.y - sy
+        val dz = localLoc.z
+        return SpineProjection(sy, dx, dy, dz, sqrt(dx * dx + dy * dy + dz * dz))
+    }
+
+    private data class SpineProjection(val sy: Double, val dx: Double, val dy: Double, val dz: Double, val len: Double)
+
+    /**
+     * Samples the cylinder wall on rings whose end rings land exactly on the hemisphere
+     * seams, then each hemisphere in latitude rings. The seam rings belong to the wall, so
+     * the hemispheres start past them, and the pole rings collapse to single points, so no
+     * sample is emitted twice.
+     */
+    override fun sampleBoundary(density: Double): Sequence<Vector> = sequence {
+        if (radius <= 0.0) return@sequence
+        val surfaceArea = 4 * PI * radius * radius + 4 * PI * radius * halfHeight
+        val step = sampleStep(density, surfaceArea)
+        val ringSamples = max(8, (2 * PI * radius / step).toInt())
+        for (y in axisSamples(-halfHeight, halfHeight, step)) {
+            for (i in 0 until ringSamples) {
+                val theta = 2 * PI * i / ringSamples
+                yield(Vector(cos(theta) * radius, y, sin(theta) * radius))
+            }
+        }
+        val slices = max(4, (ringSamples / 4))
+        for (j in 1..slices) {
+            val phi = (PI / 2) * j / slices
+            val r = cos(phi) * radius
+            val cap = sin(phi) * radius
+            if (r < Vector.EPSILON) {
+                yield(Vector(0.0, halfHeight + cap, 0.0))
+                yield(Vector(0.0, -halfHeight - cap, 0.0))
+                continue
+            }
+            // Each ring is sized on its own, like the cone's. Giving a ring near the pole the
+            // equator's count asks for roughly PI/2 times the budget, and the truncation that
+            // follows removes whole samples from one end, so both caps disappear instead of
+            // thinning out.
+            val capSamples = max(4, (2 * PI * r / step).toInt())
+            for (i in 0 until capSamples) {
+                val theta = 2 * PI * i / capSamples
+                yield(Vector(cos(theta) * r, halfHeight + cap, sin(theta) * r))
+                yield(Vector(cos(theta) * r, -halfHeight - cap, sin(theta) * r))
+            }
+        }
+    }.withinSampleBudget()
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/shape/ConeShape.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/shape/ConeShape.kt
@@ -1,0 +1,190 @@
+package com.typewritermc.region.shape
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.AlgebraicTypeInfo
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.core.extension.annotations.Max
+import com.typewritermc.core.extension.annotations.Min
+import com.typewritermc.core.utils.point.Vector
+import kotlin.math.*
+
+/**
+ * Spherical cone (vision cone) aligned with the local +Z axis. Points within angle
+ * [halfAngleDegrees] of +Z and within [length] of the origin are inside.
+ */
+@AlgebraicTypeInfo("cone_shape", Colors.PURPLE, "mdi:cone")
+data class ConeShape(
+    @Min(0)
+    @Help("How far the cone reaches from its point.")
+    @Default("5.0")
+    val length: Double = 5.0,
+    @Min(1)
+    @Max(89)
+    @Help("Half-angle of the cone in degrees. A wider angle opens the cone; 89 is nearly a half sphere.")
+    @Default("30.0")
+    val halfAngleDegrees: Double = 30.0,
+) : Shape {
+    init {
+        require(length >= 0.0) { "Cone length must be non-negative, was $length" }
+        require(halfAngleDegrees in 0.0..90.0) {
+            "Cone half-angle must be in [0, 90] degrees, was $halfAngleDegrees"
+        }
+    }
+
+    private val halfAngleRad: Double get() = Math.toRadians(halfAngleDegrees)
+    private val rimRadius: Double get() = length * sin(halfAngleRad)
+
+    override val usable: Boolean get() = length > 0.0 && halfAngleDegrees > 0.0
+
+    override val localBounds: LocalBounds
+        get() = LocalBounds(-rimRadius, -rimRadius, 0.0, rimRadius, rimRadius, length)
+
+    override fun contains(localLoc: Vector): Boolean {
+        val r = sqrt(localLoc.x * localLoc.x + localLoc.y * localLoc.y + localLoc.z * localLoc.z)
+        if (r > length) return false
+        if (r < Vector.EPSILON) return true
+        val cosAngle = localLoc.z / r
+        return cosAngle >= cos(halfAngleRad)
+    }
+
+    override fun signedDistance(localLoc: Vector): Double {
+        val projection = project(localLoc)
+        return if (contains(localLoc)) -projection.distance else projection.distance
+    }
+
+    /**
+     * Exact because the cone is axisymmetric about +Z: the silhouette equals the Y = 0
+     * slice, and the nearest cone point to a point in that plane stays in that plane.
+     */
+    override fun signedDistanceHorizontal(localLoc: Vector): Double =
+        signedDistance(Vector(localLoc.x, 0.0, localLoc.z))
+
+    override fun nearestOutside(localLoc: Vector): Vector = project(localLoc).point
+
+    override fun outwardNormals(localLoc: Vector): List<Vector> = listOf(project(localLoc).normal)
+
+    /**
+     * The nearest point on the cone's boundary, its distance, and the outward normal there.
+     *
+     * The boundary has four features and each one owns a region of space: the spherical cap
+     * closing the far end, the lateral surface running from the apex to the rim, the rim
+     * circle where those two meet, and the apex itself. Which feature is nearest decides all
+     * three answers, so they are computed together rather than rediscovered per method.
+     * A lateral normal reported for a point past the cap would send a KeepIn barrier's push
+     * along the cone's axis, away from the region, instead of back into it.
+     */
+    private fun project(localLoc: Vector): ConeProjection {
+        val horizontal = sqrt(localLoc.x * localLoc.x + localLoc.y * localLoc.y)
+        val radius = sqrt(horizontal * horizontal + localLoc.z * localLoc.z)
+        if (radius < Vector.EPSILON) return ConeProjection(0.0, Vector.ZERO, Vector(0.0, 0.0, -1.0))
+
+        // Any meridian will do on the axis: the cone is symmetric about it.
+        val meridianX = if (horizontal < Vector.EPSILON) 1.0 else localLoc.x / horizontal
+        val meridianY = if (horizontal < Vector.EPSILON) 0.0 else localLoc.y / horizontal
+
+        val angle = atan2(horizontal, localLoc.z)
+        val delta = angle - halfAngleRad
+        val lateral = radius * cos(delta)
+
+        if (delta <= 0.0) {
+            val toCap = abs(length - radius)
+            val toLateral = radius * sin(-delta)
+            if (radius >= length || toCap <= toLateral) {
+                val scale = length / radius
+                return ConeProjection(
+                    toCap,
+                    Vector(localLoc.x * scale, localLoc.y * scale, localLoc.z * scale),
+                    Vector(localLoc.x / radius, localLoc.y / radius, localLoc.z / radius),
+                )
+            }
+            return lateralProjection(toLateral, lateral, meridianX, meridianY)
+        }
+
+        if (lateral <= 0.0) {
+            return ConeProjection(
+                radius,
+                Vector.ZERO,
+                Vector(localLoc.x / radius, localLoc.y / radius, localLoc.z / radius),
+            )
+        }
+
+        if (lateral >= length) {
+            val rim = Vector(meridianX * rimRadius, meridianY * rimRadius, length * cos(halfAngleRad))
+            val toRimX = localLoc.x - rim.x
+            val toRimY = localLoc.y - rim.y
+            val toRimZ = localLoc.z - rim.z
+            val toRim = sqrt(toRimX * toRimX + toRimY * toRimY + toRimZ * toRimZ)
+            if (toRim < Vector.EPSILON) {
+                return ConeProjection(0.0, rim, lateralNormal(meridianX, meridianY))
+            }
+            return ConeProjection(toRim, rim, Vector(toRimX / toRim, toRimY / toRim, toRimZ / toRim))
+        }
+
+        return lateralProjection(radius * sin(delta), lateral, meridianX, meridianY)
+    }
+
+    private fun lateralProjection(
+        distance: Double,
+        lateral: Double,
+        meridianX: Double,
+        meridianY: Double,
+    ): ConeProjection {
+        val footRadius = lateral * sin(halfAngleRad)
+        val foot = Vector(meridianX * footRadius, meridianY * footRadius, lateral * cos(halfAngleRad))
+        return ConeProjection(distance, foot, lateralNormal(meridianX, meridianY))
+    }
+
+    private fun lateralNormal(meridianX: Double, meridianY: Double): Vector = Vector(
+        meridianX * cos(halfAngleRad),
+        meridianY * cos(halfAngleRad),
+        -sin(halfAngleRad),
+    )
+
+    private data class ConeProjection(val distance: Double, val point: Vector, val normal: Vector)
+
+    /**
+     * Samples the lateral surface up to where it meets the spherical cap, then the cap
+     * itself, so every sample lies on the exact boundary [signedDistance] reports. The
+     * cap's last latitude ring is the rim the lateral surface already ends on, so the cap
+     * stops one ring short of it and no sample is emitted twice.
+     */
+    override fun sampleBoundary(density: Double): Sequence<Vector> = sequence {
+        if (length <= 0.0 || halfAngleDegrees <= 0.0) return@sequence
+        val surfaceArea = PI * rimRadius * length + 2 * PI * length * length * (1 - cos(halfAngleRad))
+        val step = sampleStep(density, surfaceArea)
+
+        val lateralEnd = length * cos(halfAngleRad)
+        for (t in axisSamples(0.0, lateralEnd, step)) {
+            val r = t * tan(halfAngleRad)
+            if (r < Vector.EPSILON) {
+                yield(Vector(0.0, 0.0, t))
+                continue
+            }
+            // Each ring is sized on its own, not for the rim: a ring near the apex is a fraction
+            // of the rim's circumference, and giving it the rim's count crowds the tip and
+            // exhausts the budget.
+            val ringSamples = max(4, (2 * PI * r / step).toInt())
+            for (i in 0 until ringSamples) {
+                val theta = 2 * PI * i / ringSamples
+                yield(Vector(cos(theta) * r, sin(theta) * r, t))
+            }
+        }
+
+        val phis = axisSamples(0.0, halfAngleRad, step / length)
+        for (phiIndex in 0 until phis.size - 1) {
+            val phi = phis[phiIndex]
+            val r = length * sin(phi)
+            val z = length * cos(phi)
+            if (r < Vector.EPSILON) {
+                yield(Vector(0.0, 0.0, z))
+                continue
+            }
+            val ringPoints = max(4, (2 * PI * r / step).toInt())
+            for (i in 0 until ringPoints) {
+                val theta = 2 * PI * i / ringPoints
+                yield(Vector(cos(theta) * r, sin(theta) * r, z))
+            }
+        }
+    }.withinSampleBudget()
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/shape/CuboidShape.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/shape/CuboidShape.kt
@@ -1,0 +1,159 @@
+package com.typewritermc.region.shape
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.AlgebraicTypeInfo
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.core.extension.annotations.Min
+import com.typewritermc.core.utils.point.Vector
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.sqrt
+
+/**
+ * Axis aligned cuboid centered at the local origin, with half extents along each axis.
+ *
+ * The region transform places the cuboid's center, not a corner. To anchor by a corner,
+ * set the region's offset accordingly.
+ */
+@AlgebraicTypeInfo("cuboid_shape", Colors.PURPLE, "mdi:cube-outline")
+data class CuboidShape(
+    @Min(0)
+    @Help("Distance from the center to the east and west faces. The full width is twice this.")
+    @Default("1.0")
+    val halfX: Double = 1.0,
+    @Min(0)
+    @Help("Distance from the center to the floor and ceiling. The full height is twice this.")
+    @Default("1.0")
+    val halfY: Double = 1.0,
+    @Min(0)
+    @Help("Distance from the center to the north and south faces. The full depth is twice this.")
+    @Default("1.0")
+    val halfZ: Double = 1.0,
+) : Shape {
+    init {
+        require(halfX >= 0.0 && halfY >= 0.0 && halfZ >= 0.0) {
+            "Cuboid half-extents must be non-negative, were ($halfX, $halfY, $halfZ)"
+        }
+    }
+
+    override val usable: Boolean get() = halfX > 0.0 && halfY > 0.0 && halfZ > 0.0
+
+    override val localBounds: LocalBounds
+        get() = LocalBounds(-halfX, -halfY, -halfZ, halfX, halfY, halfZ)
+
+    override fun contains(localLoc: Vector): Boolean =
+        abs(localLoc.x) <= halfX && abs(localLoc.y) <= halfY && abs(localLoc.z) <= halfZ
+
+    override fun signedDistance(localLoc: Vector): Double {
+        val dx = abs(localLoc.x) - halfX
+        val dy = abs(localLoc.y) - halfY
+        val dz = abs(localLoc.z) - halfZ
+        val outside = sqrt(max(dx, 0.0).sq() + max(dy, 0.0).sq() + max(dz, 0.0).sq())
+        val inside = min(max(dx, max(dy, dz)), 0.0)
+        return outside + inside
+    }
+
+    override fun signedDistanceHorizontal(localLoc: Vector): Double {
+        val dx = abs(localLoc.x) - halfX
+        val dz = abs(localLoc.z) - halfZ
+        val outside = sqrt(max(dx, 0.0).sq() + max(dz, 0.0).sq())
+        val inside = min(max(dx, dz), 0.0)
+        return outside + inside
+    }
+
+    override fun nearestOutside(localLoc: Vector): Vector {
+        return Vector(
+            localLoc.x.coerceIn(-halfX, halfX),
+            localLoc.y.coerceIn(-halfY, halfY),
+            localLoc.z.coerceIn(-halfZ, halfZ),
+        ).let { clamped ->
+            if (contains(localLoc)) {
+                val gx = halfX - abs(localLoc.x)
+                val gy = halfY - abs(localLoc.y)
+                val gz = halfZ - abs(localLoc.z)
+                when (min(gx, min(gy, gz))) {
+                    gx -> Vector(if (localLoc.x >= 0) halfX else -halfX, localLoc.y, localLoc.z)
+                    gy -> Vector(localLoc.x, if (localLoc.y >= 0) halfY else -halfY, localLoc.z)
+                    else -> Vector(localLoc.x, localLoc.y, if (localLoc.z >= 0) halfZ else -halfZ)
+                }
+            } else clamped
+        }
+    }
+
+    override fun outwardNormals(localLoc: Vector): List<Vector> {
+        // Past a corner or an edge the distance field's gradient is the direction away from the
+        // closest surface point, and it is what the barrier and the push follow. Naming one face
+        // normal per axis the point overshoots averages to a fixed 45 degrees instead, which
+        // aims somewhere the surface is not and swings the moment the player crosses a face
+        // plane. The multiple normals still describe a point standing on the corner itself.
+        outsideDirection(localLoc)?.let { return listOf(it) }
+
+        val normals = mutableListOf<Vector>()
+        if (abs(abs(localLoc.x) - halfX) < EDGE_EPSILON || abs(localLoc.x) > halfX) {
+            normals.add(Vector(if (localLoc.x >= 0) 1.0 else -1.0, 0.0, 0.0))
+        }
+        if (abs(abs(localLoc.y) - halfY) < EDGE_EPSILON || abs(localLoc.y) > halfY) {
+            normals.add(Vector(0.0, if (localLoc.y >= 0) 1.0 else -1.0, 0.0))
+        }
+        if (abs(abs(localLoc.z) - halfZ) < EDGE_EPSILON || abs(localLoc.z) > halfZ) {
+            normals.add(Vector(0.0, 0.0, if (localLoc.z >= 0) 1.0 else -1.0))
+        }
+        if (normals.isEmpty()) {
+            val gx = halfX - abs(localLoc.x)
+            val gy = halfY - abs(localLoc.y)
+            val gz = halfZ - abs(localLoc.z)
+            normals += when (min(gx, min(gy, gz))) {
+                gx -> Vector(if (localLoc.x >= 0) 1.0 else -1.0, 0.0, 0.0)
+                gy -> Vector(0.0, if (localLoc.y >= 0) 1.0 else -1.0, 0.0)
+                else -> Vector(0.0, 0.0, if (localLoc.z >= 0) 1.0 else -1.0)
+            }
+        }
+        return normals
+    }
+
+    /** The unit direction away from the closest surface point, or `null` for a point not outside. */
+    private fun outsideDirection(localLoc: Vector): Vector? {
+        if (signedDistance(localLoc) <= EDGE_EPSILON) return null
+        val offset = localLoc - nearestOutside(localLoc)
+        if (offset.length <= EDGE_EPSILON) return null
+        return offset.normalize()
+    }
+
+    /**
+     * Samples the six faces on evenly divided grids whose rows land exactly on the edges,
+     * with every edge and corner point emitted exactly once. Duplicate free samples matter
+     * for the entity boundary display, which spawns one entity per sample.
+     */
+    override fun sampleBoundary(density: Double): Sequence<Vector> = sequence {
+        val surfaceArea = 8.0 * (halfX * halfY + halfY * halfZ + halfX * halfZ)
+        val step = sampleStep(density, surfaceArea)
+        val xs = axisSamples(-halfX, halfX, step)
+        val ys = axisSamples(-halfY, halfY, step)
+        val zs = axisSamples(-halfZ, halfZ, step)
+
+        for (x in xs) for (z in zs) {
+            yield(Vector(x, -halfY, z))
+            if (halfY > 0.0) yield(Vector(x, halfY, z))
+        }
+        for (yIndex in 1 until ys.size - 1) {
+            val y = ys[yIndex]
+            for (x in xs) {
+                yield(Vector(x, y, -halfZ))
+                if (halfZ > 0.0) yield(Vector(x, y, halfZ))
+            }
+            for (zIndex in 1 until zs.size - 1) {
+                val z = zs[zIndex]
+                yield(Vector(-halfX, y, z))
+                if (halfX > 0.0) yield(Vector(halfX, y, z))
+            }
+        }
+    }.withinSampleBudget()
+
+    companion object {
+        private const val EDGE_EPSILON = 1e-6
+    }
+}
+
+private fun Double.sq(): Double = this * this

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/shape/EllipsoidDistance.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/shape/EllipsoidDistance.kt
@@ -1,0 +1,277 @@
+package com.typewritermc.region.shape
+
+import com.typewritermc.core.utils.point.Vector
+import kotlin.math.abs
+import kotlin.math.sqrt
+import kotlin.math.withSign
+
+/**
+ * The closest point on an axis aligned ellipsoid, after David Eberly's "Distance from a
+ * Point to an Ellipse, an Ellipsoid, or a Hyperellipsoid". Exact inside and out.
+ *
+ * The two cheaper estimates fail where consumers publish the number as a distance in
+ * blocks. Projecting radially onto the surface lands on the wrong point for anything but a
+ * sphere. Dividing the implicit function by the magnitude of its gradient measures against
+ * the long axis near the center: inside radii (20, 2, 20) it reports a point 0.001 blocks
+ * off center as 20 blocks deep, where the surface is 2 blocks away, and jumps 18 blocks
+ * across a millionth of a block at the center itself.
+ *
+ * Every routine here takes radii sorted descending and coordinates already made
+ * non negative, which is what lets the degenerate cases be enumerated at all.
+ */
+internal object EllipsoidDistance {
+    /** Enough halvings to drive the bracket below the spacing of a double. */
+    private const val MAX_BISECTIONS = 149
+
+    /** How far off the smallest axis' plane a coordinate has to be for the bisection to resolve it. */
+    private const val FLAT_PLANE_RATIO = 1e-12
+
+    /** Distance from [point] to the surface of the ellipsoid with the given radii. */
+    fun distance(radiusX: Double, radiusY: Double, radiusZ: Double, point: Vector): Double =
+        solveOriented(radiusX, radiusY, radiusZ, point, DoubleArray(3))
+
+    /** The point on the surface closest to [point]. */
+    fun closestPoint(radiusX: Double, radiusY: Double, radiusZ: Double, point: Vector): Vector {
+        val closest = DoubleArray(3)
+        solveOriented(radiusX, radiusY, radiusZ, point, closest)
+        return Vector(
+            closest[0].withSign(point.x),
+            closest[1].withSign(point.y),
+            closest[2].withSign(point.z),
+        )
+    }
+
+    /** Distance from ([x], [z]) to the outline of the ellipse with the given radii. */
+    fun distanceToEllipse(radiusX: Double, radiusZ: Double, x: Double, z: Double): Double {
+        val scratch = DoubleArray(3)
+        return if (radiusX >= radiusZ) {
+            solveEllipse(radiusX, radiusZ, abs(x), abs(z), scratch, 0, 1)
+        } else {
+            solveEllipse(radiusZ, radiusX, abs(z), abs(x), scratch, 0, 1)
+        }
+    }
+
+    /**
+     * Sorts the axes descending, mirrors the point into the first octant, and writes the
+     * closest point back in that sorted frame.
+     */
+    private fun solveOriented(
+        radiusX: Double,
+        radiusY: Double,
+        radiusZ: Double,
+        point: Vector,
+        closest: DoubleArray,
+    ): Double {
+        var first = 0
+        var second = 1
+        var third = 2
+        fun radius(axis: Int) = when (axis) {
+            0 -> radiusX
+            1 -> radiusY
+            else -> radiusZ
+        }
+
+        fun coordinate(axis: Int) = when (axis) {
+            0 -> abs(point.x)
+            1 -> abs(point.y)
+            else -> abs(point.z)
+        }
+
+        if (radius(first) < radius(second)) {
+            val swap = first; first = second; second = swap
+        }
+        if (radius(second) < radius(third)) {
+            val swap = second; second = third; third = swap
+        }
+        if (radius(first) < radius(second)) {
+            val swap = first; first = second; second = swap
+        }
+
+        val sorted = DoubleArray(3)
+        val distance = solveEllipsoid(
+            radius(first), radius(second), radius(third),
+            coordinate(first), coordinate(second), coordinate(third),
+            sorted,
+        )
+        closest[first] = sorted[0]
+        closest[second] = sorted[1]
+        closest[third] = sorted[2]
+        return distance
+    }
+
+    private fun solveEllipsoid(
+        e0: Double,
+        e1: Double,
+        e2: Double,
+        y0: Double,
+        y1: Double,
+        y2: Double,
+        closest: DoubleArray,
+    ): Double {
+        // Not `y2 > 0.0`: the bisection brackets the root at `y2 / e2 - 1`, so a coordinate this
+        // close to the plane of the smallest axis leaves a bracket one rounding error wide. The
+        // root that comes back is noise, and the distance built from it can even place the
+        // closest point off the surface. Such a point is on the plane for every practical
+        // purpose, and the solve below answers it exactly.
+        if (y2 > e2 * FLAT_PLANE_RATIO) {
+            if (y1 <= 0.0) {
+                if (y0 <= 0.0) {
+                    closest[0] = 0.0
+                    closest[1] = 0.0
+                    closest[2] = e2
+                    return abs(y2 - e2)
+                }
+                closest[1] = 0.0
+                return solveEllipse(e0, e2, y0, y2, closest, 0, 2)
+            }
+            if (y0 <= 0.0) {
+                closest[0] = 0.0
+                return solveEllipse(e1, e2, y1, y2, closest, 1, 2)
+            }
+
+            val z0 = y0 / e0
+            val z1 = y1 / e1
+            val z2 = y2 / e2
+            val outside = z0 * z0 + z1 * z1 + z2 * z2 - 1.0
+            if (outside == 0.0) {
+                closest[0] = y0
+                closest[1] = y1
+                closest[2] = y2
+                return 0.0
+            }
+            val r0 = (e0 / e2) * (e0 / e2)
+            val r1 = (e1 / e2) * (e1 / e2)
+            val root = ellipsoidRoot(r0, r1, z0, z1, z2, outside)
+            // A point a rounding error off the smallest axis' plane collapses the bracket onto
+            // its lower end, and these divisions would answer infinity, which reaches a barrier
+            // as a NaN push. Such a point is on that plane for every practical purpose, so it
+            // falls through to the solve that treats it as one.
+            if (root + r0 > 0.0 && root + r1 > 0.0 && root + 1.0 > 0.0) {
+                closest[0] = r0 * y0 / (root + r0)
+                closest[1] = r1 * y1 / (root + r1)
+                closest[2] = y2 / (root + 1.0)
+                return length(closest[0] - y0, closest[1] - y1, closest[2] - y2)
+            }
+        }
+
+        // On the plane of the smallest axis the closest point usually lifts off it, and the
+        // usual root does not see that, so the lift is solved directly.
+        val denominator0 = e0 * e0 - e2 * e2
+        val denominator1 = e1 * e1 - e2 * e2
+        val numerator0 = e0 * y0
+        val numerator1 = e1 * y1
+        if (numerator0 < denominator0 && numerator1 < denominator1) {
+            val ratio0 = numerator0 / denominator0
+            val ratio1 = numerator1 / denominator1
+            val remainder = 1.0 - ratio0 * ratio0 - ratio1 * ratio1
+            if (remainder > 0.0) {
+                closest[0] = e0 * ratio0
+                closest[1] = e1 * ratio1
+                closest[2] = e2 * sqrt(remainder)
+                return length(closest[0] - y0, closest[1] - y1, closest[2])
+            }
+        }
+        closest[2] = 0.0
+        return solveEllipse(e0, e1, y0, y1, closest, 0, 1)
+    }
+
+    private fun solveEllipse(
+        e0: Double,
+        e1: Double,
+        y0: Double,
+        y1: Double,
+        closest: DoubleArray,
+        axis0: Int,
+        axis1: Int,
+    ): Double {
+        if (y1 > 0.0) {
+            if (y0 <= 0.0) {
+                closest[axis0] = 0.0
+                closest[axis1] = e1
+                return abs(y1 - e1)
+            }
+
+            val z0 = y0 / e0
+            val z1 = y1 / e1
+            val outside = z0 * z0 + z1 * z1 - 1.0
+            if (outside == 0.0) {
+                closest[axis0] = y0
+                closest[axis1] = y1
+                return 0.0
+            }
+            val r0 = (e0 / e1) * (e0 / e1)
+            val root = ellipseRoot(r0, z0, z1, outside)
+            // As in the ellipsoid solve above: a collapsed bracket would divide by zero here,
+            // and the point belongs on the smaller axis' line anyway.
+            if (root + r0 > 0.0 && root + 1.0 > 0.0) {
+                closest[axis0] = r0 * y0 / (root + r0)
+                closest[axis1] = y1 / (root + 1.0)
+                return length(closest[axis0] - y0, closest[axis1] - y1)
+            }
+        }
+
+        val denominator = e0 * e0 - e1 * e1
+        val numerator = e0 * y0
+        if (numerator < denominator) {
+            val ratio = numerator / denominator
+            closest[axis0] = e0 * ratio
+            closest[axis1] = e1 * sqrt(1.0 - ratio * ratio)
+            return length(closest[axis0] - y0, closest[axis1])
+        }
+        closest[axis0] = e0
+        closest[axis1] = 0.0
+        return abs(y0 - e0)
+    }
+
+    /**
+     * Bisects for the Lagrange multiplier of the closest point, in units of the smallest
+     * radius squared. The bracket starts at the multiplier that would put the closest point
+     * on the smallest axis, which is what keeps an interior point from converging on the
+     * far side of the long axis.
+     */
+    private fun ellipsoidRoot(r0: Double, r1: Double, z0: Double, z1: Double, z2: Double, outside: Double): Double {
+        val n0 = r0 * z0
+        val n1 = r1 * z1
+        var low = z2 - 1.0
+        var high = if (outside < 0.0) 0.0 else length(n0, n1, z2) - 1.0
+        var root = 0.0
+        repeat(MAX_BISECTIONS) {
+            root = (low + high) / 2.0
+            if (root == low || root == high) return root
+            val ratio0 = n0 / (root + r0)
+            val ratio1 = n1 / (root + r1)
+            val ratio2 = z2 / (root + 1.0)
+            val value = ratio0 * ratio0 + ratio1 * ratio1 + ratio2 * ratio2 - 1.0
+            when {
+                value > 0.0 -> low = root
+                value < 0.0 -> high = root
+                else -> return root
+            }
+        }
+        return root
+    }
+
+    private fun ellipseRoot(r0: Double, z0: Double, z1: Double, outside: Double): Double {
+        val n0 = r0 * z0
+        var low = z1 - 1.0
+        var high = if (outside < 0.0) 0.0 else length(n0, z1) - 1.0
+        var root = 0.0
+        repeat(MAX_BISECTIONS) {
+            root = (low + high) / 2.0
+            if (root == low || root == high) return root
+            val ratio0 = n0 / (root + r0)
+            val ratio1 = z1 / (root + 1.0)
+            val value = ratio0 * ratio0 + ratio1 * ratio1 - 1.0
+            when {
+                value > 0.0 -> low = root
+                value < 0.0 -> high = root
+                else -> return root
+            }
+        }
+        return root
+    }
+
+    private fun length(a: Double, b: Double): Double = sqrt(a * a + b * b)
+
+    private fun length(a: Double, b: Double, c: Double): Double = sqrt(a * a + b * b + c * c)
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/shape/EllipsoidShape.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/shape/EllipsoidShape.kt
@@ -1,0 +1,116 @@
+package com.typewritermc.region.shape
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.AlgebraicTypeInfo
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.core.extension.annotations.Min
+import com.typewritermc.core.utils.point.Vector
+import kotlin.math.PI
+import kotlin.math.pow
+import kotlin.math.sqrt
+
+@AlgebraicTypeInfo("ellipsoid_shape", Colors.PURPLE, "mdi:ellipse-outline")
+data class EllipsoidShape(
+    @Min(0)
+    @Help("Half-extent along the local X axis.")
+    @Default("1.0")
+    val radiusX: Double = 1.0,
+    @Min(0)
+    @Help("Half-extent along the local Y axis (vertical before pitch).")
+    @Default("1.0")
+    val radiusY: Double = 1.0,
+    @Min(0)
+    @Help("Half-extent along the local Z axis.")
+    @Default("1.0")
+    val radiusZ: Double = 1.0,
+) : Shape {
+    init {
+        require(radiusX >= 0.0 && radiusY >= 0.0 && radiusZ >= 0.0) {
+            "Ellipsoid radii must be non-negative"
+        }
+    }
+
+    override val usable: Boolean get() = radiusX > 0.0 && radiusY > 0.0 && radiusZ > 0.0
+
+    override val localBounds: LocalBounds
+        get() = LocalBounds(-radiusX, -radiusY, -radiusZ, radiusX, radiusY, radiusZ)
+
+    override fun contains(localLoc: Vector): Boolean {
+        // A zero radius collapses the ellipsoid to the single point at its own origin, which is
+        // what [signedDistance] measures against, so nothing but that point is inside.
+        if (radiusX == 0.0 || radiusY == 0.0 || radiusZ == 0.0) return localLoc.lengthSquared == 0.0
+        val nx = localLoc.x / radiusX
+        val ny = localLoc.y / radiusY
+        val nz = localLoc.z / radiusZ
+        return nx * nx + ny * ny + nz * nz <= 1.0
+    }
+
+    /**
+     * The distance to the closest point on the surface, solved exactly by
+     * [EllipsoidDistance]. Consumers publish this to the user as a distance in blocks and
+     * the barrier ramps its push across it, so an estimate measured against the wrong axis
+     * is not good enough. On radii (20, 2, 20) such an estimate reports 20 blocks of depth
+     * just off center, where the surface is 2 blocks away, and the barrier never pushes.
+     */
+    override fun signedDistance(localLoc: Vector): Double {
+        if (radiusX == 0.0 || radiusY == 0.0 || radiusZ == 0.0) return localLoc.length
+        val distance = EllipsoidDistance.distance(radiusX, radiusY, radiusZ, localLoc)
+        return if (contains(localLoc)) -distance else distance
+    }
+
+    /** The same exact solve applied to the XZ silhouette ellipse. */
+    override fun signedDistanceHorizontal(localLoc: Vector): Double {
+        if (radiusX == 0.0 || radiusZ == 0.0) {
+            return sqrt(localLoc.x * localLoc.x + localLoc.z * localLoc.z)
+        }
+        val distance = EllipsoidDistance.distanceToEllipse(radiusX, radiusZ, localLoc.x, localLoc.z)
+        val nx = localLoc.x / radiusX
+        val nz = localLoc.z / radiusZ
+        return if (nx * nx + nz * nz <= 1.0) -distance else distance
+    }
+
+    override fun nearestOutside(localLoc: Vector): Vector {
+        if (radiusX == 0.0 || radiusY == 0.0 || radiusZ == 0.0) return Vector.ZERO
+        return EllipsoidDistance.closestPoint(radiusX, radiusY, radiusZ, localLoc)
+    }
+
+    /**
+     * The surface normal at the closest point, which is where a push out of the region has
+     * to aim. The gradient at the player's own position points elsewhere entirely once the
+     * axes differ, and so does any fixed axis: at the center of radii (20, 2, 20) the surface
+     * is 2 blocks up, not 20 blocks sideways.
+     */
+    override fun outwardNormals(localLoc: Vector): List<Vector> {
+        if (radiusX == 0.0 || radiusY == 0.0 || radiusZ == 0.0) return listOf(Vector(1.0, 0.0, 0.0))
+        val surface = nearestOutside(localLoc)
+        val nx = surface.x / (radiusX * radiusX)
+        val ny = surface.y / (radiusY * radiusY)
+        val nz = surface.z / (radiusZ * radiusZ)
+        val len = sqrt(nx * nx + ny * ny + nz * nz)
+        if (len < Vector.EPSILON) return listOf(Vector(1.0, 0.0, 0.0))
+        return listOf(Vector(nx / len, ny / len, nz / len))
+    }
+
+    /**
+     * Knud Thomsen's approximation, within about 1% for every axis ratio. A sphere of the
+     * mean radius over counts badly once the axes differ: radii (1, 1, 50) would ask for
+     * 3775 samples for a surface of 494, and the entity display spawns one entity per
+     * sample.
+     */
+    private fun surfaceArea(): Double {
+        val exponent = 1.6075
+        val xy = (radiusX * radiusY).pow(exponent)
+        val xz = (radiusX * radiusZ).pow(exponent)
+        val yz = (radiusY * radiusZ).pow(exponent)
+        return 4 * PI * ((xy + xz + yz) / 3.0).pow(1.0 / exponent)
+    }
+
+    override fun sampleBoundary(density: Double): Sequence<Vector> {
+        if (radiusX == 0.0 || radiusY == 0.0 || radiusZ == 0.0) return sequenceOf(Vector.ZERO)
+        return fibonacciSphereSamples(
+            boundarySampleCount(surfaceArea(), density),
+            Vector(radiusX, radiusY, radiusZ),
+        )
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/shape/HitboxSampling.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/shape/HitboxSampling.kt
@@ -1,0 +1,76 @@
+package com.typewritermc.region.shape
+
+import com.typewritermc.core.utils.point.Vector
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.math.ceil
+
+private val offsetCache = ConcurrentHashMap<Pair<Double, Double>, List<Vector>>()
+
+private const val OFFSET_CACHE_MAX = 64
+
+/**
+ * The widest gap allowed between neighbouring hitbox samples.
+ *
+ * A lattice detects a shape only when a sample lands inside it, so the spacing is the
+ * thinnest shape the classification can see. Three levels over a standing player's 1.8
+ * blocks would leave a 0.9 block gap, wide enough for a narrow vision cone to pass through
+ * a player's chest without a sample landing inside it.
+ */
+private const val MAX_SAMPLE_SPACING = 0.5
+
+/**
+ * The most points one lattice may hold.
+ *
+ * Spacing alone does not bound the count, which grows with the cube of the box: the vanilla
+ * `scale` attribute goes to 16, and a player that size would ask for twenty six thousand
+ * signed distance evaluations per tracker per move, on the main thread. A giant is easy to
+ * hit, so it loses resolution rather than the server losing the tick.
+ */
+private const val MAX_SAMPLES = 125
+
+/**
+ * Sample offsets covering a bounding box of the given dimensions, relative to the box's
+ * bottom center, spaced no further apart than [MAX_SAMPLE_SPACING] on every axis until the
+ * box is large enough for [MAX_SAMPLES] to widen it. A shape at least that thick passing
+ * through any part of the box is detected. Includes the bottom center itself, so a shape
+ * that contains the player's feet is always detected.
+ *
+ * The lattice is cached per box dimensions. Player boxes only come in a handful of sizes
+ * (standing, sneaking, swimming), and classification runs on every dispatch, so the cache
+ * removes the per call allocation from the hot path.
+ */
+internal fun hitboxSampleOffsets(halfWidth: Double, height: Double): List<Vector> {
+    require(halfWidth >= 0.0) { "Hitbox half-width must be non-negative, was $halfWidth" }
+    require(height >= 0.0) { "Hitbox height must be non-negative, was $height" }
+
+    val key = halfWidth to height
+    offsetCache[key]?.let { return it }
+
+    if (offsetCache.size >= OFFSET_CACHE_MAX) offsetCache.clear()
+    val spacing = spacingFor(halfWidth, height)
+    val lateral = axisSamples(-halfWidth, halfWidth, spacing)
+    val vertical = axisSamples(0.0, height, spacing)
+    val offsets = ArrayList<Vector>(vertical.size * lateral.size * lateral.size)
+    for (y in vertical) for (x in lateral) for (z in lateral) {
+        offsets.add(Vector(x, y, z))
+    }
+    return offsetCache.putIfAbsent(key, offsets) ?: offsets
+}
+
+/** The tightest spacing at or above [MAX_SAMPLE_SPACING] that keeps the lattice within [MAX_SAMPLES]. */
+private fun spacingFor(halfWidth: Double, height: Double): Double {
+    var spacing = MAX_SAMPLE_SPACING
+    while (latticeSize(halfWidth, height, spacing) > MAX_SAMPLES) spacing *= 2.0
+    return spacing
+}
+
+private fun latticeSize(halfWidth: Double, height: Double, spacing: Double): Long {
+    val lateral = axisSampleCount(2.0 * halfWidth, spacing)
+    val vertical = axisSampleCount(height, spacing)
+    return lateral * lateral * vertical
+}
+
+private fun axisSampleCount(span: Double, spacing: Double): Long {
+    if (span <= 0.0) return 1
+    return ceil(span / spacing).toLong() + 1
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/shape/Outline.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/shape/Outline.kt
@@ -1,0 +1,161 @@
+package com.typewritermc.region.shape
+
+import com.typewritermc.core.utils.point.Vector
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * A polyline tracing a characteristic edge of a shape, in local coordinates. Closed
+ * polylines connect the last point back to the first.
+ */
+data class OutlinePolyline(val points: List<Vector>, val closed: Boolean) {
+    init {
+        require(points.size >= 2) { "An outline polyline needs at least two points, got ${points.size}" }
+    }
+
+    /** The polyline as segment pairs, including the closing segment for closed polylines. */
+    fun segments(): List<Pair<Vector, Vector>> {
+        val result = ArrayList<Pair<Vector, Vector>>(points.size)
+        for (index in 0 until points.size - 1) {
+            result += points[index] to points[index + 1]
+        }
+        if (closed) result += points.last() to points.first()
+        return result
+    }
+}
+
+/**
+ * The characteristic edges of the shape: box edges, silhouette rings, cone generatrices,
+ * polygon prism edges. Editor outlines and command visualizations render these as solid
+ * lines so the shape reads at a glance, where surface samples alone stay ambiguous.
+ *
+ * [circleSegments] is the resolution of full rings; arcs use a proportional share.
+ */
+fun Shape.outlinePolylines(circleSegments: Int = 24): List<OutlinePolyline> = when (this) {
+    is CuboidShape -> cuboidOutline(halfX, halfY, halfZ)
+    is SphereShape -> axisRings(radius, radius, radius, circleSegments)
+    is EllipsoidShape -> axisRings(radiusX, radiusY, radiusZ, circleSegments)
+    is CapsuleShape -> capsuleOutline(radius, halfHeight, circleSegments)
+    is ConeShape -> coneOutline(length, halfAngleDegrees, circleSegments)
+    is PolygonShape -> polygonOutline(points, halfHeight)
+}
+
+private fun cuboidOutline(halfX: Double, halfY: Double, halfZ: Double): List<OutlinePolyline> {
+    fun rect(y: Double) = OutlinePolyline(
+        listOf(
+            Vector(-halfX, y, -halfZ),
+            Vector(halfX, y, -halfZ),
+            Vector(halfX, y, halfZ),
+            Vector(-halfX, y, halfZ),
+        ),
+        closed = true,
+    )
+
+    val verticals = listOf(-halfX to -halfZ, halfX to -halfZ, halfX to halfZ, -halfX to halfZ).map { (x, z) ->
+        OutlinePolyline(listOf(Vector(x, -halfY, z), Vector(x, halfY, z)), closed = false)
+    }
+    return listOf(rect(-halfY), rect(halfY)) + verticals
+}
+
+/**
+ * The three axis plane rings of an ellipsoid (or sphere, with equal radii): the XZ equator
+ * and the XY and YZ meridians.
+ */
+private fun axisRings(radiusX: Double, radiusY: Double, radiusZ: Double, circleSegments: Int): List<OutlinePolyline> {
+    if (radiusX <= 0.0 || radiusY <= 0.0 || radiusZ <= 0.0) return emptyList()
+    fun ring(point: (angle: Double) -> Vector) = OutlinePolyline(
+        List(circleSegments) { index -> point(2.0 * PI * index / circleSegments) },
+        closed = true,
+    )
+    return listOf(
+        ring { angle -> Vector(cos(angle) * radiusX, 0.0, sin(angle) * radiusZ) },
+        ring { angle -> Vector(cos(angle) * radiusX, sin(angle) * radiusY, 0.0) },
+        ring { angle -> Vector(0.0, sin(angle) * radiusY, cos(angle) * radiusZ) },
+    )
+}
+
+/**
+ * Two rings where the cylinder meets the hemispheres, and two stadium shaped profile loops
+ * through the XY and ZY planes.
+ */
+private fun capsuleOutline(radius: Double, halfHeight: Double, circleSegments: Int): List<OutlinePolyline> {
+    if (radius <= 0.0) return emptyList()
+    val arcSegments = (circleSegments / 2).coerceAtLeast(4)
+
+    fun ring(y: Double) = OutlinePolyline(
+        List(circleSegments) { index ->
+            val angle = 2.0 * PI * index / circleSegments
+            Vector(cos(angle) * radius, y, sin(angle) * radius)
+        },
+        closed = true,
+    )
+
+    fun profile(point: (x: Double, y: Double) -> Vector): OutlinePolyline {
+        val loop = mutableListOf(point(radius, -halfHeight))
+        loop += point(radius, halfHeight)
+        for (index in 1..arcSegments) {
+            val angle = PI * index / arcSegments
+            loop += point(cos(angle) * radius, halfHeight + sin(angle) * radius)
+        }
+        loop += point(-radius, -halfHeight)
+        for (index in 1 until arcSegments) {
+            val angle = PI + PI * index / arcSegments
+            loop += point(cos(angle) * radius, -halfHeight - sin(angle - PI) * radius)
+        }
+        return OutlinePolyline(loop, closed = true)
+    }
+
+    return listOf(
+        ring(halfHeight),
+        ring(-halfHeight),
+        profile { x, y -> Vector(x, y, 0.0) },
+        profile { x, y -> Vector(0.0, y, x) },
+    )
+}
+
+/**
+ * The rim ring where the lateral surface meets the spherical cap, generatrix lines from
+ * the apex to the rim, and two profile arcs over the cap. The generatrices make the cone's
+ * direction and reach followable at a glance.
+ */
+private fun coneOutline(length: Double, halfAngleDegrees: Double, circleSegments: Int): List<OutlinePolyline> {
+    if (length <= 0.0 || halfAngleDegrees <= 0.0) return emptyList()
+    val halfAngle = Math.toRadians(halfAngleDegrees)
+    val rimRadius = length * sin(halfAngle)
+    val rimZ = length * cos(halfAngle)
+
+    fun rimPoint(angle: Double) = Vector(cos(angle) * rimRadius, sin(angle) * rimRadius, rimZ)
+
+    val rim =
+        OutlinePolyline(List(circleSegments) { index -> rimPoint(2.0 * PI * index / circleSegments) }, closed = true)
+    val generatrices = List(CONE_GENERATRIX_LINES) { index ->
+        val angle = 2.0 * PI * index / CONE_GENERATRIX_LINES
+        OutlinePolyline(listOf(Vector.ZERO, rimPoint(angle)), closed = false)
+    }
+
+    val arcSegments = (circleSegments / 2).coerceAtLeast(4)
+    fun capArc(point: (lateral: Double, z: Double) -> Vector) = OutlinePolyline(
+        List(arcSegments + 1) { index ->
+            val angle = -halfAngle + 2.0 * halfAngle * index / arcSegments
+            point(length * sin(angle), length * cos(angle))
+        },
+        closed = false,
+    )
+
+    return listOf(rim) + generatrices + listOf(
+        capArc { lateral, z -> Vector(lateral, 0.0, z) },
+        capArc { lateral, z -> Vector(0.0, lateral, z) },
+    )
+}
+
+private fun polygonOutline(points: List<Vector>, halfHeight: Double): List<OutlinePolyline> {
+    if (points.size < 3) return emptyList()
+    fun ring(y: Double) = OutlinePolyline(points.map { Vector(it.x, y, it.z) }, closed = true)
+    val verticals = points.map {
+        OutlinePolyline(listOf(Vector(it.x, -halfHeight, it.z), Vector(it.x, halfHeight, it.z)), closed = false)
+    }
+    return listOf(ring(-halfHeight), ring(halfHeight)) + verticals
+}
+
+private const val CONE_GENERATRIX_LINES = 8

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/shape/PolygonShape.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/shape/PolygonShape.kt
@@ -1,0 +1,373 @@
+package com.typewritermc.region.shape
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.AlgebraicTypeInfo
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.core.extension.annotations.Min
+import com.typewritermc.core.utils.point.Vector
+import kotlin.math.*
+
+/**
+ * A vertical prism whose horizontal cross section is the polygon spanned by [points],
+ * extruded [halfHeight] blocks up and down from the local origin's Y level.
+ *
+ * Only the X and Z components of each point are used. Points are relative to the resolved
+ * region origin and may be listed in either winding order. The polygon may be concave but
+ * must not self intersect.
+ *
+ * A polygon needs at least three points. With fewer, the shape contains nothing and
+ * reports far outside distances instead of failing the page load while the user is still
+ * drawing the outline in the editor.
+ */
+@AlgebraicTypeInfo("polygon_shape", Colors.PURPLE, "mdi:vector-polygon")
+data class PolygonShape(
+    @Help("Polygon outline points relative to the origin; only X and Z are used. Needs at least 3.")
+    val points: List<Vector> = emptyList(),
+    @Min(0)
+    @Help("Half the prism's height in blocks; the prism spans origin Y ± this value.")
+    @Default("1.0")
+    val halfHeight: Double = 1.0,
+) : Shape {
+    private val degenerate: Boolean get() = points.size < 3
+
+    // Points in a straight line pass the count and still enclose nothing, which the area catches.
+    override val usable: Boolean get() = !degenerate && halfHeight > 0.0 && twiceCapArea() > EDGE_EPSILON
+
+    override val localBounds: LocalBounds
+        get() {
+            if (degenerate) return LocalBounds(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+            return LocalBounds(
+                points.minOf { it.x }, -halfHeight, points.minOf { it.z },
+                points.maxOf { it.x }, halfHeight, points.maxOf { it.z },
+            )
+        }
+
+    override fun contains(localLoc: Vector): Boolean {
+        if (degenerate) return false
+        if (abs(localLoc.y) > halfHeight) return false
+        return lateralContains(localLoc.x, localLoc.z)
+    }
+
+    override fun signedDistance(localLoc: Vector): Double {
+        if (degenerate) return FAR_OUTSIDE
+        val lateral = closestBoundary2d(localLoc.x, localLoc.z)
+        val dy = abs(localLoc.y) - halfHeight
+        val inside = min(max(lateral.signedDistance, dy), 0.0)
+        val ox = max(lateral.signedDistance, 0.0)
+        val oy = max(dy, 0.0)
+        return inside + sqrt(ox * ox + oy * oy)
+    }
+
+    override fun signedDistanceHorizontal(localLoc: Vector): Double {
+        if (degenerate) return FAR_OUTSIDE
+        return closestBoundary2d(localLoc.x, localLoc.z).signedDistance
+    }
+
+    override fun nearestOutside(localLoc: Vector): Vector {
+        // An outline still being drawn has no surface. [signedDistance] answers FAR_OUTSIDE for
+        // it, so the nearest point has to be that far away too, or a caller comparing the two
+        // sees a surface it can touch.
+        if (degenerate) return Vector(localLoc.x, localLoc.y + FAR_OUTSIDE, localLoc.z)
+        val lateral = closestBoundary2d(localLoc.x, localLoc.z)
+        val dy = abs(localLoc.y) - halfHeight
+        val capY = if (localLoc.y >= 0) halfHeight else -halfHeight
+        if (lateral.signedDistance <= 0.0 && dy <= 0.0) {
+            return if (-lateral.signedDistance <= -dy) Vector(lateral.x, localLoc.y, lateral.z)
+            else Vector(localLoc.x, capY, localLoc.z)
+        }
+        if (lateral.signedDistance <= 0.0) return Vector(localLoc.x, capY, localLoc.z)
+        val clampedY = localLoc.y.coerceIn(-halfHeight, halfHeight)
+        return Vector(lateral.x, clampedY, lateral.z)
+    }
+
+    override fun outwardNormals(localLoc: Vector): List<Vector> {
+        if (degenerate) return emptyList()
+        // Past the rim the direction away from the closest surface point is the one the barrier
+        // and the push want. A wall normal plus a cap normal averages to a fixed 45 degrees,
+        // which aims off the prism and swings as the player crosses the plane of either.
+        outsideDirection(localLoc)?.let { return listOf(it) }
+
+        val lateral = closestBoundary2d(localLoc.x, localLoc.z)
+        val dy = abs(localLoc.y) - halfHeight
+        val normals = mutableListOf<Vector>()
+        if (dy > -EDGE_EPSILON) {
+            normals.add(Vector(0.0, if (localLoc.y >= 0) 1.0 else -1.0, 0.0))
+        }
+        if (lateral.signedDistance > -EDGE_EPSILON) {
+            lateralNormal(localLoc, lateral)?.let(normals::add)
+        }
+        if (normals.isEmpty()) {
+            if (-lateral.signedDistance <= -dy) lateralNormal(localLoc, lateral)?.let(normals::add)
+            if (normals.isEmpty()) normals.add(Vector(0.0, if (localLoc.y >= 0) 1.0 else -1.0, 0.0))
+        }
+        return normals
+    }
+
+    /** The unit direction away from the closest surface point, or `null` for a point not outside. */
+    private fun outsideDirection(localLoc: Vector): Vector? {
+        if (signedDistance(localLoc) <= EDGE_EPSILON) return null
+        val offset = localLoc - nearestOutside(localLoc)
+        if (offset.length <= EDGE_EPSILON) return null
+        return offset.normalize()
+    }
+
+    /** The prism's wall plus its two caps. */
+    private fun surfaceArea(): Double {
+        if (degenerate) return 0.0
+        var perimeter = 0.0
+        var j = points.size - 1
+        for (i in points.indices) {
+            val from = points[j]
+            val to = points[i]
+            perimeter += sqrt((to.x - from.x) * (to.x - from.x) + (to.z - from.z) * (to.z - from.z))
+            j = i
+        }
+        return perimeter * 2.0 * halfHeight + twiceCapArea()
+    }
+
+    /** Twice the outline's enclosed area, by the shoelace formula. Zero for a line. */
+    private fun twiceCapArea(): Double {
+        if (degenerate) return 0.0
+        var doubled = 0.0
+        var j = points.size - 1
+        for (i in points.indices) {
+            doubled += points[j].x * points[i].z - points[i].x * points[j].z
+            j = i
+        }
+        return abs(doubled)
+    }
+
+    /**
+     * Samples the walls in evenly divided columns whose rows land exactly on the top and
+     * bottom edges, then fills the caps with the grid points strictly inside the outline.
+     * Each edge's endpoint is the next edge's start and the wall already covers the cap
+     * rims, so no sample is emitted twice.
+     */
+    override fun sampleBoundary(density: Double): Sequence<Vector> {
+        if (degenerate) return emptySequence()
+        val step = sampleStep(density, surfaceArea())
+        return sequence {
+            val ys = axisSamples(-halfHeight, halfHeight, step)
+            var j = points.size - 1
+            for (i in points.indices) {
+                val ax = points[j].x
+                val az = points[j].z
+                val ex = points[i].x - ax
+                val ez = points[i].z - az
+                val length = sqrt(ex * ex + ez * ez)
+                j = i
+                if (length < EDGE_EPSILON) continue
+                val segments = max(1, ceil(length / step).toInt())
+                for (segment in 0 until segments) {
+                    val fraction = segment.toDouble() / segments
+                    val px = ax + ex * fraction
+                    val pz = az + ez * fraction
+                    for (y in ys) yield(Vector(px, y, pz))
+                }
+            }
+            val bounds = localBounds
+            val xs = axisSamples(bounds.minX, bounds.maxX, step)
+            for (z in axisSamples(bounds.minZ, bounds.maxZ, step)) {
+                val crossings = rowCrossings(z)
+                var pair = 0
+                while (pair + 1 < crossings.size) {
+                    var index = xs.firstIndexAtLeast(crossings[pair])
+                    while (index < xs.size && xs[index] <= crossings[pair + 1]) {
+                        val x = xs[index]
+                        index++
+                        if (closestBoundary2d(x, z).signedDistance >= -CAP_INSET) continue
+                        yield(Vector(x, -halfHeight, z))
+                        if (halfHeight > 0.0) yield(Vector(x, halfHeight, z))
+                    }
+                    pair += 2
+                }
+            }
+        }.withinSampleBudget()
+    }
+
+    private fun lateralNormal(localLoc: Vector, lateral: LateralHit): Vector? {
+        val toPointX = localLoc.x - lateral.x
+        val toPointZ = localLoc.z - lateral.z
+        val length = sqrt(toPointX * toPointX + toPointZ * toPointZ)
+        if (length < EDGE_EPSILON) return wallNormal(lateral)
+        val sign = if (lateral.signedDistance >= 0.0) 1.0 else -1.0
+        return Vector(sign * toPointX / length, 0.0, sign * toPointZ / length)
+    }
+
+    /**
+     * The outward perpendicular of the wall [lateral] lies on, for a point standing exactly on
+     * it. Winding is not assumed: the side that leaves the outline is found by probing.
+     *
+     * A corner belongs to both of the edges that meet there, and at a sharp one a single edge's
+     * perpendicular runs almost along the other, so it points along the outline rather than out
+     * of it. Both edges are averaged there, which gives the bisector.
+     */
+    private fun wallNormal(lateral: LateralHit): Vector? {
+        val corner = points.indexOfFirst {
+            abs(it.x - lateral.x) < EDGE_EPSILON && abs(it.z - lateral.z) < EDGE_EPSILON
+        }
+        if (corner < 0) return edgeNormal(lateral.x, lateral.z, lateral.edgeX, lateral.edgeZ)
+
+        val here = points[corner]
+        val previous = neighbourOf(corner, -1) ?: return null
+        val next = neighbourOf(corner, 1) ?: return null
+        val incoming = edgeNormal(
+            (previous.x + here.x) / 2.0, (previous.z + here.z) / 2.0,
+            here.x - previous.x, here.z - previous.z,
+        )
+        val outgoing = edgeNormal(
+            (here.x + next.x) / 2.0, (here.z + next.z) / 2.0,
+            next.x - here.x, next.z - here.z,
+        )
+        return averageUnitDirection(listOfNotNull(incoming, outgoing))
+    }
+
+    /**
+     * The nearest point [step] hops away from [index] that does not sit on the point at [index],
+     * or `null` when every point does.
+     *
+     * The editor lets a builder drop a vertex on one already placed, and the zero length edge that
+     * makes has no perpendicular. Taking the listed neighbour regardless leaves a sharp corner with
+     * one edge's perpendicular, which is the direction that runs along the outline rather than out
+     * of it, and a barrier there pushes a player along the wall instead of off it.
+     */
+    private fun neighbourOf(index: Int, step: Int): Vector? {
+        val here = points[index]
+        for (hop in 1 until points.size) {
+            val candidate = points[Math.floorMod(index + step * hop, points.size)]
+            if (abs(candidate.x - here.x) >= EDGE_EPSILON || abs(candidate.z - here.z) >= EDGE_EPSILON) {
+                return candidate
+            }
+        }
+        return null
+    }
+
+    /** The outward perpendicular of the edge along ([edgeX], [edgeZ]), probed from ([x], [z]) on it. */
+    private fun edgeNormal(x: Double, z: Double, edgeX: Double, edgeZ: Double): Vector? {
+        val length = sqrt(edgeX * edgeX + edgeZ * edgeZ)
+        if (length < EDGE_EPSILON) return null
+        val nx = edgeZ / length
+        val nz = -edgeX / length
+        val outward = !lateralContains(x + nx * NORMAL_PROBE, z + nz * NORMAL_PROBE)
+        return if (outward) Vector(nx, 0.0, nz) else Vector(-nx, 0.0, -nz)
+    }
+
+    /**
+     * Ray cast parity test in the XZ plane.
+     */
+    private fun lateralContains(px: Double, pz: Double): Boolean {
+        var inside = false
+        var j = points.size - 1
+        for (i in points.indices) {
+            val zi = points[i].z
+            val zj = points[j].z
+            if ((zi > pz) != (zj > pz) && px < (points[j].x - points[i].x) * (pz - zi) / (zj - zi) + points[i].x) {
+                inside = !inside
+            }
+            j = i
+        }
+        return inside
+    }
+
+    /**
+     * The x coordinates where the outline crosses the row at [z], sorted.
+     *
+     * By the parity rule [lateralContains] uses, the points between the first and the second
+     * crossing are inside, as are the points between the third and the fourth, and so on.
+     *
+     * The cap fill walks these spans rather than the whole bounding box. The sample budget cannot
+     * bound that walk: it counts the samples emitted, and a point rejected for being outside the
+     * outline is rejected for free. A thin outline lying across its bounding box diagonally rejects
+     * nearly everything it tests, which costs a million outline tests per render on a band a
+     * thousand blocks long.
+     */
+    private fun rowCrossings(z: Double): DoubleArray {
+        val crossings = DoubleArray(points.size)
+        var count = 0
+        var j = points.size - 1
+        for (i in points.indices) {
+            val zi = points[i].z
+            val zj = points[j].z
+            if ((zi > z) != (zj > z)) {
+                crossings[count] = (points[j].x - points[i].x) * (z - zi) / (zj - zi) + points[i].x
+                count += 1
+            }
+            j = i
+        }
+        return crossings.copyOf(count).also { it.sort() }
+    }
+
+    /**
+     * The closest point on the polygon outline plus the signed lateral distance, negative
+     * when the point is laterally inside. The sign comes from [lateralContains], so it
+     * works for both winding orders.
+     */
+    private fun closestBoundary2d(px: Double, pz: Double): LateralHit {
+        var bestDistSq = Double.MAX_VALUE
+        var bestX = px
+        var bestZ = pz
+        var bestEdgeX = 0.0
+        var bestEdgeZ = 0.0
+        var j = points.size - 1
+        for (i in points.indices) {
+            val ax = points[j].x
+            val az = points[j].z
+            val ex = points[i].x - ax
+            val ez = points[i].z - az
+            val lenSq = ex * ex + ez * ez
+            val t = if (lenSq < EDGE_EPSILON) 0.0
+            else (((px - ax) * ex + (pz - az) * ez) / lenSq).coerceIn(0.0, 1.0)
+            val cx = ax + ex * t
+            val cz = az + ez * t
+            val dx = px - cx
+            val dz = pz - cz
+            val distSq = dx * dx + dz * dz
+            if (distSq < bestDistSq) {
+                bestDistSq = distSq
+                bestX = cx
+                bestZ = cz
+                bestEdgeX = ex
+                bestEdgeZ = ez
+            }
+            j = i
+        }
+        val distance = sqrt(bestDistSq)
+        val signed = if (lateralContains(px, pz)) -distance else distance
+        return LateralHit(bestX, bestZ, signed, bestEdgeX, bestEdgeZ)
+    }
+
+    /**
+     * A point on the outline, its signed distance, and the direction of the wall it lies on.
+     *
+     * The wall direction is carried because a point sitting exactly on the outline has no
+     * direction of its own to normalize, and the wall's own perpendicular is the answer there.
+     */
+    private data class LateralHit(
+        val x: Double,
+        val z: Double,
+        val signedDistance: Double,
+        val edgeX: Double,
+        val edgeZ: Double,
+    )
+
+    companion object {
+        private const val EDGE_EPSILON = 1e-6
+        private const val FAR_OUTSIDE = 1.0e9
+
+        /** How far off a wall to probe to find which side of it is outside. */
+        private const val NORMAL_PROBE = 1e-4
+
+        /**
+         * Cap grid points closer to the outline than this sample as wall points instead,
+         * so grid lines that coincide with an axis aligned edge do not double the wall.
+         */
+        private const val CAP_INSET = 1e-9
+    }
+}
+
+/** The first index of this sorted list whose value is at least [threshold], or the list's size. */
+private fun List<Double>.firstIndexAtLeast(threshold: Double): Int {
+    val found = binarySearch(threshold)
+    return if (found >= 0) found else -(found + 1)
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/shape/RayCast.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/shape/RayCast.kt
@@ -1,0 +1,125 @@
+package com.typewritermc.region.shape
+
+import com.typewritermc.core.utils.point.Vector
+import kotlin.math.abs
+import kotlin.math.min
+
+private const val RAY_STEP = 0.25
+private const val RAY_MAX_DISTANCE = 192.0
+private const val RAY_BISECTIONS = 12
+private const val RAY_REFINEMENTS = 8
+private const val PROJECTION_ITERATIONS = 3
+private const val GRADIENT_EPSILON = 0.01
+private const val PROJECTION_TOLERANCE = 0.05
+
+/**
+ * The first point on the shape's boundary along the local ray from [origin] in [direction] (a
+ * unit vector), or `null` when the ray does not cross the boundary within [maxDistance].
+ *
+ * The ray is stepped at a fixed interval and the crossing bisected, rather than sphere traced.
+ * A sphere trace needs a true distance field in every direction, which a rotated prism does not
+ * give, so it can step through a thin wall.
+ */
+fun Shape.raycastBoundary(
+    origin: Vector,
+    direction: Vector,
+    maxDistance: Double = RAY_MAX_DISTANCE,
+): Vector? {
+    var behind = 0.0
+    var behindDistance = signedDistance(origin)
+    var travelled = RAY_STEP
+
+    while (travelled <= maxDistance) {
+        val distance = signedDistance(origin + direction * travelled)
+        if (distance < 0.0 != behindDistance < 0.0) {
+            return bisectCrossing(origin, direction, behind, behindDistance, travelled)
+        }
+        // A step can enter and leave again between two samples: without the finer scan, a ray
+        // grazing a sphere's silhouette or crossing a cone near its apex reads as a clean miss.
+        // Only a step that came within its own length of the surface pays for the finer scan,
+        // measured on both sides: inside the shape both distances are negative, and comparing
+        // them signed would rescan every step of a ray cast from inside a region.
+        if (min(abs(distance), abs(behindDistance)) < RAY_STEP) {
+            refineCrossing(origin, direction, behind, behindDistance, travelled)?.let { return it }
+        }
+        behind = travelled
+        behindDistance = distance
+        travelled += RAY_STEP
+    }
+    return null
+}
+
+/**
+ * Rescans one march interval at [RAY_REFINEMENTS] times the resolution, for the crossing pair
+ * the coarse march stepped over. `null` when the interval really does not cross.
+ */
+private fun Shape.refineCrossing(
+    origin: Vector,
+    direction: Vector,
+    start: Double,
+    startDistance: Double,
+    end: Double,
+): Vector? {
+    var low = start
+    var lowDistance = startDistance
+    for (step in 1..RAY_REFINEMENTS) {
+        val at = start + (end - start) * step / RAY_REFINEMENTS
+        val distance = signedDistance(origin + direction * at)
+        if (distance < 0.0 != lowDistance < 0.0) {
+            return bisectCrossing(origin, direction, low, lowDistance, at)
+        }
+        low = at
+        lowDistance = distance
+    }
+    return null
+}
+
+private fun Shape.bisectCrossing(
+    origin: Vector,
+    direction: Vector,
+    start: Double,
+    startDistance: Double,
+    end: Double,
+): Vector {
+    var low = start
+    var lowDistance = startDistance
+    var high = end
+    repeat(RAY_BISECTIONS) {
+        val middle = (low + high) / 2.0
+        val distance = signedDistance(origin + direction * middle)
+        if (distance < 0.0 != lowDistance < 0.0) {
+            high = middle
+        } else {
+            low = middle
+            lowDistance = distance
+        }
+    }
+    return origin + direction * ((low + high) / 2.0)
+}
+
+/**
+ * The point on the boundary nearest to [local], by Newton steps along the numeric gradient of
+ * the signed distance. `null` where the gradient vanishes, like the exact center of a sphere,
+ * or where the steps do not converge within [PROJECTION_TOLERANCE]: a polygon prism near its
+ * corners or a cone have a signed distance that is only a bound, not an exact distance field,
+ * and Newton steps on a bound can bounce around a kink instead of settling on the boundary.
+ */
+fun Shape.nearestBoundaryPoint(local: Vector): Vector? {
+    var point = local
+    repeat(PROJECTION_ITERATIONS) {
+        val distance = signedDistance(point)
+        val gradient = Vector(
+            signedDistance(point + Vector(GRADIENT_EPSILON, 0.0, 0.0)) -
+                    signedDistance(point - Vector(GRADIENT_EPSILON, 0.0, 0.0)),
+            signedDistance(point + Vector(0.0, GRADIENT_EPSILON, 0.0)) -
+                    signedDistance(point - Vector(0.0, GRADIENT_EPSILON, 0.0)),
+            signedDistance(point + Vector(0.0, 0.0, GRADIENT_EPSILON)) -
+                    signedDistance(point - Vector(0.0, 0.0, GRADIENT_EPSILON)),
+        )
+        val length = gradient.length
+        if (length < 1e-9) return null
+        point -= gradient * (distance / length)
+    }
+    if (abs(signedDistance(point)) > PROJECTION_TOLERANCE) return null
+    return point
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/shape/Sampling.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/shape/Sampling.kt
@@ -1,0 +1,74 @@
+package com.typewritermc.region.shape
+
+import com.typewritermc.core.utils.point.Vector
+import kotlin.math.ceil
+import kotlin.math.max
+import kotlin.math.sqrt
+
+/**
+ * The most boundary samples any shape will emit, however large it is or however high its
+ * density is set.
+ *
+ * Without it the count grows with the square of the region's size: a sphere of radius 2000
+ * at the default density asks for 25 million samples, and the boundary displays turn each
+ * one into a fake entity or a block packet on the main thread. A region that big is beyond
+ * what any display can usefully draw, so past this point the boundary is drawn sparser
+ * rather than not at all.
+ */
+internal const val MAX_BOUNDARY_SAMPLES = 20_000
+
+/**
+ * The share of [MAX_BOUNDARY_SAMPLES] a step length is sized for.
+ *
+ * A sampler emits more than `boundaryArea / step²`: every axis run repeats the far endpoint
+ * and every ring has a minimum count of its own, so a step sized for the whole budget
+ * overshoots it on ordinary regions. [withinSampleBudget] cuts a contiguous tail rather than
+ * thinning the sampling, which deletes whole caps or wall rows, so the step leaves room and
+ * the hard cap stays a backstop for the shapes whose count no step can bound.
+ */
+private const val STEP_BUDGET_SHARE = 0.7
+
+/**
+ * Boundary sampling density converted to a step length, floored so extreme densities do
+ * not explode the sample count, and floored again so a shape of [boundaryArea] stays
+ * within [MAX_BOUNDARY_SAMPLES].
+ */
+internal fun sampleStep(density: Double, boundaryArea: Double): Double {
+    val fromDensity = max(1.0 / sqrt(density.coerceAtLeast(0.001)), 0.5)
+    if (boundaryArea <= 0.0) return fromDensity
+    return max(fromDensity, sqrt(boundaryArea / (MAX_BOUNDARY_SAMPLES * STEP_BUDGET_SHARE)))
+}
+
+/** Sample count for a shape of [boundaryArea], clamped to [MAX_BOUNDARY_SAMPLES]. */
+internal fun boundarySampleCount(boundaryArea: Double, density: Double): Int =
+    (boundaryArea * density).toInt().coerceIn(8, MAX_BOUNDARY_SAMPLES)
+
+/**
+ * Stops a boundary sequence at [MAX_BOUNDARY_SAMPLES].
+ *
+ * [sampleStep] only picks a step length, and a step length alone does not bound the count
+ * for a shape sampled edge by edge or ring by ring: a polygon emits at least one column per
+ * edge whatever the step is, so enough vertices breach the budget on their own. The step
+ * keeps the boundary evenly sampled and this keeps it finite.
+ */
+internal fun Sequence<Vector>.withinSampleBudget(): Sequence<Vector> = take(MAX_BOUNDARY_SAMPLES)
+
+/**
+ * Evenly divides [from]..[to] into segments no longer than [maxStep], returning the
+ * segment boundaries with both endpoints exact. A zero length range yields the single
+ * endpoint.
+ *
+ * Boundary samplers use this instead of accumulating float steps: accumulation drifts, so
+ * rows stop short of the far edge and adjacent faces no longer meet on their shared edge,
+ * which shows up as smeared or doubled edges in the boundary displays.
+ */
+internal fun axisSamples(from: Double, to: Double, maxStep: Double): List<Double> {
+    require(to >= from) { "Invalid sample range [$from, $to]" }
+    require(maxStep > 0.0) { "Sample step must be positive, was $maxStep" }
+    val span = to - from
+    if (span == 0.0) return listOf(from)
+    val segments = max(1, ceil(span / maxStep).toInt())
+    return List(segments + 1) { index ->
+        if (index == segments) to else from + span * index / segments
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/shape/Shape.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/shape/Shape.kt
@@ -1,0 +1,140 @@
+package com.typewritermc.region.shape
+
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.region.data.rotationMatrix
+import kotlin.math.sqrt
+
+/**
+ * A local frame geometric primitive. Shapes have no notion of world position; they answer
+ * geometric queries about a point already expressed in the shape's local coordinate system.
+ *
+ * The owning region is responsible for inverse transforming world positions before calling.
+ *
+ * The interface is sealed so the Typewriter editor knows the full set of concrete shape
+ * variants for the inline region inspector. New shapes are added by extending this interface and tagging
+ * the implementation with `@AlgebraicTypeInfo`.
+ */
+sealed interface Shape {
+    /**
+     * `false` when the fields do not describe a volume: a polygon of fewer than three points or
+     * of points in a straight line, a radius or an extent left at zero. Such a shape answers
+     * every query as "nothing is inside", which is the hardest kind of failure for a builder to
+     * diagnose, so the engine names its definition in the console instead.
+     */
+    val usable: Boolean get() = true
+
+    /**
+     * The axis aligned bounding box of the shape in local coordinates. Used for cheap
+     * rejection before exact queries.
+     */
+    val localBounds: LocalBounds
+
+    /**
+     * `true` when the local frame point is inside (or on the boundary of) the shape.
+     */
+    fun contains(localLoc: Vector): Boolean
+
+    /**
+     * Signed distance from the point to the shape's boundary. Negative inside, positive
+     * outside, zero on the boundary.
+     */
+    fun signedDistance(localLoc: Vector): Double
+
+    /**
+     * Signed distance from the point to the shape's vertical silhouette, measured in the
+     * local XZ plane. The local Y coordinate is ignored, so floor and ceiling faces do
+     * not contribute. For a region without pitch this is the world horizontal distance;
+     * with a pitched region the local XZ plane tilts along with the shape.
+     */
+    fun signedDistanceHorizontal(localLoc: Vector): Double
+
+    /**
+     * The closest point on the shape that lies on or outside the boundary. For a point
+     * already outside, this is the closest boundary point; for an interior point, this is
+     * the boundary point with the smallest outward distance.
+     */
+    fun nearestOutside(localLoc: Vector): Vector
+
+    /**
+     * Outward unit normals at (or relative to) the local frame point. Returns multiple
+     * normals when the nearest boundary feature is a corner/edge where two or more faces
+     * meet (a cuboid corner returns up to three). Smooth shapes return one.
+     */
+    fun outwardNormals(localLoc: Vector): List<Vector>
+
+    /**
+     * A sampling of points on the shape's boundary. Density is the number of samples per
+     * unit of boundary area. Implementations interpret it best effort.
+     */
+    fun sampleBoundary(density: Double): Sequence<Vector>
+}
+
+/**
+ * Unit direction of the average of [normals], or `null` when there is no meaningful
+ * direction (no normals, or normals that cancel out). Consumers of [Shape.outwardNormals]
+ * use this to turn a corner's multiple normals into a single push direction.
+ */
+fun averageUnitDirection(normals: List<Vector>): Vector? {
+    if (normals.isEmpty()) return null
+
+    var x = 0.0
+    var y = 0.0
+    var z = 0.0
+    for ((normalX, normalY, normalZ) in normals) {
+        x += normalX
+        y += normalY
+        z += normalZ
+    }
+
+    val length = sqrt(x * x + y * y + z * z)
+    if (length < 1e-6) return null
+    return Vector(x / length, y / length, z / length)
+}
+
+/**
+ * Axis aligned bounding box in local coordinates. Inclusive on both ends.
+ */
+data class LocalBounds(
+    val minX: Double,
+    val minY: Double,
+    val minZ: Double,
+    val maxX: Double,
+    val maxY: Double,
+    val maxZ: Double,
+) {
+    /**
+     * Returns the smallest [LocalBounds] containing the AABB after the region's stored
+     * rotation: yaw about the vertical axis, pitch about the local horizontal axis, roll
+     * about the local facing axis. Used for spatial pre filtering of dynamic regions
+     * whose rotation resolved this tick.
+     */
+    fun rotated(yawDegrees: Float, pitchDegrees: Float, rollDegrees: Float = 0f): LocalBounds {
+        if (yawDegrees == 0f && pitchDegrees == 0f && rollDegrees == 0f) return this
+
+        val rotation = rotationMatrix(yawDegrees, pitchDegrees, rollDegrees)
+
+        var newMinX = Double.POSITIVE_INFINITY
+        var newMinY = Double.POSITIVE_INFINITY
+        var newMinZ = Double.POSITIVE_INFINITY
+        var newMaxX = Double.NEGATIVE_INFINITY
+        var newMaxY = Double.NEGATIVE_INFINITY
+        var newMaxZ = Double.NEGATIVE_INFINITY
+
+        for (cornerX in 0..1) for (cornerY in 0..1) for (cornerZ in 0..1) {
+            val corner = rotation * Vector(
+                if (cornerX == 0) minX else maxX,
+                if (cornerY == 0) minY else maxY,
+                if (cornerZ == 0) minZ else maxZ,
+            )
+
+            newMinX = minOf(newMinX, corner.x)
+            newMaxX = maxOf(newMaxX, corner.x)
+            newMinY = minOf(newMinY, corner.y)
+            newMaxY = maxOf(newMaxY, corner.y)
+            newMinZ = minOf(newMinZ, corner.z)
+            newMaxZ = maxOf(newMaxZ, corner.z)
+        }
+
+        return LocalBounds(newMinX, newMinY, newMinZ, newMaxX, newMaxY, newMaxZ)
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/shape/SphereShape.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/shape/SphereShape.kt
@@ -1,0 +1,54 @@
+package com.typewritermc.region.shape
+
+import com.typewritermc.core.books.pages.Colors
+import com.typewritermc.core.extension.annotations.AlgebraicTypeInfo
+import com.typewritermc.core.extension.annotations.Default
+import com.typewritermc.core.extension.annotations.Help
+import com.typewritermc.core.extension.annotations.Min
+import com.typewritermc.core.utils.point.Vector
+import kotlin.math.PI
+import kotlin.math.max
+import kotlin.math.sqrt
+
+@AlgebraicTypeInfo("sphere_shape", Colors.PURPLE, "mdi:sphere")
+data class SphereShape(
+    @Min(0)
+    @Help("Sphere radius in blocks.")
+    @Default("1.0")
+    val radius: Double = 1.0,
+) : Shape {
+    init {
+        require(radius >= 0.0) { "Sphere radius must be non-negative, was $radius" }
+    }
+
+    override val usable: Boolean get() = radius > 0.0
+
+    override val localBounds: LocalBounds
+        get() = LocalBounds(-radius, -radius, -radius, radius, radius, radius)
+
+    override fun contains(localLoc: Vector): Boolean = localLoc.lengthSquared <= radius * radius
+
+    override fun signedDistance(localLoc: Vector): Double = localLoc.length - radius
+
+    override fun signedDistanceHorizontal(localLoc: Vector): Double =
+        sqrt(localLoc.x * localLoc.x + localLoc.z * localLoc.z) - radius
+
+    override fun nearestOutside(localLoc: Vector): Vector {
+        val len = localLoc.length
+        if (len < Vector.EPSILON) return Vector(radius, 0.0, 0.0)
+        val scale = radius / len
+        return Vector(localLoc.x * scale, localLoc.y * scale, localLoc.z * scale)
+    }
+
+    override fun outwardNormals(localLoc: Vector): List<Vector> {
+        val len = localLoc.length
+        if (len < Vector.EPSILON) return listOf(Vector(1.0, 0.0, 0.0))
+        return listOf(Vector(localLoc.x / len, localLoc.y / len, localLoc.z / len))
+    }
+
+    override fun sampleBoundary(density: Double): Sequence<Vector> {
+        if (radius <= 0.0) return sequenceOf(Vector.ZERO)
+        val surfaceArea = 4.0 * PI * radius * radius
+        return fibonacciSphereSamples(boundarySampleCount(surfaceArea, density), Vector(radius, radius, radius))
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/tracker/RegionTracker.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/tracker/RegionTracker.kt
@@ -1,0 +1,542 @@
+package com.typewritermc.region.tracker
+
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.core.utils.point.World
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.get
+import com.typewritermc.engine.paper.interaction.interactionContext
+import com.typewritermc.engine.paper.utils.position
+import com.typewritermc.engine.paper.utils.server
+import com.typewritermc.region.data.*
+import com.typewritermc.region.handler.EnterExitHandler
+import com.typewritermc.region.handler.LazyInsideQueryHandler
+import com.typewritermc.region.handler.ProximityHandler
+import com.typewritermc.region.handler.RegionHandler
+import com.typewritermc.region.shape.LocalBounds
+import com.typewritermc.region.shape.Shape
+import com.typewritermc.region.shape.hitboxSampleOffsets
+import org.bukkit.entity.Player
+import org.bukkit.event.player.PlayerMoveEvent
+import org.bukkit.util.BoundingBox
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.math.floor
+import kotlin.math.sqrt
+
+/**
+ * Tracks one region definition. When the definition's placement is fully constant, one
+ * tracker is shared by every subscriber and [viewer] is `null`. Otherwise each viewer gets
+ * their own tracker and [viewer] is that player.
+ *
+ * Enter and exit handlers are given the distance of the player's bounding box, so partial
+ * overlap counts as inside; proximity handlers are given the distance of their position.
+ *
+ * The handler lists are copy on write. Dispatch, the hot path, reads a snapshot without
+ * locking and the rare attach or detach pays for the copy. A suspending mutex cannot be
+ * used because dispatch runs inside non suspending Bukkit event handlers.
+ */
+class RegionTracker internal constructor(
+    val viewer: Player?,
+    private val definition: RegionDefinition,
+) {
+    private val handlerGeneration = AtomicLong()
+    private val enterExitHandlers = CopyOnWriteArrayList<EnterExitHandler>()
+    private val proximityHandlers = CopyOnWriteArrayList<ProximityHandler>()
+    private val lazyQueryHandlers = CopyOnWriteArrayList<LazyInsideQueryHandler>()
+
+    val shape: Shape = definition.buildShape()
+
+    /** Names this region in diagnostics. An inline definition has no entry to name. */
+    internal val definitionName: String
+        get() = (definition as? RegionDefinitionEntry)?.name ?: "inline region"
+
+    val tier: Tier = if (definition.hasConstPlacement) Tier.Static else Tier.Dynamic
+
+    val refreshRateTicks: Int get() = definition.refreshRateTicks
+
+    @Volatile
+    var lastTransform: ResolvedTransform? = null
+        private set
+
+    /**
+     * Cached world AABB of the resolved shape expanded by the largest constant proximity
+     * distance. `null` until the first [refresh] or when the transform cannot resolve.
+     */
+    @Volatile
+    internal var cachedAabb: WorldAabb? = null
+        private set
+
+    /**
+     * `true` when an attached proximity handler has a non constant distance or measures
+     * horizontally. No finite AABB margin covers such a handler, so the engine skips
+     * spatial pre filtering for this tracker.
+     */
+    @Volatile
+    internal var marginUnbounded: Boolean = false
+        private set
+
+    /**
+     * Set by the engine while the tracker lives in the registry. The scheduler drops
+     * unregistered trackers when they come due. Query cache trackers are never registered.
+     */
+    @Volatile
+    internal var isRegistered: Boolean = false
+
+    internal fun attach(handler: RegionHandler) {
+        when (handler) {
+            is EnterExitHandler -> enterExitHandlers.add(handler)
+            is ProximityHandler -> proximityHandlers.add(handler)
+            is LazyInsideQueryHandler -> lazyQueryHandlers.add(handler)
+        }
+        handlerGeneration.incrementAndGet()
+        refreshAabb()
+    }
+
+    internal fun detach(handler: RegionHandler) {
+        when (handler) {
+            is EnterExitHandler -> enterExitHandlers.remove(handler)
+            is ProximityHandler -> proximityHandlers.remove(handler)
+            is LazyInsideQueryHandler -> lazyQueryHandlers.remove(handler)
+        }
+        handlerGeneration.incrementAndGet()
+        refreshAabb()
+    }
+
+    internal fun isEmpty(): Boolean =
+        enterExitHandlers.isEmpty() && proximityHandlers.isEmpty() && lazyQueryHandlers.isEmpty()
+
+    internal fun wantsDispatch(): Boolean =
+        enterExitHandlers.isNotEmpty() || proximityHandlers.isNotEmpty()
+
+    /**
+     * Resolves the current world space transform and rebuilds the cached AABB. Called once
+     * at registration for static trackers and once per scheduled refresh for dynamic ones.
+     */
+    internal fun refresh() {
+        val viewer = viewer
+        if (viewer != null && !viewer.isOnline) {
+            lastTransform = null
+            cachedAabb = null
+            return
+        }
+
+        val context = viewer?.interactionContext
+        val origin = definition.origin.get(viewer, context)
+        val offset = definition.offset.get(viewer, context)
+        val yaw = definition.yaw.get(viewer, context)
+        val pitch = definition.pitch.get(viewer, context)
+        val roll = definition.roll.get(viewer, context)
+        if (origin == null || offset == null || yaw == null || pitch == null || roll == null) {
+            lastTransform = null
+            cachedAabb = null
+            return
+        }
+
+        val rotate = definition.rotateWithOrigin
+        val yawDegrees = if (rotate) yaw + origin.yaw else yaw
+        val pitchDegrees = if (rotate) pitch + origin.pitch else pitch
+        lastTransform = ResolvedTransform.fromOriginAndOffset(origin, offset, yawDegrees, pitchDegrees, roll)
+        refreshAabb()
+    }
+
+    /**
+     * Recomputes the cached AABB, and does it again whenever a handler arrived or left while it
+     * was computing.
+     *
+     * Two audience filters attaching at once would otherwise race, and the loser writes what it
+     * read before the winner's handler existed: a proximity band whose margin no AABB covers can
+     * end up recorded as bounded and two blocks wide, which takes the tracker into the chunk
+     * index and stops the band firing for anyone further out.
+     */
+    private fun refreshAabb() {
+        do {
+            val generation = handlerGeneration.get()
+            writeAabb()
+        } while (generation != handlerGeneration.get())
+    }
+
+    private fun writeAabb() {
+        val transform = lastTransform
+        if (transform == null) {
+            cachedAabb = null
+            return
+        }
+
+        var margin = 0.0
+        var unbounded = false
+        for (handler in proximityHandlers) {
+            if (handler.distanceMode == DistanceMode.HORIZONTAL) {
+                unbounded = true
+                continue
+            }
+            val distance = handler.distance
+            if (distance is ConstVar) {
+                margin = maxOf(margin, distance.value)
+            } else {
+                unbounded = true
+            }
+        }
+        if (enterExitHandlers.isNotEmpty()) margin = maxOf(margin, HITBOX_MARGIN)
+
+        marginUnbounded = unbounded
+        val rotated = shape.localBounds.rotated(
+            transform.yawDegrees,
+            transform.pitchDegrees,
+            transform.rollDegrees,
+        )
+        cachedAabb = WorldAabb.of(transform, rotated, margin.coerceAtLeast(0.0))
+    }
+
+    fun isInside(worldPosition: Position): Boolean {
+        val transform = lastTransform ?: return false
+        if (transform.world != worldPosition.world) return false
+
+        val local = transform.toLocal(Vector(worldPosition.x, worldPosition.y, worldPosition.z))
+        return shape.contains(local)
+    }
+
+    /**
+     * `true` when any part of the player's bounding box overlaps the resolved shape. This
+     * is the same membership check enter and exit classification uses.
+     */
+    fun isInside(player: Player): Boolean {
+        val signed = classifyHitbox(player, player.position) ?: return false
+        return signed <= 0.0
+    }
+
+    /**
+     * How many of [players] have any part of their body inside the region, answered once per
+     * server tick.
+     *
+     * A count fact is read once per reader per refresh, and every read classifies every player's
+     * hitbox, so a sidebar showing the count on a full server ran players squared distance
+     * evaluations several times a second. Nothing about the count changes within a tick, so one
+     * tick's answer serves every reader of that tick.
+     */
+    fun countInside(players: Collection<Player>): Int {
+        val tick = server.currentTick
+        val memo = insideCount
+        if (memo != null && memo.tick == tick) return memo.count
+        var count = 0
+        for (player in players) if (isInside(player)) count++
+        insideCount = InsideCount(tick, count)
+        return count
+    }
+
+    @Volatile
+    private var insideCount: InsideCount? = null
+
+    private class InsideCount(val tick: Int, val count: Int)
+
+    /**
+     * Signed distance from the position to the shape boundary. Negative inside, positive
+     * outside. Returns `null` when the transform is unresolved or the position is in
+     * another world.
+     */
+    fun signedDistance(worldPosition: Position): Double? = classify(worldPosition)
+
+    /** [signedDistance] against the vertical silhouette only, ignoring floor and ceiling faces. */
+    fun signedDistanceHorizontal(worldPosition: Position): Double? = classifyHorizontal(worldPosition)
+
+    fun signedDistance(worldPosition: Position, mode: DistanceMode): Double? = when (mode) {
+        DistanceMode.FULL -> classify(worldPosition)
+        DistanceMode.HORIZONTAL -> classifyHorizontal(worldPosition)
+    }
+
+    /**
+     * The smallest signed distance over the player's bounding box at their live position.
+     * This is the metric enter and exit classification observes; expose it so diagnostics
+     * can report exactly what the handlers see.
+     */
+    fun hitboxDistance(player: Player): Double? = classifyHitbox(player, player.position)
+
+    /**
+     * Unit direction in the world XZ plane along which the signed distance to the region
+     * grows fastest, or radially away from the region anchor when the gradient vanishes.
+     * The barrier and push action use it to steer grounded players toward a lateral exit
+     * instead of into the floor or ceiling. Returns `null` only when the transform is
+     * unresolved or the position is in another world.
+     */
+    fun horizontalEscapeDirection(worldPosition: Position): Vector? {
+        val transform = lastTransform ?: return null
+        if (transform.world != worldPosition.world) return null
+
+        // The silhouette, not the full field: this is only ever called when the nearest face is
+        // the floor or the ceiling, and there the full field's horizontal gradient is flat, so
+        // differencing it hands back nothing and the player keeps being pushed into the floor.
+        fun distanceAt(dx: Double, dz: Double): Double = shape.signedDistanceHorizontal(
+            transform.toLocal(Vector(worldPosition.x + dx, worldPosition.y, worldPosition.z + dz)),
+        )
+
+        val gradientX = distanceAt(GRADIENT_STEP, 0.0) - distanceAt(-GRADIENT_STEP, 0.0)
+        val gradientZ = distanceAt(0.0, GRADIENT_STEP) - distanceAt(0.0, -GRADIENT_STEP)
+        val gradientLength = sqrt(gradientX * gradientX + gradientZ * gradientZ)
+        if (gradientLength > Vector.EPSILON) {
+            return Vector(gradientX / gradientLength, 0.0, gradientZ / gradientLength)
+        }
+
+        val anchorX = worldPosition.x - transform.worldOrigin.x
+        val anchorZ = worldPosition.z - transform.worldOrigin.z
+        val anchorLength = sqrt(anchorX * anchorX + anchorZ * anchorZ)
+        if (anchorLength > Vector.EPSILON) {
+            return Vector(anchorX / anchorLength, 0.0, anchorZ / anchorLength)
+        }
+
+        // Dead center of a symmetric region: every lateral direction leads out as well as the
+        // next. The caller only asks here because the face it found points at the floor or the
+        // ceiling, and answering nothing leaves the player pressed into one of them.
+        return CENTERED_ESCAPE
+    }
+
+    /**
+     * `true` when any attached enter/exit handler currently counts [player] as entered.
+     * Diagnostics report it next to the geometric membership, so a gap between
+     * "geometrically inside" and "enter fired" is directly visible.
+     */
+    fun countsAsEntered(player: Player): Boolean = enterExitHandlers.any { it.tracks(player) }
+
+    /**
+     * Snapshot of the tracker's state for the `/typewriter region debug` command.
+     */
+    fun debugSnapshot(): DebugSnapshot = DebugSnapshot(
+        registered = isRegistered,
+        enterExitHandlers = enterExitHandlers.size,
+        proximityHandlers = proximityHandlers.size,
+        lazyQueryHandlers = lazyQueryHandlers.size,
+        transform = lastTransform,
+    )
+
+    data class DebugSnapshot(
+        val registered: Boolean,
+        val enterExitHandlers: Int,
+        val proximityHandlers: Int,
+        val lazyQueryHandlers: Int,
+        val transform: ResolvedTransform?,
+    )
+
+    /**
+     * Classifies [player] at [position] and notifies every attached handler with the metric
+     * that handler observes. Returns `true` when a handler requests cancellation of
+     * [moveEvent]. The engine ignores the result on the async reconcile path, where there
+     * is no move event.
+     */
+    internal fun dispatch(
+        player: Player,
+        position: Position,
+        cause: CrossingCause,
+        moveEvent: PlayerMoveEvent?,
+    ): Boolean {
+        // The check comes before the metrics: classifying a player's whole hitbox is forty five signed
+        // distance evaluations, and every handler here would throw the result away.
+        if (!wantsPlayer(player)) return false
+        val metrics = metricsAt(player, position)
+        var cancel = false
+        forEachDispatchHandler { handler ->
+            if (handler.onClassification(player, metrics.metricFor(handler), cause, moveEvent)) cancel = true
+        }
+        return cancel
+    }
+
+    /**
+     * Updates every handler's membership for [player] as if they stood at [position],
+     * without firing callbacks, and marks the crossing refused. The engine calls this after
+     * cancelling a move, so no handler keeps state from the rolled back crossing and none of
+     * them fires it again on the next move.
+     */
+    internal fun resyncAt(player: Player, position: Position) {
+        val metrics = metricsAt(player, position)
+        // The refusal comes before the resync. It tells a handler which side it was heading
+        // for, and the resync needs that: the player is left standing where their body still
+        // overlaps the region, so deriving membership from the geometry alone would put them
+        // back on the side they were just refused from.
+        forEachDispatchHandler { it.refuse(player) }
+        forEachDispatchHandler { it.resync(player, metrics.metricFor(it)) }
+    }
+
+    /** Forgets the refusals [resyncAt] recorded, once [player] completes a move. */
+    internal fun clearRefusals(player: Player) {
+        forEachDispatchHandler { it.clearRefusal(player) }
+    }
+
+    /**
+     * Aligns a fresh handler's membership with the player's current position without
+     * firing callbacks, using the same metric the handler observes during dispatch.
+     */
+    internal fun seedHandler(player: Player, handler: RegionHandler) {
+        val metric = when (handler) {
+            is EnterExitHandler -> classifyHitbox(player, player.position)
+            is ProximityHandler -> when (handler.distanceMode) {
+                DistanceMode.FULL -> classify(player.position)
+                DistanceMode.HORIZONTAL -> classifyHorizontal(player.position)
+            }
+
+            is LazyInsideQueryHandler -> return
+        }
+        handler.resync(player, metric)
+    }
+
+    /** Aligns every attached handler's membership with [players], firing nothing. */
+    internal fun seedHandlers(players: Collection<Player>) {
+        for (player in players) forEachDispatchHandler { seedHandler(player, it) }
+    }
+
+    /**
+     * Final dispatch for a player leaving the server. Every handler sees a `null`
+     * classification, fires a leave for current members, and drops their state.
+     */
+    internal fun evict(player: Player, cause: CrossingCause) {
+        forEachDispatchHandler { it.onClassification(player, null, cause, null) }
+    }
+
+    /**
+     * `true` when any attached handler still considers [player] a member. The engine only
+     * skips a tracker for a player outside its world AABB when this is `false`, otherwise
+     * the exit would never be dispatched.
+     */
+    internal fun hasMember(player: Player): Boolean =
+        enterExitHandlers.any { it.tracks(player) } || proximityHandlers.any { it.tracks(player) }
+
+    private fun wantsPlayer(player: Player): Boolean {
+        val uuid = player.uniqueId
+        return enterExitHandlers.any { it.tracked == null || it.tracked == uuid } ||
+                proximityHandlers.any { it.tracked == null || it.tracked == uuid }
+    }
+
+    private inline fun forEachDispatchHandler(action: (RegionHandler) -> Unit) {
+        for (handler in enterExitHandlers) action(handler)
+        for (handler in proximityHandlers) action(handler)
+    }
+
+    private fun classify(position: Position): Double? {
+        val transform = lastTransform ?: return null
+        if (transform.world != position.world) return null
+
+        val local = transform.toLocal(Vector(position.x, position.y, position.z))
+        return shape.signedDistance(local)
+    }
+
+    private fun classifyHorizontal(position: Position): Double? {
+        val transform = lastTransform ?: return null
+        if (transform.world != position.world) return null
+
+        val local = transform.toLocal(Vector(position.x, position.y, position.z))
+        return shape.signedDistanceHorizontal(local)
+    }
+
+    /**
+     * The smallest signed distance over sample points of the player's bounding box,
+     * anchored at [position]. Negative as soon as a sample lands in the shape, so a player
+     * brushing a thin region (like a cone near its apex) still classifies as inside, down
+     * to the lattice's spacing.
+     */
+    private fun classifyHitbox(player: Player, position: Position): Double? {
+        val transform = lastTransform ?: return null
+        if (transform.world != position.world) return null
+
+        val box = player.boundingBox
+        var min = Double.MAX_VALUE
+        for ((x, y, z) in hitboxSampleOffsets(box.widthX / 2.0, box.height)) {
+            val local = transform.toLocal(
+                Vector(position.x + x, position.y + y, position.z + z),
+            )
+            val signed = shape.signedDistance(local)
+            if (signed < min) min = signed
+        }
+        return min
+    }
+
+    private fun metricsAt(player: Player, position: Position): Metrics {
+        var needFull = false
+        var needHorizontal = false
+        for (handler in proximityHandlers) {
+            when (handler.distanceMode) {
+                DistanceMode.FULL -> needFull = true
+                DistanceMode.HORIZONTAL -> needHorizontal = true
+            }
+        }
+        return Metrics(
+            hitbox = if (enterExitHandlers.isNotEmpty()) classifyHitbox(player, position) else null,
+            full = if (needFull) classify(position) else null,
+            horizontal = if (needHorizontal) classifyHorizontal(position) else null,
+        )
+    }
+
+    private class Metrics(val hitbox: Double?, val full: Double?, val horizontal: Double?) {
+        fun metricFor(handler: RegionHandler): Double? = when (handler) {
+            is EnterExitHandler -> hitbox
+            is ProximityHandler -> when (handler.distanceMode) {
+                DistanceMode.FULL -> full
+                DistanceMode.HORIZONTAL -> horizontal
+            }
+
+            is LazyInsideQueryHandler -> null
+        }
+    }
+
+    companion object {
+        /**
+         * AABB slack covering the largest player bounding box, so a player whose feet are
+         * outside the shape's AABB but whose body overlaps the region is still dispatched.
+         */
+        private const val HITBOX_MARGIN = 2.0
+
+        /** Half width of the central difference used by [horizontalEscapeDirection]. */
+        private const val GRADIENT_STEP = 0.25
+
+        /** The lateral direction [horizontalEscapeDirection] falls back on at a region's center. */
+        private val CENTERED_ESCAPE = Vector(1.0, 0.0, 0.0)
+    }
+}
+
+/**
+ * Inclusive world space AABB. The engine uses it to cheaply reject players before
+ * classifying and to compute the chunk span for the spatial index.
+ */
+internal data class WorldAabb(
+    val world: World,
+    val minX: Double,
+    val minY: Double,
+    val minZ: Double,
+    val maxX: Double,
+    val maxY: Double,
+    val maxZ: Double,
+) {
+    val minChunkX: Int get() = floor(minX).toInt() shr 4
+    val maxChunkX: Int get() = floor(maxX).toInt() shr 4
+    val minChunkZ: Int get() = floor(minZ).toInt() shr 4
+    val maxChunkZ: Int get() = floor(maxZ).toInt() shr 4
+
+    fun contains(position: Position): Boolean =
+        position.x in minX..maxX && position.y in minY..maxY && position.z in minZ..maxZ
+
+    /**
+     * Whether a player standing at [position] could overlap this box with any part of [box].
+     *
+     * The classification samples the whole hitbox but the position is the player's feet, so the
+     * box has to be accounted for here too. A scaled player is the case that makes this matter:
+     * `generic.scale` reaches 16, which is a hitbox 28.8 blocks tall, far past any fixed slack.
+     */
+    fun reachableBy(position: Position, box: BoundingBox): Boolean {
+        if (world != position.world) return false
+        val halfWidth = box.widthX / 2.0
+        return position.x in (minX - halfWidth)..(maxX + halfWidth) &&
+                position.y in (minY - box.height)..maxY &&
+                position.z in (minZ - halfWidth)..(maxZ + halfWidth)
+    }
+
+    companion object {
+        fun of(transform: ResolvedTransform, rotated: LocalBounds, margin: Double): WorldAabb {
+            val origin = transform.worldOrigin
+            return WorldAabb(
+                world = transform.world,
+                minX = origin.x + rotated.minX - margin,
+                minY = origin.y + rotated.minY - margin,
+                minZ = origin.z + rotated.minZ - margin,
+                maxX = origin.x + rotated.maxX + margin,
+                maxY = origin.y + rotated.maxY + margin,
+                maxZ = origin.z + rotated.maxZ + margin,
+            )
+        }
+    }
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/tracker/Tier.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/tracker/Tier.kt
@@ -1,0 +1,13 @@
+package com.typewritermc.region.tracker
+
+/**
+ * The tier of a [RegionTracker], which decides whether the engine schedules per tick
+ * reconciliation for it or only consults it on Bukkit player move events.
+ */
+enum class Tier {
+    /** Geometry never changes between ticks for this viewer; only consulted on PlayerMove. */
+    Static,
+
+    /** Geometry or a handler's parameters change between ticks; reconciled each cycle. */
+    Dynamic,
+}

--- a/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/tracker/TrackerKey.kt
+++ b/extensions/RegionExtension/src/main/kotlin/com/typewritermc/region/tracker/TrackerKey.kt
@@ -1,0 +1,22 @@
+package com.typewritermc.region.tracker
+
+import com.typewritermc.region.data.RegionDefinition
+import java.util.UUID
+
+/**
+ * Identifies a tracker in the engine's registry.
+ *
+ * Keys compare by the [definition] itself. [RegionDefinitionEntry][com.typewritermc.region.data.RegionDefinitionEntry]
+ * instances are singletons, and inline
+ * [RegionDefinitionData][com.typewritermc.region.data.RegionDefinitionData] is a data class
+ * whose `Var` fields implement value equality, so two structurally identical inline
+ * definitions share one tracker.
+ *
+ * [viewerId] is `null` for definitions whose placement is fully constant. Those resolve the
+ * same for everyone and are shared by all subscribers. Definitions with any non const
+ * placement `Var` get one tracker per viewer.
+ */
+data class TrackerKey(
+    val definition: RegionDefinition,
+    val viewerId: UUID?,
+)

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/RegionEngineSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/RegionEngineSpec.kt
@@ -1,0 +1,331 @@
+package com.typewritermc.region
+
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.core.utils.point.World
+import com.typewritermc.engine.paper.entry.entries.ComputeVar
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.interaction.PlayerSessionManager
+import com.typewritermc.region.data.CrossingCause
+import com.typewritermc.region.data.DistanceMode
+import com.typewritermc.region.data.RegionDefinitionData
+import com.typewritermc.region.handler.EnterExitHandler
+import com.typewritermc.region.handler.ProximityHandler
+import com.typewritermc.region.shape.ConeShape
+import com.typewritermc.region.shape.CuboidShape
+import com.typewritermc.region.shape.SphereShape
+import com.typewritermc.engine.paper.utils.toPosition
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.mockk
+import org.bukkit.Location
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.HandlerList
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerJoinEvent
+import org.bukkit.event.player.PlayerMoveEvent
+import org.bukkit.event.player.PlayerTeleportEvent
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.mockbukkit.mockbukkit.MockBukkit
+import org.mockbukkit.mockbukkit.ServerMock
+import org.mockbukkit.mockbukkit.world.WorldMock
+
+class RegionEngineSpec : FunSpec() {
+    private lateinit var server: ServerMock
+    private lateinit var world: WorldMock
+
+    private fun position(x: Double, y: Double, z: Double) =
+        Position(World(world.uid.toString()), x, y, z, 0f, 0f)
+
+    private fun location(x: Double, y: Double, z: Double) = Location(world, x, y, z)
+
+    private fun move(engine: RegionEngine, player: Player, to: Location): PlayerMoveEvent {
+        val from = player.location
+        player.teleport(to)
+        val event = PlayerMoveEvent(player, from, to)
+        engine.onMove(event)
+        return event
+    }
+
+    init {
+        beforeSpec {
+            server = MockBukkit.mock()
+            world = server.addSimpleWorld("region-world")
+            startKoin {
+                modules(module { single { mockk<PlayerSessionManager>(relaxed = true) } })
+            }
+        }
+
+        afterSpec {
+            stopKoin()
+            MockBukkit.unmock()
+        }
+
+        test("a player brushing a cone apex counts as inside") {
+            val engine = RegionEngine()
+            val player = server.addPlayer()
+            player.teleport(location(90.0, 64.0, 90.0))
+
+            val region = RegionDefinitionData(
+                origin = ConstVar(position(100.0, 64.9, 100.0)),
+                shape = ConeShape(length = 8.0, halfAngleDegrees = 30.0),
+            )
+            val enters = mutableListOf<CrossingCause>()
+            val handler = EnterExitHandler(
+                owner = "test",
+                onEnter = { _, cause, _ -> enters.add(cause); false },
+            )
+            val subscription = engine.observe(region, null, handler)!!
+
+            subscription.tracker.isInside(position(100.0, 64.0, 100.0)) shouldBe false
+            subscription.tracker.isInside(player) shouldBe false
+
+            move(engine, player, location(100.0, 64.0, 100.0))
+            enters shouldBe listOf(CrossingCause.PLAYER_MOVED)
+            subscription.tracker.isInside(player) shouldBe true
+
+            subscription.cancel()
+        }
+
+        test("boundary inset keeps a member while skimming the boundary") {
+            val engine = RegionEngine()
+            val player = server.addPlayer()
+            player.teleport(location(93.0, 61.0, 100.0))
+
+            val region = RegionDefinitionData(
+                origin = ConstVar(position(100.0, 64.0, 100.0)),
+                shape = CuboidShape(5.0, 5.0, 5.0),
+            )
+            val events = mutableListOf<String>()
+            val handler = EnterExitHandler(
+                owner = "test",
+                boundaryInset = ConstVar(0.5),
+                onEnter = { _, _, _ -> events.add("enter"); false },
+                onLeave = { _, _, _ -> events.add("leave"); false },
+            )
+            val subscription = engine.observe(region, null, handler)!!
+
+            move(engine, player, location(94.8, 61.0, 100.0))
+            events shouldBe listOf("enter")
+
+            move(engine, player, location(94.5, 61.0, 100.0))
+            events shouldBe listOf("enter")
+
+            move(engine, player, location(94.8, 61.0, 100.0))
+            events shouldBe listOf("enter")
+
+            move(engine, player, location(93.5, 61.0, 100.0))
+            events shouldBe listOf("enter", "leave")
+
+            move(engine, player, location(94.5, 61.0, 100.0))
+            events shouldBe listOf("enter", "leave")
+
+            subscription.cancel()
+        }
+
+        test("a shallow overlap fires enter the moment the boundary is crossed") {
+            val engine = RegionEngine()
+            val player = server.addPlayer()
+            player.teleport(location(93.0, 61.0, 100.0))
+
+            val region = RegionDefinitionData(
+                origin = ConstVar(position(100.0, 64.0, 100.0)),
+                shape = CuboidShape(5.0, 5.0, 5.0),
+            )
+            val events = mutableListOf<String>()
+            val handler = EnterExitHandler(
+                owner = "test",
+                boundaryInset = ConstVar(0.5),
+                onEnter = { _, _, _ -> events.add("enter"); false },
+                onLeave = { _, _, _ -> events.add("leave"); false },
+            )
+            val subscription = engine.observe(region, null, handler)!!
+
+            move(engine, player, location(94.8, 61.0, 100.0))
+            subscription.tracker.isInside(player) shouldBe true
+            events shouldBe listOf("enter")
+
+            subscription.cancel()
+        }
+
+        test("teleports classify with the Teleported cause") {
+            val engine = RegionEngine()
+            val player = server.addPlayer()
+            player.teleport(location(90.0, 61.0, 100.0))
+
+            val region = RegionDefinitionData(
+                origin = ConstVar(position(100.0, 64.0, 100.0)),
+                shape = CuboidShape(5.0, 5.0, 5.0),
+            )
+            val enters = mutableListOf<CrossingCause>()
+            val subscription = engine.observe(
+                region,
+                null,
+                EnterExitHandler(
+                    owner = "test",
+                    onEnter = { _, cause, _ -> enters.add(cause); false },
+                ),
+            )!!
+
+            val from = player.location
+            val to = location(100.0, 61.0, 100.0)
+            player.teleport(to)
+            engine.onTeleport(PlayerTeleportEvent(player, from, to))
+
+            enters shouldBe listOf(CrossingCause.TELEPORTED)
+            subscription.cancel()
+        }
+
+        test("a cancelled enter rolls membership back") {
+            val engine = RegionEngine()
+            val player = server.addPlayer()
+            player.teleport(location(90.0, 61.0, 100.0))
+
+            val region = RegionDefinitionData(
+                origin = ConstVar(position(100.0, 64.0, 100.0)),
+                shape = CuboidShape(5.0, 5.0, 5.0),
+            )
+            val handler = EnterExitHandler(
+                owner = "test",
+                onEnter = { _, _, _ -> true },
+            )
+            val subscription = engine.observe(region, null, handler)!!
+
+            val event = move(engine, player, location(100.0, 61.0, 100.0))
+
+            event.isCancelled shouldBe true
+            handler.tracks(player) shouldBe false
+            subscription.cancel()
+        }
+
+        test("a moving region engulfing a player fires Engulfed crossings") {
+            val engine = RegionEngine()
+            val player = server.addPlayer()
+            player.teleport(location(100.0, 64.0, 100.0))
+
+            var origin = position(100.0, 90.0, 100.0)
+            val region = RegionDefinitionData(
+                origin = ComputeVar { _, _ -> origin },
+                shape = SphereShape(3.0),
+            )
+            val events = mutableListOf<Pair<String, CrossingCause>>()
+            val handler = EnterExitHandler(
+                owner = "test",
+                tracked = player.uniqueId,
+                onEnter = { _, cause, _ -> events.add("enter" to cause); false },
+                onLeave = { _, cause, _ -> events.add("leave" to cause); false },
+            )
+            val subscription = engine.observe(region, player, handler)!!
+            handler.tracks(player) shouldBe false
+
+            origin = position(100.0, 65.0, 100.0)
+            engine.refreshAndReconcile(subscription.tracker)
+            events shouldBe listOf("enter" to CrossingCause.ENGULFED)
+
+            origin = position(100.0, 90.0, 100.0)
+            engine.refreshAndReconcile(subscription.tracker)
+            events shouldBe listOf("enter" to CrossingCause.ENGULFED, "leave" to CrossingCause.ENGULFED)
+
+            subscription.cancel()
+        }
+
+        test("the guard tutorial cone spots a player walking toward the guard") {
+            val engine = RegionEngine()
+            val player = server.addPlayer()
+            player.teleport(location(185.0, 64.0, 200.0))
+
+            val guard = Position(World(world.uid.toString()), 200.0, 64.0, 200.0, 90f, 0f)
+            val region = RegionDefinitionData(
+                origin = ComputeVar { _, _ -> guard },
+                offset = ConstVar(Vector(0.0, 1.6, 0.0)),
+                rotateWithOrigin = true,
+                shape = ConeShape(length = 12.0, halfAngleDegrees = 30.0),
+            )
+            val enters = mutableListOf<CrossingCause>()
+            val handler = EnterExitHandler(
+                owner = "test",
+                tracked = player.uniqueId,
+                boundaryInset = ConstVar(0.5),
+                onEnter = { _, cause, _ -> enters.add(cause); false },
+            )
+            val subscription = engine.observe(region, player, handler)!!
+
+            var x = 185.0
+            var enteredAt = Double.NaN
+            while (x < 196.0) {
+                x += 0.2
+                move(engine, player, location(x, 64.0, 200.0))
+                engine.refreshAndReconcile(subscription.tracker)
+                if (enters.isNotEmpty() && enteredAt.isNaN()) enteredAt = x
+            }
+
+            enters.isNotEmpty() shouldBe true
+            (200.0 - enteredAt >= 8.0) shouldBe true
+            subscription.tracker.isInside(player) shouldBe true
+
+            subscription.cancel()
+        }
+
+        test("horizontal proximity ignores height while full does not") {
+            val engine = RegionEngine()
+            val player = server.addPlayer()
+            player.teleport(location(208.0, 90.0, 200.0))
+
+            val region = RegionDefinitionData(
+                origin = ConstVar(position(200.0, 64.0, 200.0)),
+                shape = CuboidShape(5.0, 2.0, 5.0),
+            )
+            val horizontal = ProximityHandler("test", player.uniqueId, ConstVar(3.0), DistanceMode.HORIZONTAL)
+            val full = ProximityHandler("test", player.uniqueId, ConstVar(3.0), DistanceMode.FULL)
+            val first = engine.observe(region, null, horizontal)!!
+            val second = engine.observe(region, null, full)!!
+
+            horizontal.tracks(player) shouldBe true
+            full.tracks(player) shouldBe false
+
+            first.cancel()
+            second.cancel()
+        }
+
+        // The audience manager and the event binder both subscribe from PlayerJoinEvent at NORMAL
+        // priority, so the engine has to have recorded the joiner by then. Without that, every
+        // region with a variable placement is refused for the rest of that player's session.
+        test("a region subscribed to while a player joins is kept") {
+            val engine = RegionEngine()
+            val plugin = MockBukkit.createMockPlugin("region-join-test")
+            engine.recordRoster(server.onlinePlayers)
+            server.pluginManager.registerEvents(engine, plugin)
+
+            val region = RegionDefinitionData(
+                origin = ComputeVar { viewer, _ -> viewer?.location?.toPosition() ?: position(0.0, 0.0, 0.0) },
+                shape = SphereShape(5.0),
+            )
+            var subscription: RegionEngine.Subscription? = null
+            val binder = object : Listener {
+                @EventHandler
+                fun onJoin(event: PlayerJoinEvent) {
+                    subscription = engine.observe(
+                        region,
+                        event.player,
+                        EnterExitHandler(owner = "test", tracked = event.player.uniqueId),
+                    )
+                }
+            }
+            server.pluginManager.registerEvents(binder, plugin)
+
+            val joiner = server.addPlayer()
+
+            withClue("the joiner's own bubble region was refused") { subscription shouldNotBe null }
+            subscription!!.tracker.viewer shouldBe joiner
+
+            subscription!!.cancel()
+            HandlerList.unregisterAll(binder)
+            HandlerList.unregisterAll(engine)
+        }
+    }
+}

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/CoalescingReproSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/CoalescingReproSpec.kt
@@ -1,0 +1,101 @@
+package com.typewritermc.region.content
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Covers undo without the wand, using the real labels and windows from RegionContentMode:
+ * rotate gestures record per axis ("Yaw", "Pitch") with a 1200ms scroll window, and clicks
+ * record with window 0 and never coalesce.
+ */
+class CoalescingReproSpec : FunSpec({
+    test("A: a yaw scroll and a pitch scroll stay separate entries") {
+        val history = EditHistory()
+        history.record(
+            "rotate",
+            "Yaw",
+            mapOf("work.yaw" to 0f),
+            mapOf("work.yaw" to 5f),
+            coalesceMillis = 1200,
+            now = 0
+        )
+        history.record(
+            "rotate",
+            "Pitch",
+            mapOf("work.pitch" to 0f),
+            mapOf("work.pitch" to 5f),
+            coalesceMillis = 1200,
+            now = 500
+        )
+
+        history.undoCount shouldBe 2
+        history.undoTool("rotate").shouldBeInstanceOf<ToolHistoryResult.Restored>()
+            .change.values shouldBe mapOf("work.pitch" to 0f)
+        history.undoTool("rotate").shouldBeInstanceOf<ToolHistoryResult.Restored>()
+            .change.values shouldBe mapOf("work.yaw" to 0f)
+    }
+
+    test("B: a fine scroll after a rotate click stays its own entry, one Q reverts only the scroll") {
+        val history = EditHistory()
+        history.record("rotate", "Yaw", mapOf("work.yaw" to 0f), mapOf("work.yaw" to 15f), coalesceMillis = 0, now = 0)
+        history.record(
+            "rotate",
+            "Yaw",
+            mapOf("work.yaw" to 15f),
+            mapOf("work.yaw" to 20f),
+            coalesceMillis = 1200,
+            now = 300
+        )
+
+        history.undoCount shouldBe 2
+        history.undoTool("rotate").shouldBeInstanceOf<ToolHistoryResult.Restored>()
+            .change.values shouldBe mapOf("work.yaw" to 15f)
+    }
+
+    test("C: a scroll out and back leaves no entry and no phantom undo") {
+        val history = EditHistory()
+        history.record(
+            "resize",
+            "+Z face",
+            mapOf("size.halfZ" to 6.5),
+            mapOf("size.halfZ" to 6.75),
+            coalesceMillis = 1200,
+            now = 0
+        )
+        history.record(
+            "resize",
+            "+Z face",
+            mapOf("size.halfZ" to 6.75),
+            mapOf("size.halfZ" to 6.5),
+            coalesceMillis = 1200,
+            now = 300
+        )
+
+        history.undoCount shouldBe 0
+        history.undoTool("resize") shouldBe ToolHistoryResult.NothingLeft
+    }
+
+    test("D: a fine-tuning session chunks at the burst cap instead of collapsing into one step") {
+        val history = EditHistory()
+        var yaw = 0f
+        var now = 0L
+        repeat(20) {
+            history.record(
+                "rotate",
+                "Yaw",
+                mapOf("work.yaw" to yaw),
+                mapOf("work.yaw" to yaw + 5f),
+                coalesceMillis = 1200,
+                now = now
+            )
+            yaw += 5f
+            now += 1000
+        }
+
+        // Notches 1s apart never hit the 1200ms gap, but the 4s cap cuts a chunk of four.
+        history.undoCount shouldBe 5
+        history.undoTool("rotate").shouldBeInstanceOf<ToolHistoryResult.Restored>()
+            .change.values shouldBe mapOf("work.yaw" to 80f)
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/EditHistorySpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/EditHistorySpec.kt
@@ -1,0 +1,432 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.core.utils.point.Vector
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class EditHistorySpec : FunSpec({
+    fun state(vararg pairs: Pair<String, Any?>): Map<String, Any?> = mapOf(*pairs)
+
+    test("undo applies the before values and redo the after values") {
+        val history = EditHistory()
+        history.record("move", "Origin nudge", state("origin" to 1.0), state("origin" to 2.0)).shouldBeTrue()
+
+        val undone = history.undoLast().shouldNotBeNull()
+        undone.label shouldBe "Origin nudge"
+        undone.values shouldBe state("origin" to 1.0)
+
+        val redone = history.redoLast().shouldNotBeNull()
+        redone.values shouldBe state("origin" to 2.0)
+    }
+
+    test("only changed keys land in the entry") {
+        val history = EditHistory()
+        history.record(
+            "resize", "+X face",
+            state("halfX" to 2.0, "halfY" to 3.0),
+            state("halfX" to 4.0, "halfY" to 3.0),
+        ).shouldBeTrue()
+
+        history.undoLast().shouldNotBeNull().values shouldBe state("halfX" to 2.0)
+    }
+
+    test("recording without an actual change stores nothing") {
+        val history = EditHistory()
+        history.record("move", "Origin nudge", state("origin" to 1.0), state("origin" to 1.0)).shouldBeFalse()
+        history.undoCount shouldBe 0
+    }
+
+    test("empty history returns null on undo and redo") {
+        val history = EditHistory()
+        history.undoLast().shouldBeNull()
+        history.redoLast().shouldBeNull()
+        history.undoAll().shouldBeNull()
+        history.redoAll().shouldBeNull()
+    }
+
+    test("a new change clears the redo entries") {
+        val history = EditHistory()
+        history.record("move", "Origin nudge", state("origin" to 1.0), state("origin" to 2.0))
+        history.undoLast()
+        history.redoCount shouldBe 1
+        history.record("move", "Origin nudge", state("origin" to 1.0), state("origin" to 3.0))
+        history.redoCount shouldBe 0
+    }
+
+    test("bursts with the same tool and label coalesce, keeping oldest before and newest after") {
+        val history = EditHistory()
+        history.record(
+            "move",
+            "Origin slide",
+            state("origin" to 1.0),
+            state("origin" to 2.0),
+            coalesceMillis = 1000,
+            now = 0
+        )
+        history.record(
+            "move",
+            "Origin slide",
+            state("origin" to 2.0),
+            state("origin" to 3.0),
+            coalesceMillis = 1000,
+            now = 500
+        )
+        history.record(
+            "move",
+            "Origin slide",
+            state("origin" to 3.0),
+            state("origin" to 4.0),
+            coalesceMillis = 1000,
+            now = 900
+        )
+
+        history.undoCount shouldBe 1
+        history.undoLast().shouldNotBeNull().values shouldBe state("origin" to 1.0)
+        history.redoLast().shouldNotBeNull().values shouldBe state("origin" to 4.0)
+    }
+
+    test("a coalesced burst adopts keys that only change later in the burst") {
+        val history = EditHistory()
+        history.record(
+            "move",
+            "Origin slide",
+            state("x" to 1.0, "y" to 5.0),
+            state("x" to 2.0, "y" to 5.0),
+            coalesceMillis = 1000,
+            now = 0
+        )
+        history.record(
+            "move",
+            "Origin slide",
+            state("x" to 2.0, "y" to 5.0),
+            state("x" to 2.0, "y" to 6.0),
+            coalesceMillis = 1000,
+            now = 100
+        )
+
+        history.undoCount shouldBe 1
+        history.undoLast().shouldNotBeNull().values shouldBe state("x" to 1.0, "y" to 5.0)
+    }
+
+    test("an expired window starts a new entry") {
+        val history = EditHistory()
+        history.record(
+            "move",
+            "Origin slide",
+            state("origin" to 1.0),
+            state("origin" to 2.0),
+            coalesceMillis = 1000,
+            now = 0
+        )
+        history.record(
+            "move",
+            "Origin slide",
+            state("origin" to 2.0),
+            state("origin" to 3.0),
+            coalesceMillis = 1000,
+            now = 1500
+        )
+        history.undoCount shouldBe 2
+    }
+
+    test("a different label breaks coalescing") {
+        val history = EditHistory()
+        history.record(
+            "move",
+            "Origin slide",
+            state("origin" to 1.0),
+            state("origin" to 2.0),
+            coalesceMillis = 1000,
+            now = 0
+        )
+        history.record(
+            "move",
+            "Origin nudge",
+            state("origin" to 2.0),
+            state("origin" to 3.0),
+            coalesceMillis = 1000,
+            now = 100
+        )
+        history.undoCount shouldBe 2
+    }
+
+    test("the history is bounded and evicts the oldest entries") {
+        val history = EditHistory(capacity = 3)
+        repeat(5) { index ->
+            history.record("move", "Origin nudge", state("origin" to index), state("origin" to index + 1))
+        }
+        history.undoCount shouldBe 3
+    }
+
+    test("undo all merges every entry with the oldest value winning") {
+        val history = EditHistory()
+        history.record("move", "Origin nudge", state("origin" to 1.0), state("origin" to 2.0))
+        history.record("rotate", "Rotation", state("yaw" to 0f), state("yaw" to 45f))
+        history.record("move", "Origin nudge", state("origin" to 2.0), state("origin" to 3.0))
+
+        val undone = history.undoAll().shouldNotBeNull()
+        undone.count shouldBe 3
+        undone.values shouldBe state("origin" to 1.0, "yaw" to 0f)
+        history.undoCount shouldBe 0
+        history.redoCount shouldBe 3
+
+        history.redoLast().shouldNotBeNull().values shouldBe state("origin" to 2.0)
+    }
+
+    test("redo all merges every entry with the newest value winning") {
+        val history = EditHistory()
+        history.record("move", "Origin nudge", state("origin" to 1.0), state("origin" to 2.0))
+        history.record("move", "Origin nudge", state("origin" to 2.0), state("origin" to 3.0))
+        history.undoAll()
+
+        val redone = history.redoAll().shouldNotBeNull()
+        redone.count shouldBe 2
+        redone.values shouldBe state("origin" to 3.0)
+        history.undoCount shouldBe 2
+    }
+
+    test("tool undo restores the tool's newest entry and keeps a newer disjoint change in place") {
+        val history = EditHistory()
+        history.record("resize", "+X face", state("halfX" to 2.0), state("halfX" to 4.0))
+        history.record("rotate", "Yaw", state("yaw" to 0f), state("yaw" to 45f))
+
+        val result = history.undoTool("resize").shouldBeInstanceOf<ToolHistoryResult.Restored>()
+        result.change.label shouldBe "+X face"
+        result.change.values shouldBe state("halfX" to 2.0)
+        history.undoCount shouldBe 1
+        history.undoLast().shouldNotBeNull().values shouldBe state("yaw" to 0f)
+    }
+
+    test("tool undo refuses when a newer entry touches the same key and leaves the stack intact") {
+        val history = EditHistory()
+        history.record("rotate", "Yaw", state("yaw" to 0f), state("yaw" to 45f))
+        history.record("wand", "Capture", state("yaw" to 45f, "origin" to 1.0), state("yaw" to 0f, "origin" to 2.0))
+
+        val result = history.undoTool("rotate").shouldBeInstanceOf<ToolHistoryResult.Entangled>()
+        result.blockingTool shouldBe "wand"
+        history.undoCount shouldBe 2
+        history.undoLast().shouldNotBeNull().values shouldBe state("yaw" to 45f, "origin" to 1.0)
+    }
+
+    test("tool undo of a missing tool reports nothing left") {
+        val history = EditHistory()
+        history.record("move", "Origin nudge", state("origin" to 1.0), state("origin" to 2.0))
+        history.undoTool("resize") shouldBe ToolHistoryResult.NothingLeft
+    }
+
+    test("tool undo walks a tool's changes one at a time, across an interleaved axis") {
+        // An editing session as recorded on a server: move, yaw x3, pitch x3, yaw x4, resize, move.
+        val history = EditHistory()
+        history.record("move", "carry", state("origin" to 0.0), state("origin" to 1.0))
+        var yaw = 0f
+        for (to in listOf(-15f, -30f, -45f)) {
+            history.record("rotate", "Yaw", state("yaw" to yaw), state("yaw" to to)); yaw = to
+        }
+        var pitch = 0f
+        for (to in listOf(-15f, -30f, -45f)) {
+            history.record("rotate", "Pitch", state("pitch" to pitch), state("pitch" to to)); pitch = to
+        }
+        for (to in listOf(-60f, -75f, -90f, -105f)) {
+            history.record("rotate", "Yaw", state("yaw" to yaw), state("yaw" to to)); yaw = to
+        }
+        history.record(
+            "resize",
+            "+Z face",
+            state("halfZ" to 6.5, "shift" to 0.0),
+            state("halfZ" to 13.75, "shift" to 7.25)
+        )
+        history.record("move", "carry", state("origin" to 1.0), state("origin" to 2.0))
+
+        val yawThenPitchThenYaw = listOf(
+            state("yaw" to -90f), state("yaw" to -75f), state("yaw" to -60f), state("yaw" to -45f),
+            state("pitch" to -30f), state("pitch" to -15f), state("pitch" to 0f),
+            state("yaw" to -30f), state("yaw" to -15f), state("yaw" to 0f),
+        )
+        for (expected in yawThenPitchThenYaw) {
+            history.undoTool("rotate").shouldBeInstanceOf<ToolHistoryResult.Restored>().change.values shouldBe expected
+        }
+        history.undoTool("rotate") shouldBe ToolHistoryResult.NothingLeft
+
+        history.undoTool("move")
+            .shouldBeInstanceOf<ToolHistoryResult.Restored>().change.values shouldBe state("origin" to 1.0)
+        history.undoTool("move")
+            .shouldBeInstanceOf<ToolHistoryResult.Restored>().change.values shouldBe state("origin" to 0.0)
+        history.undoTool("resize").shouldBeInstanceOf<ToolHistoryResult.Restored>().change.values shouldBe state(
+            "halfZ" to 6.5,
+            "shift" to 0.0
+        )
+    }
+
+    test("tool undo moves the entry to the redo stack and the arrow redoes it") {
+        val history = EditHistory()
+        history.record("resize", "+X face", state("halfX" to 2.0), state("halfX" to 3.0))
+        history.record("rotate", "Yaw", state("yaw" to 0f), state("yaw" to 45f))
+
+        history.undoTool("resize").shouldBeInstanceOf<ToolHistoryResult.Restored>()
+        history.redoCount shouldBe 1
+        history.redoLast().shouldNotBeNull().values shouldBe state("halfX" to 3.0)
+        history.undoCount shouldBe 2
+    }
+
+    test("tool redo brings back the tool's last undone change") {
+        val history = EditHistory()
+        history.record("rotate", "Yaw", state("yaw" to 0f), state("yaw" to 45f))
+        history.undoTool("rotate").shouldBeInstanceOf<ToolHistoryResult.Restored>()
+
+        val result = history.redoTool("rotate").shouldBeInstanceOf<ToolHistoryResult.Restored>()
+        result.change.values shouldBe state("yaw" to 45f)
+        history.undoCount shouldBe 1
+        history.redoCount shouldBe 0
+    }
+
+    test("tool redo reaches past another tool's undone change when the keys are disjoint") {
+        val history = EditHistory()
+        history.record("rotate", "Yaw", state("yaw" to 0f), state("yaw" to 45f))
+        history.record("move", "Origin nudge", state("origin" to 1.0), state("origin" to 2.0))
+        history.undoTool("rotate")
+        history.undoTool("move")
+
+        history.redoTool("rotate")
+            .shouldBeInstanceOf<ToolHistoryResult.Restored>().change.values shouldBe state("yaw" to 45f)
+        history.redoTool("move")
+            .shouldBeInstanceOf<ToolHistoryResult.Restored>().change.values shouldBe state("origin" to 2.0)
+        history.redoCount shouldBe 0
+    }
+
+    test("tool redo refuses when an undone change in front shares a key") {
+        val history = EditHistory()
+        history.record("rotate", "Yaw", state("yaw" to 0f), state("yaw" to 45f))
+        history.record("wand", "Capture", state("yaw" to 45f), state("yaw" to 0f))
+        history.undoLast()
+        history.undoLast()
+
+        val result = history.redoTool("wand").shouldBeInstanceOf<ToolHistoryResult.Entangled>()
+        result.blockingTool shouldBe "rotate"
+        history.redoCount shouldBe 2
+    }
+
+    test("tool redo reports nothing left when the tool has no undone changes") {
+        val history = EditHistory()
+        history.record("rotate", "Yaw", state("yaw" to 0f), state("yaw" to 45f))
+        history.undoTool("rotate")
+        history.redoTool("move") shouldBe ToolHistoryResult.NothingLeft
+    }
+
+    test("a new change clears the tool redo entries too") {
+        val history = EditHistory()
+        history.record("rotate", "Yaw", state("yaw" to 0f), state("yaw" to 45f))
+        history.undoTool("rotate")
+        history.record("move", "Origin nudge", state("origin" to 1.0), state("origin" to 2.0))
+        history.redoTool("rotate") shouldBe ToolHistoryResult.NothingLeft
+    }
+
+    test("mixed tool and arrow traffic stays consistent when entries move out of order") {
+        val history = EditHistory()
+        history.record("rotate", "Yaw", state("yaw" to 0f), state("yaw" to 45f))
+        history.record("move", "Origin nudge", state("origin" to 1.0), state("origin" to 2.0))
+
+        history.undoTool("rotate").shouldBeInstanceOf<ToolHistoryResult.Restored>()
+        history.undoLast().shouldNotBeNull().values shouldBe state("origin" to 1.0)
+
+        history.redoLast().shouldNotBeNull().values shouldBe state("origin" to 2.0)
+        history.redoLast().shouldNotBeNull().values shouldBe state("yaw" to 45f)
+        history.undoCount shouldBe 2
+        history.redoCount shouldBe 0
+
+        history.undoLast().shouldNotBeNull().values shouldBe state("yaw" to 0f)
+        history.undoLast().shouldNotBeNull().values shouldBe state("origin" to 1.0)
+    }
+
+    test("a click entry never absorbs a following scroll") {
+        val history = EditHistory()
+        history.record("rotate", "Yaw", state("yaw" to 0f), state("yaw" to 15f), coalesceMillis = 0, now = 0)
+        history.record("rotate", "Yaw", state("yaw" to 15f), state("yaw" to 20f), coalesceMillis = 1200, now = 300)
+
+        history.undoCount shouldBe 2
+        history.undoTool("rotate")
+            .shouldBeInstanceOf<ToolHistoryResult.Restored>().change.values shouldBe state("yaw" to 15f)
+    }
+
+    test("a scroll burst never absorbs a following click") {
+        val history = EditHistory()
+        history.record("rotate", "Yaw", state("yaw" to 0f), state("yaw" to 5f), coalesceMillis = 1200, now = 0)
+        history.record("rotate", "Yaw", state("yaw" to 5f), state("yaw" to 20f), coalesceMillis = 0, now = 300)
+        history.undoCount shouldBe 2
+    }
+
+    test("a merge drops keys that returned to their start value but keeps the live ones") {
+        val history = EditHistory()
+        history.record(
+            "move",
+            "Origin slide",
+            state("x" to 1.0, "y" to 5.0),
+            state("x" to 2.0, "y" to 6.0),
+            coalesceMillis = 1200,
+            now = 0
+        )
+        history.record(
+            "move",
+            "Origin slide",
+            state("x" to 2.0, "y" to 6.0),
+            state("x" to 1.0, "y" to 6.0),
+            coalesceMillis = 1200,
+            now = 300
+        )
+
+        history.undoCount shouldBe 1
+        history.undoLast().shouldNotBeNull().values shouldBe state("y" to 5.0)
+    }
+
+    test("a coalescing record merges into an entry a tool redo just brought back") {
+        val history = EditHistory()
+        history.record("rotate", "Yaw", state("yaw" to 0f), state("yaw" to 5f), coalesceMillis = 1200, now = 0)
+        history.undoTool("rotate").shouldBeInstanceOf<ToolHistoryResult.Restored>()
+        history.redoTool("rotate").shouldBeInstanceOf<ToolHistoryResult.Restored>()
+        history.record("rotate", "Yaw", state("yaw" to 5f), state("yaw" to 10f), coalesceMillis = 1200, now = 500)
+
+        history.undoCount shouldBe 1
+        history.undoLast().shouldNotBeNull().values shouldBe state("yaw" to 0f)
+    }
+
+    test("a point carry entry restores the pre-grab vertex list via tool undo") {
+        val history = EditHistory()
+        val before = mapOf("poly.points" to listOf(Vector(1.0, 0.0, 1.0), Vector(2.0, 0.0, 2.0)))
+        val after = mapOf("poly.points" to listOf(Vector(1.0, 0.0, 1.0), Vector(5.0, 0.0, 5.0)))
+        history.record("wand", "Point 2 carry", before, after)
+
+        val result = history.undoTool("wand").shouldBeInstanceOf<ToolHistoryResult.Restored>()
+        result.change.values shouldBe before
+    }
+
+    test("wand point edits entangle with a newer resize wall drag") {
+        val history = EditHistory()
+        history.record(
+            "wand", "Point 1 nudge",
+            mapOf("poly.points" to listOf(Vector(1.0, 0.0, 1.0))),
+            mapOf("poly.points" to listOf(Vector(1.5, 0.0, 1.0))),
+        )
+        history.record(
+            "resize", "wall 1",
+            mapOf("poly.points" to listOf(Vector(1.5, 0.0, 1.0))),
+            mapOf("poly.points" to listOf(Vector(2.0, 0.0, 1.0))),
+        )
+
+        val result = history.undoTool("wand").shouldBeInstanceOf<ToolHistoryResult.Entangled>()
+        result.blockingTool shouldBe "resize"
+    }
+
+    test("point slides coalesce and an out-and-back slide pops off the stack") {
+        val history = EditHistory()
+        val start = mapOf("poly.points" to listOf(Vector(1.0, 0.0, 1.0)))
+        val out = mapOf("poly.points" to listOf(Vector(1.25, 0.0, 1.0)))
+        history.record("wand", "Point 1 slide", start, out, coalesceMillis = 1200, now = 1000)
+        history.record("wand", "Point 1 slide", out, start, coalesceMillis = 1200, now = 1500)
+
+        history.undoCount shouldBe 0
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/EditorInputSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/EditorInputSpec.kt
@@ -1,0 +1,191 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.core.utils.point.Vector
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.bukkit.Location
+import org.bukkit.entity.Player
+import org.bukkit.event.player.PlayerItemHeldEvent
+import org.bukkit.inventory.PlayerInventory
+import java.util.UUID
+
+class EditorInputSpec : FunSpec({
+    test("scrolling up by one is a positive step") {
+        scrollSteps(previousSlot = 3, newSlot = 2) shouldBe 1
+        scrollSteps(previousSlot = 3, newSlot = 4) shouldBe -1
+    }
+
+    test("scrolling across the hotbar wrap takes the short way") {
+        scrollSteps(previousSlot = 0, newSlot = 8) shouldBe 1
+        scrollSteps(previousSlot = 8, newSlot = 0) shouldBe -1
+        scrollSteps(previousSlot = 1, newSlot = 7) shouldBe 3
+    }
+
+    test("no slot change is zero steps") {
+        scrollSteps(previousSlot = 4, newSlot = 4) shouldBe 0
+    }
+
+    fun SpectatorInputTracker.press(
+        locked: Boolean,
+        forward: Boolean = false,
+        backward: Boolean = false,
+        left: Boolean = false,
+        right: Boolean = false,
+        jump: Boolean = false,
+        sneak: Boolean = false,
+        sprint: Boolean = false,
+    ): List<SpectatorSignal> = update(locked, forward, backward, left, right, jump, sneak, sprint)
+
+    test("jump and sneak together fire the lock chord once and re-arm on release") {
+        val tracker = SpectatorInputTracker()
+        tracker.press(locked = false, sneak = true) shouldBe emptyList()
+        tracker.press(locked = false, sneak = true, jump = true) shouldBe listOf(SpectatorSignal.LockChord)
+        tracker.press(locked = false, sneak = true, jump = true) shouldBe emptyList()
+        tracker.press(locked = false) shouldBe emptyList()
+        tracker.press(locked = false, sneak = true, jump = true) shouldBe listOf(SpectatorSignal.LockChord)
+    }
+
+    test("the keys forming the lock chord never nudge on release") {
+        val tracker = SpectatorInputTracker()
+        tracker.press(locked = false, sneak = true, jump = true) shouldBe listOf(SpectatorSignal.LockChord)
+        tracker.press(locked = true) shouldBe emptyList()
+    }
+
+    test("locked movement keys fire on press, not on hold") {
+        val tracker = SpectatorInputTracker()
+        tracker.press(locked = true, forward = true) shouldBe listOf(SpectatorSignal.Key(SpectatorKey.FORWARD))
+        tracker.press(locked = true, forward = true) shouldBe emptyList()
+        tracker.press(locked = true, forward = true, left = true) shouldBe listOf(SpectatorSignal.Key(SpectatorKey.LEFT))
+    }
+
+    test("a locked jump or sneak tap nudges on release") {
+        val tracker = SpectatorInputTracker()
+        tracker.press(locked = true, jump = true) shouldBe emptyList()
+        tracker.press(locked = true) shouldBe listOf(SpectatorSignal.Key(SpectatorKey.UP))
+        tracker.press(locked = true, sneak = true) shouldBe emptyList()
+        tracker.press(locked = true) shouldBe listOf(SpectatorSignal.Key(SpectatorKey.DOWN))
+    }
+
+    test("sprint marks while locked and consumes a held sneak") {
+        val tracker = SpectatorInputTracker()
+        tracker.press(locked = true, sneak = true) shouldBe emptyList()
+        tracker.press(locked = true, sneak = true, sprint = true) shouldBe listOf(SpectatorSignal.Key(SpectatorKey.MARK))
+        tracker.press(locked = true) shouldBe emptyList()
+    }
+
+    test("sprint and sneak fire the secondary chord only in free flight") {
+        val tracker = SpectatorInputTracker()
+        tracker.press(locked = false, sneak = true) shouldBe emptyList()
+        tracker.press(locked = false, sneak = true, sprint = true) shouldBe listOf(SpectatorSignal.SecondaryChord)
+        tracker.press(locked = false, sneak = true, sprint = true) shouldBe emptyList()
+    }
+
+    test("unlocking with the chord while sneak stays held does not fire the secondary chord") {
+        val tracker = SpectatorInputTracker()
+        tracker.press(locked = true, sneak = true, jump = true) shouldBe listOf(SpectatorSignal.LockChord)
+        tracker.press(locked = false, sneak = true) shouldBe emptyList()
+        tracker.press(locked = false, sneak = true, sprint = true) shouldBe listOf(SpectatorSignal.SecondaryChord)
+    }
+
+    test("cardinal directions follow the yaw quadrants") {
+        cardinalFromYaw(0f) shouldBe Vector(0.0, 0.0, 1.0)
+        cardinalFromYaw(90f) shouldBe Vector(-1.0, 0.0, 0.0)
+        cardinalFromYaw(180f) shouldBe Vector(0.0, 0.0, -1.0)
+        cardinalFromYaw(-90f) shouldBe Vector(1.0, 0.0, 0.0)
+        cardinalFromYaw(44f) shouldBe Vector(0.0, 0.0, 1.0)
+        cardinalFromYaw(46f) shouldBe Vector(-1.0, 0.0, 0.0)
+    }
+
+    test("locked key directions are view relative") {
+        spectatorKeyDirection(SpectatorKey.FORWARD, 0f) shouldBe Vector(0.0, 0.0, 1.0)
+        spectatorKeyDirection(SpectatorKey.BACKWARD, 0f) shouldBe Vector(0.0, 0.0, -1.0)
+        spectatorKeyDirection(SpectatorKey.LEFT, 0f) shouldBe Vector(1.0, 0.0, 0.0)
+        spectatorKeyDirection(SpectatorKey.RIGHT, 0f) shouldBe Vector(-1.0, 0.0, 0.0)
+        spectatorKeyDirection(SpectatorKey.UP, 0f) shouldBe Vector(0.0, 1.0, 0.0)
+        spectatorKeyDirection(SpectatorKey.DOWN, 0f) shouldBe Vector(0.0, -1.0, 0.0)
+        spectatorKeyDirection(SpectatorKey.MARK, 0f) shouldBe null
+    }
+
+    test("half grid snapping rounds to the nearest half block") {
+        snapToHalfGrid(10.2) shouldBe 10.0
+        snapToHalfGrid(10.3) shouldBe 10.5
+        snapToHalfGrid(10.75) shouldBe 11.0
+        snapToHalfGrid(-3.2) shouldBe -3.0
+        snapToHalfGrid(-3.3) shouldBe -3.5
+    }
+
+    fun scrollingPlayer(): Pair<Player, PlayerInventory> {
+        val inventory = mockk<PlayerInventory>(relaxed = true)
+        val player = mockk<Player>(relaxed = true) {
+            every { uniqueId } returns UUID.randomUUID()
+            every { getInventory() } returns inventory
+        }
+        return player to inventory
+    }
+
+    test("a consumed scroll cancels the switch and resyncs the client's slot") {
+        val (player, inventory) = scrollingPlayer()
+        val listener = ScrollListener(player) { _, _ -> true }
+
+        val event = PlayerItemHeldEvent(player, 1, 2)
+        listener.onHeldItemChange(event)
+
+        event.isCancelled shouldBe true
+        verify { inventory.heldItemSlot = 1 }
+    }
+
+    test("a declined scroll right after a consumed one is swallowed, not switched") {
+        val (player, _) = scrollingPlayer()
+        var consume = true
+        val listener = ScrollListener(player) { _, _ -> consume }
+
+        listener.onHeldItemChange(PlayerItemHeldEvent(player, 1, 2))
+        consume = false
+        val burstTail = PlayerItemHeldEvent(player, 1, 2)
+        listener.onHeldItemChange(burstTail)
+
+        burstTail.isCancelled shouldBe true
+    }
+
+    test("a declined scroll with no gesture in flight switches items normally") {
+        val (player, inventory) = scrollingPlayer()
+        val listener = ScrollListener(player) { _, _ -> false }
+
+        val event = PlayerItemHeldEvent(player, 1, 2)
+        listener.onHeldItemChange(event)
+
+        event.isCancelled shouldBe false
+        verify(exactly = 0) { inventory.heldItemSlot = any<Int>() }
+    }
+
+    test("another player's slot change is ignored") {
+        val (player, _) = scrollingPlayer()
+        val (other, _) = scrollingPlayer()
+        var called = false
+        val listener = ScrollListener(player) { _, _ ->
+            called = true
+            true
+        }
+
+        val event = PlayerItemHeldEvent(other, 1, 2)
+        listener.onHeldItemChange(event)
+
+        called shouldBe false
+        event.isCancelled shouldBe false
+    }
+
+    test("a teleport onto the lock anchor does not count as leaving it") {
+        val anchor = Location(null, 10.0, 64.0, -3.0, 90f, 20f)
+        leavesAnchor(Location(null, 10.0, 64.0, -3.0, 0f, 0f), anchor) shouldBe false
+    }
+
+    test("a teleport anywhere else leaves the anchor") {
+        val anchor = Location(null, 10.0, 64.0, -3.0)
+        leavesAnchor(Location(null, 10.0, 64.0, -2.0), anchor) shouldBe true
+        leavesAnchor(Location(null, 10.5, 64.0, -3.0), anchor) shouldBe true
+        leavesAnchor(Location(null, 10.0, 70.0, -3.0), anchor) shouldBe true
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/FaceMathSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/FaceMathSpec.kt
@@ -1,0 +1,101 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.core.utils.point.Vector
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+class FaceMathSpec : FunSpec({
+    val boxFaces = listOf(
+        RegionFace("+x", "+X face", Vector(2.0, 0.0, 0.0), Vector(1, 0, 0), Vector(0, 1, 0), Vector(0, 0, 1), 2.0, 2.0),
+        RegionFace(
+            "-x",
+            "-X face",
+            Vector(-2.0, 0.0, 0.0),
+            Vector(-1, 0, 0),
+            Vector(0, 0, 1),
+            Vector(0, 1, 0),
+            2.0,
+            2.0
+        ),
+        RegionFace(
+            "+y",
+            "top face",
+            Vector(0.0, 2.0, 0.0),
+            Vector(0, 1, 0),
+            Vector(0, 0, 1),
+            Vector(1, 0, 0),
+            2.0,
+            2.0
+        ),
+    )
+
+    test("the nearest face the ray hits wins, not the one behind it") {
+        val face = pickFace(boxFaces, localEye = Vector(10.0, 0.0, 0.0), localDirection = Vector(-1, 0, 0))
+        face.shouldNotBeNull().id shouldBe "+x"
+    }
+
+    test("looking down from above picks the top face") {
+        val face = pickFace(boxFaces, localEye = Vector(0.5, 10.0, 0.5), localDirection = Vector(0, -1, 0))
+        face.shouldNotBeNull().id shouldBe "+y"
+    }
+
+    test("looking away from every face picks nothing") {
+        pickFace(boxFaces, localEye = Vector(10.0, 0.0, 0.0), localDirection = Vector(1, 0, 0)).shouldBeNull()
+    }
+
+    test("a ray missing all panels falls back to the nearest face on the player's side") {
+        val face =
+            pickFace(boxFaces, localEye = Vector(10.0, 0.0, 0.0), localDirection = Vector(-0.7, 0.0, 0.7).normalize())
+        face.shouldNotBeNull().id shouldBe "+x"
+    }
+
+    test("a corner ray hitting two faces keeps the previously targeted one") {
+        val eye = Vector(10.0, 10.0, 0.0)
+        val direction = Vector(-1.0, -1.0, 0.0).normalize()
+        pickFace(boxFaces, eye, direction).shouldNotBeNull().id shouldBe "+x"
+        pickFace(boxFaces, eye, direction, preferredId = "+y").shouldNotBeNull().id shouldBe "+y"
+    }
+
+    test("the near fallback sticks to the previous face while it stays nearly as close") {
+        val eye = Vector(6.0, 6.5, -5.0)
+        val direction = Vector(0, 0, 1)
+        pickFace(boxFaces, eye, direction).shouldNotBeNull().id shouldBe "+y"
+        pickFace(boxFaces, eye, direction, preferredId = "+x").shouldNotBeNull().id shouldBe "+x"
+    }
+
+    test("drag delta is the normal-line coordinate closest to the view ray") {
+        val delta = dragDelta(
+            eye = Vector(3.0, 10.0, 0.0),
+            direction = Vector(0, -1, 0),
+            faceCenter = Vector.ZERO,
+            faceNormal = Vector(1, 0, 0),
+        )
+        delta shouldBe (3.0 plusOrMinus 1e-9)
+    }
+
+    test("a drag parallel to the normal reports zero") {
+        val delta = dragDelta(
+            eye = Vector(0.0, 0.0, -5.0),
+            direction = Vector(0, 0, 1),
+            faceCenter = Vector.ZERO,
+            faceNormal = Vector(0, 0, 1),
+        )
+        delta shouldBe (0.0 plusOrMinus 1e-9)
+    }
+
+    test("quarter grid snapping rounds to the nearest quarter, negatives included") {
+        snapToQuarterGrid(0.3) shouldBe 0.25
+        snapToQuarterGrid(0.38) shouldBe 0.5
+        snapToQuarterGrid(-0.3) shouldBe -0.25
+        snapToQuarterGrid(2.0) shouldBe 2.0
+    }
+
+    test("pushing follows the view: a face looking back at the player steps inward") {
+        pushPullSign(Vector(0, 0, 1), Vector(0, 0, 1)) shouldBe 1.0
+        pushPullSign(Vector(0, 0, 1), Vector(0, 0, -1)) shouldBe -1.0
+        pushPullSign(Vector(0, 0, 1), Vector(1, 0, 0)) shouldBe 1.0
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/GuideGeometrySpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/GuideGeometrySpec.kt
@@ -1,0 +1,274 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.core.utils.point.World
+import com.typewritermc.region.shape.LocalBounds
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.doubles.shouldBeGreaterThan
+import io.kotest.matchers.doubles.shouldBeLessThan
+import io.kotest.matchers.doubles.shouldBeLessThanOrEqual
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.ints.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import kotlin.math.abs
+import kotlin.math.sqrt
+
+class GuideGeometrySpec : FunSpec({
+    fun bounds(half: Double) = LocalBounds(-half, -half, -half, half, half, half)
+
+    val east = Vector(1.0, 0.0, 0.0)
+    val up = Vector(0.0, 1.0, 0.0)
+    val south = Vector(0.0, 0.0, 1.0)
+
+    test("a small region gets a small guide instead of a ten block arrow") {
+        moveAxisLength(bounds(1.0), east) shouldBe (2.0 plusOrMinus 1e-9)
+    }
+
+    test("the guide grows with the region") {
+        moveAxisLength(bounds(12.0), east) shouldBe (13.0 plusOrMinus 1e-9)
+    }
+
+    test("the guide stops growing at the cap") {
+        moveAxisLength(bounds(200.0), east) shouldBe 24.0
+    }
+
+    test("the axis length follows the axis the move direction points down") {
+        val flat = LocalBounds(-30.0, -2.0, -30.0, 30.0, 2.0, 30.0)
+        moveAxisLength(flat, up) shouldBe (3.0 plusOrMinus 1e-9)
+        moveAxisLength(flat, east) shouldBe 24.0
+    }
+
+    test("a long axis splits into pieces no longer than the guide piece length") {
+        val segments = splitGuideSegment(Vector.ZERO, Vector(24.0, 0.0, 0.0))
+        segments.size shouldBe 6
+        for ((from, to) in segments) {
+            (to - from).length shouldBeLessThanOrEqual 4.0 + 1e-9
+        }
+        var cursor = Vector.ZERO
+        for ((from, to) in segments) {
+            from shouldBe cursor
+            cursor = to
+        }
+        cursor.x shouldBe (24.0 plusOrMinus 1e-9)
+    }
+
+    test("a short axis stays a single piece") {
+        splitGuideSegment(Vector.ZERO, Vector(3.0, 0.0, 0.0)).size shouldBe 1
+    }
+
+    test("the move guide is a chained axis plus two prongs meeting at the tip") {
+        val boundsFour = bounds(4.0)
+        val length = moveAxisLength(boundsFour, east)
+        val segments = moveGuideSegments(boundsFour, east, south)
+        val axisPieces = segments.dropLast(2)
+        val prongs = segments.takeLast(2)
+
+        axisPieces.shouldNotBeEmpty()
+        axisPieces.first().first shouldBe Vector.ZERO
+        val tip = axisPieces.last().second
+        tip.x shouldBe (length plusOrMinus 1e-9)
+
+        for ((from, to) in prongs) {
+            from shouldBe tip
+            // The prongs point back down the axis and away from it.
+            (to.x - tip.x) shouldBeLessThan 0.0
+            val offAxis = abs(to.y - tip.y) + abs(to.z - tip.z)
+            offAxis shouldBeGreaterThan 0.0
+        }
+    }
+
+    test("the arrowhead is flat and faces the viewer") {
+        // Viewer looks along +Z at an east pointing arrow: the prongs must spread along Y,
+        // so the arrow plane (X, Y) stands perpendicular to the view.
+        val side = prongBasis(east, south)
+        abs(side.dot(east)) shouldBeLessThan 1e-9
+        abs(side.dot(south)) shouldBeLessThan 1e-9
+        side.length shouldBe (1.0 plusOrMinus 1e-9)
+
+        val segments = moveGuideSegments(bounds(4.0), east, south)
+        val (first, second) = segments.takeLast(2)
+        // Two prongs on opposite sides of the axis, mirrored through it.
+        (first.second.y + second.second.y) shouldBe (2 * first.first.y plusOrMinus 1e-9)
+        abs(first.second.z - first.first.z) shouldBeLessThan 1e-9
+    }
+
+    test("a view along the axis still finds a perpendicular prong basis") {
+        val side = prongBasis(up, up)
+        abs(side.dot(up)) shouldBeLessThan 1e-9
+        side.length shouldBe (1.0 plusOrMinus 1e-9)
+    }
+
+    test("the prong basis snaps, so a step sideways does not re-render the guide") {
+        val a = prongBasis(east, south)
+        val b = prongBasis(east, Vector(0.02, 0.0, 1.0).normalize())
+        a shouldBe b
+    }
+
+    test("the rotation ring clears a small region and caps at a compact gizmo size") {
+        rotationRingRadius(bounds(1.0), pitchPlane = false) shouldBe (1.5 plusOrMinus 1e-9)
+        rotationRingRadius(bounds(5.0), pitchPlane = false) shouldBe (5.5 plusOrMinus 1e-9)
+        rotationRingRadius(bounds(10.0), pitchPlane = false) shouldBe 8.0
+        rotationRingRadius(bounds(100.0), pitchPlane = false) shouldBe 8.0
+    }
+
+    test("the pitch ring accounts for the vertical extent") {
+        val tall = LocalBounds(-2.0, -20.0, -2.0, 2.0, 20.0, 2.0)
+        rotationRingRadius(tall, pitchPlane = false) shouldBe (2.5 plusOrMinus 1e-9)
+        rotationRingRadius(tall, pitchPlane = true) shouldBe 8.0
+    }
+
+    test("a tiny region still gets a readable ring") {
+        rotationRingRadius(bounds(0.5), pitchPlane = false) shouldBe (1.25 plusOrMinus 1e-9)
+    }
+
+    test("asymmetric bounds size by half extents, not the farthest corner") {
+        val lopsided = LocalBounds(0.0, -1.0, -2.0, 10.0, 1.0, 4.0)
+        moveAxisLength(lopsided, east) shouldBe (6.0 plusOrMinus 1e-9)
+        rotationRingRadius(lopsided, pitchPlane = false) shouldBe (5.5 plusOrMinus 1e-9)
+        boundsCenter(lopsided) shouldBe Vector(5.0, 0.0, 1.0)
+    }
+
+    test("the push axis runs through the point with the arrowhead on the push end only") {
+        val segments = pushAxisSegments(east, south)
+        segments.first().first shouldBe Vector(-1.5, 0.0, 0.0)
+        segments.first().second shouldBe Vector.ZERO
+        val prongs = segments.takeLast(2)
+        for ((from, to) in prongs) {
+            from.x shouldBe (1.5 plusOrMinus 1e-9)
+            (to.x - from.x) shouldBeLessThan 0.0
+        }
+    }
+
+    test("the far ring hugs a region the player stands outside of") {
+        val flat = LocalBounds(-3.0, -2.0, -4.0, 3.0, 2.0, 4.0)
+        farRingRadius(flat, 30.0, pitchPlane = false) shouldBe (5.5 plusOrMinus 1e-9)
+    }
+
+    test("the far ring still passes through a player inside a huge region") {
+        farRingRadius(bounds(100.0), 30.0, pitchPlane = false) shouldBe (30.0 plusOrMinus 1e-9)
+    }
+
+    test("the far ring never shrinks below the near gizmo radius") {
+        farRingRadius(bounds(1.0), 0.0, pitchPlane = false) shouldBe (1.5 plusOrMinus 1e-9)
+    }
+
+    test("the pitch far ring measures its reach in the vertical plane") {
+        val slab = LocalBounds(-1.0, -3.0, -4.0, 1.0, 3.0, 4.0)
+        farRingRadius(slab, 30.0, pitchPlane = true) shouldBe (5.5 plusOrMinus 1e-9)
+    }
+
+    test("the tilt facing quantizes to the region frame, picking pitch or roll") {
+        quantizedTiltFacing(0.0, -10.0, 0f) shouldBe Vector(0.0, 0.0, -1.0)
+        quantizedTiltFacing(-10.0, 0.0, 0f) shouldBe Vector(-1.0, 0.0, 0.0)
+        quantizedTiltFacing(3.0, 10.0, 0f) shouldBe Vector(0.0, 0.0, 1.0)
+    }
+
+    test("the quantized facing follows the region's yaw") {
+        val facing = quantizedTiltFacing(0.0, 10.0, 30f)
+        facing.x shouldBe (-0.5 plusOrMinus 1e-9)
+        facing.z shouldBe (sqrt(3.0) / 2 plusOrMinus 1e-9)
+    }
+
+    test("a tilt step from the front or back is a clean pitch tipping the top away") {
+        steppedTilt(0f, 0f, Vector(0.0, 0.0, 1.0), 0f, 15f) shouldBe (15f to 0f)
+        steppedTilt(0f, 0f, Vector(0.0, 0.0, -1.0), 0f, 15f) shouldBe (-15f to 0f)
+    }
+
+    test("a tilt step from a flank is a clean roll tipping the top away") {
+        steppedTilt(0f, 0f, Vector(1.0, 0.0, 0.0), 0f, 15f) shouldBe (0f to -15f)
+        steppedTilt(0f, 0f, Vector(-1.0, 0.0, 0.0), 0f, 15f) shouldBe (0f to 15f)
+    }
+
+    test("tilting a pitched region from the flank leaves yaw and pitch alone") {
+        steppedTilt(45f, 0f, Vector(-1.0, 0.0, 0.0), 0f, 15f) shouldBe (45f to 15f)
+    }
+
+    test("the tilt step follows the region's yaw frame") {
+        val facing = quantizedTiltFacing(0.0, 10.0, 90f)
+        steppedTilt(0f, 0f, facing, 90f, 15f) shouldBe (0f to -15f)
+    }
+
+    test("a tilt step wraps past a half turn") {
+        steppedTilt(175f, 0f, Vector(0.0, 0.0, 1.0), 0f, 15f) shouldBe (-170f to 0f)
+    }
+
+    test("ring segments grow with the radius and clamp at both ends") {
+        ringSegmentCount(1.5) shouldBe 16
+        ringSegmentCount(10.0) shouldBeGreaterThan 16
+        ringSegmentCount(10.0) shouldBeLessThan ringSegmentCount(20.0)
+        ringSegmentCount(200.0) shouldBe 96
+    }
+
+    test("a ring chains around and keeps every point on the circle") {
+        val offset = Vector(0.0, 3.0, 0.0)
+        val segments = ringSegments(10.0, offset, east, south)
+        segments.size shouldBe ringSegmentCount(10.0)
+        for ((from, to) in segments) {
+            (from - offset).length shouldBe (10.0 plusOrMinus 1e-9)
+            (to - offset).length shouldBe (10.0 plusOrMinus 1e-9)
+        }
+        for (index in segments.indices) {
+            segments[index].second shouldBe segments[(index + 1) % segments.size].first
+        }
+    }
+
+    test("culling keeps only the arc near the viewer") {
+        val segments = ringSegments(50.0, Vector.ZERO, east, south)
+        val viewer = Vector(0.0, 0.0, 50.0)
+        val visible = cullSegmentsNear(segments, viewer, range = 20.0)
+        visible.shouldNotBeEmpty()
+        visible.size shouldBeLessThan segments.size
+        for ((from, to) in visible) {
+            ((from + to) * 0.5 - viewer).length shouldBeLessThanOrEqual 20.0 + 1e-9
+        }
+    }
+
+    test("cross gives a vector perpendicular to both inputs") {
+        val cross = east.cross(up)
+        cross.dot(east) shouldBe (0.0 plusOrMinus 1e-9)
+        cross.dot(up) shouldBe (0.0 plusOrMinus 1e-9)
+        cross.length shouldBe (1.0 plusOrMinus 1e-9)
+    }
+
+    val hoverWorld = World("hover-world")
+    fun block(x: Int, y: Int, z: Int) = CapturedBlock(hoverWorld, x, y, z)
+
+    test("aiming at a marked block picks it regardless of anything in between") {
+        val point = block(10, 64, 0)
+        val eye = Vector(0.5, 64.5, 0.5)
+        val aim = Vector(1.0, 0.0, 0.0)
+        pickHoveredBlock(listOf(point), hoverWorld.identifier, eye, aim, 32.0) shouldBe point
+    }
+
+    test("the nearest marked block along the ray wins") {
+        val near = block(5, 64, 0)
+        val far = block(12, 64, 0)
+        val eye = Vector(0.5, 64.5, 0.5)
+        val aim = Vector(1.0, 0.0, 0.0)
+        pickHoveredBlock(listOf(far, near), hoverWorld.identifier, eye, aim, 32.0) shouldBe near
+    }
+
+    test("a ray passing beside the block picks nothing") {
+        val point = block(10, 64, 3)
+        val eye = Vector(0.5, 64.5, 0.5)
+        val aim = Vector(1.0, 0.0, 0.0)
+        pickHoveredBlock(listOf(point), hoverWorld.identifier, eye, aim, 32.0) shouldBe null
+    }
+
+    test("flying inside a marked block hovers it") {
+        val point = block(10, 64, 0)
+        val eye = Vector(10.5, 64.5, 0.5)
+        val aim = Vector(0.0, -1.0, 0.0)
+        pickHoveredBlock(listOf(point), hoverWorld.identifier, eye, aim, 32.0) shouldBe point
+    }
+
+    test("marked blocks beyond the range or in another world are ignored") {
+        val far = block(50, 64, 0)
+        val elsewhere = CapturedBlock(World("other-world"), 10, 64, 0)
+        val eye = Vector(0.5, 64.5, 0.5)
+        val aim = Vector(1.0, 0.0, 0.0)
+        pickHoveredBlock(listOf(far, elsewhere), hoverWorld.identifier, eye, aim, 32.0) shouldBe null
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/InlineRegionWritePathSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/InlineRegionWritePathSpec.kt
@@ -1,0 +1,56 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.core.serialization.createDataSerializerGson
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.World
+import com.typewritermc.engine.paper.entry.changePathValue
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.loader.serializers.ColorSerializer
+import com.typewritermc.engine.paper.loader.serializers.EntryReferenceSerializer
+import com.typewritermc.engine.paper.loader.serializers.PositionSerializer
+import com.typewritermc.engine.paper.loader.serializers.VarSerializer
+import com.typewritermc.engine.paper.loader.serializers.VectorSerializer
+import com.typewritermc.region.data.RegionDefinitionData
+import com.typewritermc.region.entries.audience.InRegionAudienceEntry
+import com.typewritermc.region.shape.SphereShape
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * The editor stages field paths and the staging manager writes them into the entry's json.
+ * This walks that whole round trip for an inline definition, so the prefixes the editor
+ * builds are checked against the serializer that has to read them back, not against a
+ * hand written expectation of what the json looks like.
+ */
+class InlineRegionWritePathSpec : FunSpec({
+    val gson = createDataSerializerGson(
+        listOf(
+            VarSerializer(),
+            PositionSerializer(),
+            VectorSerializer(),
+            ColorSerializer(),
+            EntryReferenceSerializer(),
+        ),
+    )
+
+    test("an applied edit lands on the inline definition the runtime reads back") {
+        val entry = InRegionAudienceEntry(
+            id = "audience",
+            name = "Audience",
+            region = RegionDefinitionData(shape = SphereShape(1.0)),
+        )
+        val target = regionEditTarget(entry, "region.value.origin").shouldNotBeNull()
+
+        val json = gson.toJsonTree(entry)
+        val origin = Position(World("world"), 10.0, 64.0, -5.0)
+        json.changePathValue(target.placementPath + "origin", gson.toJsonTree(origin))
+        json.changePathValue(target.shapePath + "radius", gson.toJsonTree(7.5))
+
+        val updated = gson.fromJson(json, InRegionAudienceEntry::class.java)
+        val definition = updated.region.shouldBeInstanceOf<RegionDefinitionData>()
+        (definition.origin as ConstVar).value shouldBe origin
+        definition.buildShape() shouldBe SphereShape(7.5)
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/MoveDirectionSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/MoveDirectionSpec.kt
@@ -1,0 +1,41 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.core.utils.point.Vector
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class MoveDirectionSpec : FunSpec({
+    val plusX = Vector(1.0, 0.0, 0.0)
+    val plusZ = Vector(0.0, 0.0, 1.0)
+    val down = Vector(0.0, -1.0, 0.0)
+
+    test("a fresh look picks the dominant horizontal axis") {
+        autoMoveDirection(Vector(1.0, 0.0, 0.4), pitch = 0f) shouldBe plusX
+        autoMoveDirection(Vector(0.4, 0.0, 1.0), pitch = 0f) shouldBe plusZ
+        autoMoveDirection(Vector(-1.0, 0.0, 0.4), pitch = 0f) shouldBe Vector(-1.0, 0.0, 0.0)
+    }
+
+    test("the vertical axis needs a steep look to engage") {
+        autoMoveDirection(plusX, pitch = 50f) shouldBe plusX
+        autoMoveDirection(plusX, pitch = 60f) shouldBe down
+        autoMoveDirection(plusX, pitch = -60f) shouldBe Vector(0.0, 1.0, 0.0)
+    }
+
+    test("the vertical axis holds until the look flattens well below the entry angle") {
+        autoMoveDirection(plusX, pitch = 45f, previous = down) shouldBe down
+        autoMoveDirection(plusX, pitch = 30f, previous = down) shouldBe plusX
+    }
+
+    test("a held horizontal axis survives a shallow diagonal") {
+        autoMoveDirection(Vector(1.0, 0.0, 1.2), pitch = 0f, previous = plusX) shouldBe plusX
+    }
+
+    test("a clearly dominant other axis takes over") {
+        autoMoveDirection(Vector(0.6, 0.0, 1.0), pitch = 0f, previous = plusX) shouldBe plusZ
+        autoMoveDirection(Vector(1.0, 0.0, 0.6), pitch = 0f, previous = plusZ) shouldBe plusX
+    }
+
+    test("the sign always follows the look along the held axis") {
+        autoMoveDirection(Vector(-1.0, 0.0, 0.2), pitch = 0f, previous = plusX) shouldBe Vector(-1.0, 0.0, 0.0)
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/OutlinePiecesSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/OutlinePiecesSpec.kt
@@ -1,0 +1,169 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.region.shape.CuboidShape
+import com.typewritermc.region.shape.SphereShape
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.doubles.shouldBeLessThanOrEqual
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.ints.shouldBeLessThanOrEqual
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.joml.Quaternionf
+import org.joml.Vector3f
+
+private infix fun Vector.shouldBeCloseTo(expected: Vector) {
+    x shouldBe (expected.x plusOrMinus 1e-6)
+    y shouldBe (expected.y plusOrMinus 1e-6)
+    z shouldBe (expected.z plusOrMinus 1e-6)
+}
+
+private fun rotateExpected(rotation: Quaternionf, vector: Vector): Vector {
+    val rotated = Vector3f(vector.x.toFloat(), vector.y.toFloat(), vector.z.toFloat()).rotate(rotation)
+    return Vector(rotated.x.toDouble(), rotated.y.toDouble(), rotated.z.toDouble())
+}
+
+class OutlinePiecesSpec : FunSpec({
+    val small = CuboidShape(3.0, 3.0, 3.0)
+    val huge = CuboidShape(100.0, 20.0, 100.0)
+
+    test("no piece is longer than the piece length") {
+        val pieces = buildOutlinePieces(huge, 0f, 0f, 0f, 1f)
+        pieces.shouldNotBeEmpty()
+        for (piece in pieces) {
+            (piece.to - piece.from).length shouldBeLessThanOrEqual PIECE_LENGTH + 1e-6
+        }
+    }
+
+    test("the pieces of an edge reconstruct it end to end") {
+        val pieces = buildOutlinePieces(CuboidShape(10.0, 1.0, 1.0), 0f, 0f, 0f, 1f)
+        // The bottom rectangle's first edge runs from (-10, -1, -1) to (10, -1, -1).
+        val edge = pieces.filter { piece ->
+            val start = piece.anchorOffset
+            start.y == -1.0 && start.z == -1.0 && (piece.to - piece.from).x > 0.0
+        }.sortedBy { it.anchorOffset.x }
+        edge.size shouldBeGreaterThan 1
+        edge.first().anchorOffset.x shouldBe (-10.0 plusOrMinus 1e-9)
+        for (index in 0 until edge.size - 1) {
+            val end = edge[index].anchorOffset + (edge[index].to - edge[index].from)
+            end.x shouldBe (edge[index + 1].anchorOffset.x plusOrMinus 1e-9)
+        }
+        val last = edge.last()
+        (last.anchorOffset + (last.to - last.from)).x shouldBe (10.0 plusOrMinus 1e-9)
+    }
+
+    test("the scale draws bigger geometry without moving the anchors") {
+        val plain = buildOutlinePieces(small, 0f, 0f, 0f, 1f)
+        val pulsed = buildOutlinePieces(small, 0f, 0f, 0f, 1.5f)
+        pulsed.size shouldBe plain.size
+        for (index in plain.indices) {
+            pulsed[index].anchorOffset shouldBe plain[index].anchorOffset
+            pulsed[index].midOffset shouldBe plain[index].midOffset
+        }
+        pulsed.first().from shouldNotBe plain.first().from
+    }
+
+    test("a small outline renders whole, however far away the player stands") {
+        val pieces = buildOutlinePieces(small, 0f, 0f, 0f, 1f)
+        val visible = visibleOutlinePieces(
+            pieces,
+            anchor = Vector.ZERO,
+            viewer = Vector(500.0, 0.0, 0.0),
+            renderDistance = 64.0,
+            budget = MAX_LINE_DISPLAYS,
+        )
+        visible.size shouldBe pieces.size
+    }
+
+    test("a huge outline renders only the border near the player, nearest first") {
+        val pieces = buildOutlinePieces(huge, 0f, 0f, 0f, 1f)
+        pieces.size shouldBeGreaterThan MAX_LINE_DISPLAYS
+
+        val viewer = Vector(100.0, 0.0, 0.0)
+        val visible = visibleOutlinePieces(pieces, Vector.ZERO, viewer, 64.0, MAX_LINE_DISPLAYS)
+
+        visible.size shouldBeLessThanOrEqual MAX_LINE_DISPLAYS
+        visible.shouldNotBeEmpty()
+        for ((_, piece) in visible) {
+            (piece.midOffset - viewer).length shouldBeLessThanOrEqual 64.0
+        }
+        val distances = visible.map { (_, piece) -> (piece.midOffset - viewer).length }
+        distances shouldBe distances.sorted()
+    }
+
+    test("indices are stable, so a piece keeps its display while the player walks") {
+        val pieces = buildOutlinePieces(huge, 0f, 0f, 0f, 1f)
+        val here = visibleOutlinePieces(pieces, Vector.ZERO, Vector(100.0, 0.0, 0.0), 64.0, MAX_LINE_DISPLAYS)
+        val there = visibleOutlinePieces(pieces, Vector.ZERO, Vector(100.0, 0.0, 2.0), 64.0, MAX_LINE_DISPLAYS)
+        val shared = here.map { it.index }.intersect(there.map { it.index }.toSet())
+        shared.shouldNotBeEmpty()
+        for (index in shared) {
+            here.first { it.index == index }.value shouldBe there.first { it.index == index }.value
+        }
+    }
+
+    test("a player far from every part of a huge border sees nothing") {
+        val pieces = buildOutlinePieces(huge, 0f, 0f, 0f, 1f)
+        val visible = visibleOutlinePieces(pieces, Vector.ZERO, Vector(0.0, 0.0, 0.0), 64.0, MAX_LINE_DISPLAYS)
+        visible.size shouldBe 0
+    }
+
+    test("a rotated region's line stays local while its anchor rotates into the world") {
+        val shape = CuboidShape(5.0, 5.0, 5.0)
+        val yaw = 90f
+        val rotation = RegionOutline.regionRotation(yaw, 0f)
+        val pieces = buildOutlinePieces(shape, yaw, 0f, 0f, 1f)
+
+        // The bottom and top rectangles' first edge each run along local +X, from
+        // (-5, y, -5) to (5, y, -5). A piece's line has to point along local +X, unrotated: a
+        // segment rotated before it is stored would point along world +/-Z here instead.
+        val localPlusX = pieces.filter { piece ->
+            val direction = piece.to - piece.from
+            direction.x > 0.0 && direction.y == 0.0 && direction.z == 0.0
+        }
+        val bottomEdge = localPlusX.filter { it.anchorOffset.y < 0.0 }
+        val topEdge = localPlusX.filter { it.anchorOffset.y > 0.0 }
+        bottomEdge.size shouldBeGreaterThan 1
+        topEdge.size shouldBeGreaterThan 1
+
+        for ((y, edge) in listOf(-5.0 to bottomEdge, 5.0 to topEdge)) {
+            val start = rotateExpected(rotation, Vector(-5.0, y, -5.0))
+            val end = rotateExpected(rotation, Vector(5.0, y, -5.0))
+            edge.first().anchorOffset shouldBeCloseTo start
+
+            var cursor = edge.first().anchorOffset
+            for (piece in edge) {
+                cursor shouldBeCloseTo piece.anchorOffset
+                cursor += rotateExpected(rotation, piece.to - piece.from)
+            }
+            cursor shouldBeCloseTo end
+        }
+    }
+
+    test("circle segments scale with the shape so a big sphere stays round") {
+        adaptiveCircleSegments(SphereShape(5.0)) shouldBe OUTLINE_CIRCLE_SEGMENTS
+        adaptiveCircleSegments(SphereShape(50.0)) shouldBeGreaterThan OUTLINE_CIRCLE_SEGMENTS
+        adaptiveCircleSegments(SphereShape(50.0)) shouldBeLessThanOrEqual MAX_CIRCLE_SEGMENTS
+        adaptiveCircleSegments(SphereShape(1000.0)) shouldBe MAX_CIRCLE_SEGMENTS
+    }
+
+    test("adaptive segments keep a big sphere's chords near the piece length") {
+        val radius = 50.0
+        val segments = adaptiveCircleSegments(SphereShape(radius))
+        val chord = 2.0 * radius * kotlin.math.sin(Math.PI / segments)
+        chord shouldBeLessThanOrEqual PIECE_LENGTH * 1.1
+    }
+
+    test("a pulse's scale never changes which pieces are visible") {
+        val plain = buildOutlinePieces(huge, 0f, 0f, 0f, 1f)
+        val pulsed = buildOutlinePieces(huge, 0f, 0f, 0f, 1.5f)
+        val viewer = Vector(100.0, 0.0, 0.0)
+
+        val plainVisible = visibleOutlinePieces(plain, Vector.ZERO, viewer, 64.0, MAX_LINE_DISPLAYS)
+        val pulsedVisible = visibleOutlinePieces(pulsed, Vector.ZERO, viewer, 64.0, MAX_LINE_DISPLAYS)
+
+        pulsedVisible.map { it.index } shouldBe plainVisible.map { it.index }
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/PolygonVertexEditSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/PolygonVertexEditSpec.kt
@@ -1,0 +1,102 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.core.utils.point.Vector
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+class PolygonVertexEditSpec : FunSpec({
+    val square = listOf(
+        Vector(-5.0, 0.0, -5.0),
+        Vector(5.0, 0.0, -5.0),
+        Vector(5.0, 0.0, 5.0),
+        Vector(-5.0, 0.0, 5.0),
+    )
+    val edges = square.map { point ->
+        Vector(point.x, -2.0, point.z) to Vector(point.x, 2.0, point.z)
+    }
+
+    test("a point near a wall inserts between that wall's vertices") {
+        insertionIndexFor(square, Vector(0.0, 0.0, -6.0)) shouldBe 1
+        insertionIndexFor(square, Vector(6.0, 0.0, 0.0)) shouldBe 2
+        insertionIndexFor(square, Vector(0.0, 0.0, 6.0)) shouldBe 3
+        insertionIndexFor(square, Vector(-6.0, 0.0, 0.0)) shouldBe 4
+    }
+
+    test("a point past a corner lands on the nearer of the two walls") {
+        insertionIndexFor(square, Vector(4.0, 0.0, -7.0)) shouldBe 1
+    }
+
+    test("degenerate walls do not break the insertion") {
+        val doubled = listOf(square[0], square[0], square[1], square[2], square[3])
+        insertionIndexFor(doubled, Vector(0.0, 0.0, -6.0)) shouldBe 2
+    }
+
+    test("segment distance clamps to the endpoints") {
+        pointSegmentDistanceXZ(Vector(7.0, 0.0, -5.0), square[0], square[1]) shouldBe (2.0 plusOrMinus 1e-9)
+    }
+
+    test("ray segment distance is exact on a vertical edge") {
+        val (distance, along) = raySegmentDistance(
+            Vector(0.0, 0.0, 0.0), Vector(0.0, 0.0, 1.0),
+            Vector(0.0, -2.0, 5.0), Vector(0.0, 2.0, 5.0),
+        )
+        distance shouldBe (0.0 plusOrMinus 1e-9)
+        along shouldBe (5.0 plusOrMinus 1e-9)
+    }
+
+    test("the nearest corner edge along the ray wins") {
+        val eye = Vector(-10.0, 0.0, -5.0)
+        pickVertexEdge(edges, eye, Vector(1.0, 0.0, 0.0), 32.0) shouldBe 0
+    }
+
+    test("an aim just outside the pick radius selects nothing") {
+        val eye = Vector(-10.0, 0.0, -5.5)
+        pickVertexEdge(edges, eye, Vector(1.0, 0.0, 0.0), 32.0).shouldBeNull()
+    }
+
+    test("the selected corner sticks within the keep radius") {
+        val eye = Vector(-10.0, 0.0, -5.5)
+        pickVertexEdge(edges, eye, Vector(1.0, 0.0, 0.0), 32.0, preferredIndex = 0) shouldBe 0
+    }
+
+    test("the stickiness ends past the keep radius") {
+        val eye = Vector(-10.0, 0.0, -6.0)
+        pickVertexEdge(edges, eye, Vector(1.0, 0.0, 0.0), 32.0, preferredIndex = 0).shouldBeNull()
+    }
+
+    test("corners beyond the range are ignored") {
+        val eye = Vector(-100.0, 0.0, -5.0)
+        pickVertexEdge(edges, eye, Vector(1.0, 0.0, 0.0), 32.0).shouldBeNull()
+    }
+
+    test("an eye inside the prism picks the corner it faces") {
+        val direction = Vector(1.0, 0.0, -1.0).normalize()
+        pickVertexEdge(edges, Vector(0.0, 0.0, 0.0), direction, 32.0) shouldBe 1
+    }
+
+    test("a clear hit on another corner overrides a keep-zone selection") {
+        val pair = listOf(
+            Vector(0.0, -2.0, -5.0) to Vector(0.0, 2.0, -5.0),
+            Vector(0.0, -2.0, -4.4) to Vector(0.0, 2.0, -4.4),
+        )
+        pickVertexEdge(pair, Vector(-10.0, 0.0, -4.4), Vector(1.0, 0.0, 0.0), 32.0, preferredIndex = 0) shouldBe 1
+    }
+
+    test("a still-hit previous selection wins over a nearer equal hit") {
+        val eye = Vector(-10.0, 0.0, -5.0)
+        pickVertexEdge(edges, eye, Vector(1.0, 0.0, 0.0), 32.0, preferredIndex = 1) shouldBe 1
+    }
+
+    test("fewer than two points always appends") {
+        insertionIndexFor(emptyList(), Vector(0.0, 0.0, 0.0)) shouldBe 0
+        insertionIndexFor(listOf(Vector(1.0, 0.0, 1.0)), Vector(0.0, 0.0, 0.0)) shouldBe 1
+    }
+
+    test("a retained index survives only while it points into the list") {
+        retainedIndex(2, 5) shouldBe 2
+        retainedIndex(5, 5).shouldBeNull()
+        retainedIndex(null, 5).shouldBeNull()
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/RegionEditRegistrySpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/RegionEditRegistrySpec.kt
@@ -1,0 +1,82 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.region.data.RegionDefinitionEntry
+import com.typewritermc.region.data.RegionReferenceData
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import java.util.*
+
+class RegionEditRegistrySpec : FunSpec({
+    val alice = UUID.fromString("00000000-0000-0000-0000-000000000001")
+    val bob = UUID.fromString("00000000-0000-0000-0000-000000000002")
+
+    test("the first editor claims the lock and gets the session") {
+        val registry = RegionEditRegistry()
+        val session = registry.tryStartEditing(alice, "Alice", "region")
+        session.shouldNotBeNull()
+        session.editorId shouldBe alice
+        session.editorName shouldBe "Alice"
+        registry.isEditing(alice, "region").shouldBeTrue()
+    }
+
+    test("a second player cannot claim a locked entry") {
+        val registry = RegionEditRegistry()
+        registry.tryStartEditing(alice, "Alice", "region").shouldNotBeNull()
+        registry.tryStartEditing(bob, "Bob", "region").shouldBeNull()
+        registry.sessionOf("region")?.editorName shouldBe "Alice"
+    }
+
+    test("the holder reclaims its own session instead of a new one") {
+        val registry = RegionEditRegistry()
+        val first = registry.tryStartEditing(alice, "Alice", "region")
+        val again = registry.tryStartEditing(alice, "Alice", "region")
+        again shouldBe first
+    }
+
+    test("different entries lock independently") {
+        val registry = RegionEditRegistry()
+        registry.tryStartEditing(alice, "Alice", "hub").shouldNotBeNull()
+        registry.tryStartEditing(bob, "Bob", "arena").shouldNotBeNull()
+    }
+
+    test("stopping releases the lock for the next editor") {
+        val registry = RegionEditRegistry()
+        registry.tryStartEditing(alice, "Alice", "region")
+        registry.stopEditing(alice, "region")
+        registry.sessionOf("region").shouldBeNull()
+        registry.tryStartEditing(bob, "Bob", "region").shouldNotBeNull()
+    }
+
+    test("a non holder cannot release the lock") {
+        val registry = RegionEditRegistry()
+        registry.tryStartEditing(alice, "Alice", "region")
+        registry.stopEditing(bob, "region")
+        registry.isEditing(alice, "region").shouldBeTrue()
+    }
+
+    test("the editor and registered spectators have a live view, others do not") {
+        val registry = RegionEditRegistry()
+        val session = registry.tryStartEditing(alice, "Alice", "region").shouldNotBeNull()
+        registry.hasLiveView(alice, "region").shouldBeTrue()
+        registry.hasLiveView(bob, "region").shouldBeFalse()
+        session.spectators.add(bob)
+        registry.hasLiveView(bob, "region").shouldBeTrue()
+    }
+
+    test("suppression follows the live view through references and owner entries") {
+        val registry = RegionEditRegistry()
+        val session = registry.tryStartEditing(alice, "Alice", "definition").shouldNotBeNull()
+        val reference = RegionReferenceData(Ref("definition", RegionDefinitionEntry::class))
+
+        registry.isSuppressed(alice, null, reference).shouldBeTrue()
+        registry.isSuppressed(bob, null, reference).shouldBeFalse()
+        session.spectators.add(bob)
+        registry.isSuppressed(bob, null, reference).shouldBeTrue()
+        registry.isSuppressed(bob, "definition", RegionReferenceData()).shouldBeTrue()
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/RegionEditTargetSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/RegionEditTargetSpec.kt
@@ -1,0 +1,49 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.region.data.RegionDefinitionData
+import com.typewritermc.region.data.RegionReferenceData
+import com.typewritermc.region.entries.audience.InRegionAudienceEntry
+import com.typewritermc.region.entries.definition.SphereRegionDefinitionEntry
+import com.typewritermc.region.shape.SphereShape
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+
+class RegionEditTargetSpec : FunSpec({
+    test("a definition entry holds its geometry at the top level") {
+        val entry = SphereRegionDefinitionEntry(id = "sphere", name = "Sphere", radius = 5.0)
+        val target = regionEditTarget(entry, "origin").shouldNotBeNull()
+
+        target.entryId shouldBe "sphere"
+        target.placementPath shouldBe ""
+        target.shapePath shouldBe ""
+        target.definitionOf(entry) shouldBeSameInstanceAs entry
+    }
+
+    test("an inline definition holds its geometry behind the field that owns it") {
+        val region = RegionDefinitionData(shape = SphereShape(3.0))
+        val entry = InRegionAudienceEntry(id = "audience", name = "Audience", region = region)
+        val target = regionEditTarget(entry, "region.value.origin").shouldNotBeNull()
+
+        target.entryId shouldBe "audience"
+        target.placementPath shouldBe "region.value."
+        target.shapePath shouldBe "region.value.shape.value."
+        target.definitionOf(entry) shouldBeSameInstanceAs region
+    }
+
+    test("a referenced region has no inline definition to edit") {
+        val entry = InRegionAudienceEntry(id = "audience", region = RegionReferenceData())
+        val target = regionEditTarget(entry, "region.value.origin").shouldNotBeNull()
+
+        target.definitionOf(entry).shouldBeNull()
+    }
+
+    test("a field path naming no field of the entry is not an edit target") {
+        val entry = InRegionAudienceEntry(id = "audience", region = RegionDefinitionData())
+
+        regionEditTarget(entry, "origin").shouldBeNull()
+        regionEditTarget(entry, "missing.value.origin").shouldBeNull()
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/RegionEditorModesSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/RegionEditorModesSpec.kt
@@ -1,0 +1,27 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.engine.paper.content.ContentContext
+import com.typewritermc.region.shape.CapsuleShape
+import com.typewritermc.region.shape.ConeShape
+import com.typewritermc.region.shape.CuboidShape
+import com.typewritermc.region.shape.EllipsoidShape
+import com.typewritermc.region.shape.PolygonShape
+import com.typewritermc.region.shape.SphereShape
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.mockk
+import org.bukkit.entity.Player
+
+class RegionEditorModesSpec : FunSpec({
+    val player = mockk<Player>(relaxed = true)
+    val context = ContentContext(mapOf("entryId" to "region", "fieldPath" to "origin"))
+
+    test("an inline shape opens the same editor its definition entry would open") {
+        regionEditorMode(CuboidShape(), context, player).shouldBeInstanceOf<CuboidRegionContentMode>()
+        regionEditorMode(SphereShape(), context, player).shouldBeInstanceOf<SphereRegionContentMode>()
+        regionEditorMode(EllipsoidShape(), context, player).shouldBeInstanceOf<EllipsoidRegionContentMode>()
+        regionEditorMode(CapsuleShape(), context, player).shouldBeInstanceOf<CapsuleRegionContentMode>()
+        regionEditorMode(ConeShape(), context, player).shouldBeInstanceOf<ConeRegionContentMode>()
+        regionEditorMode(PolygonShape(), context, player).shouldBeInstanceOf<PolygonRegionContentMode>()
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/ShadowingReproSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/ShadowingReproSpec.kt
@@ -1,0 +1,70 @@
+package com.typewritermc.region.content
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.maps.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Covers a capture that shadows tool entries: marking again writes the same keys as the
+ * tools, so a tool undo across it refuses with Entangled instead of consuming the entries,
+ * and the full history stays available to the arrow.
+ */
+class ShadowingReproSpec : FunSpec({
+    test("a re-mark entangles older rotate entries: Q undoes the post-capture step, then points to the arrow") {
+        val history = EditHistory()
+
+        history.record("wand", "Marked corner A", mapOf("marks.primary" to null), mapOf("marks.primary" to "A1"))
+        history.record(
+            "wand", "Marked corner B",
+            mapOf("marks.secondary" to null, "work.origin" to "O0", "size.halfX" to 1.0),
+            mapOf("marks.secondary" to "B1", "work.origin" to "O1", "size.halfX" to 4.5),
+        )
+        history.record("rotate", "Yaw", mapOf("work.yaw" to 0f), mapOf("work.yaw" to 15f))
+        history.record("rotate", "Yaw", mapOf("work.yaw" to 15f), mapOf("work.yaw" to 30f))
+        history.record(
+            "wand", "Marked corner B",
+            mapOf("marks.secondary" to "B1", "work.origin" to "O1", "size.halfX" to 4.5, "work.yaw" to 30f),
+            mapOf("marks.secondary" to "B2", "work.origin" to "O2", "size.halfX" to 6.0, "work.yaw" to 0f),
+        )
+        history.record("rotate", "Yaw", mapOf("work.yaw" to 0f), mapOf("work.yaw" to 20f))
+
+        history.undoTool("rotate").shouldBeInstanceOf<ToolHistoryResult.Restored>()
+            .change.values shouldContain ("work.yaw" to 0f)
+
+        history.undoTool("rotate").shouldBeInstanceOf<ToolHistoryResult.Entangled>()
+            .blockingTool shouldBe "wand"
+        history.undoCount shouldBe 5
+
+        val recapture = history.undoLast().shouldNotBeNull()
+        recapture.values shouldContain ("work.yaw" to 30f)
+        recapture.values shouldContain ("work.origin" to "O1")
+        history.undoLast().shouldNotBeNull().values shouldContain ("work.yaw" to 15f)
+    }
+
+    test("with no tool change after the re-capture, Q refuses instead of consuming silently") {
+        val history = EditHistory()
+        history.record("rotate", "Yaw", mapOf("work.yaw" to 0f), mapOf("work.yaw" to 45f))
+        history.record(
+            "wand", "Marked corner B",
+            mapOf("marks.secondary" to "B1", "work.yaw" to 45f),
+            mapOf("marks.secondary" to "B2", "work.yaw" to 0f),
+        )
+
+        history.undoTool("rotate").shouldBeInstanceOf<ToolHistoryResult.Entangled>().blockingTool shouldBe "wand"
+        history.undoCount shouldBe 2
+    }
+
+    test("polygon: a point mark after a wall resize entangles it through poly.points") {
+        val history = EditHistory()
+        history.record("resize", "wall 1", mapOf("poly.points" to "P0"), mapOf("poly.points" to "P1"))
+        history.record(
+            "wand", "Outline point",
+            mapOf("poly.marked" to "M0", "poly.points" to "P1", "work.origin" to "O0"),
+            mapOf("poly.marked" to "M1", "poly.points" to "P2", "work.origin" to "O1"),
+        )
+
+        history.undoTool("resize").shouldBeInstanceOf<ToolHistoryResult.Entangled>().blockingTool shouldBe "wand"
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/WorkspaceTargetingSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/content/WorkspaceTargetingSpec.kt
@@ -1,0 +1,102 @@
+package com.typewritermc.region.content
+
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.core.utils.point.World
+import com.typewritermc.region.data.ResolvedTransform
+import com.typewritermc.region.shape.CuboidShape
+import com.typewritermc.region.shape.Shape
+import com.typewritermc.region.shape.SphereShape
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+private val world = World("test-world")
+
+private fun candidate(id: String, at: Vector, shape: Shape, yaw: Float = 0f): TargetCandidate =
+    TargetCandidate(id, ResolvedTransform(world, at, yaw, 0f), shape)
+
+private fun aimFrom(eye: Vector, at: Vector): Vector = (at - eye).normalize()
+
+class WorkspaceTargetingSpec : FunSpec({
+    val range = 64.0
+
+    test("aiming at one of two separate regions selects the aimed one") {
+        val regions = listOf(
+            candidate("west", Vector(-20.0, 65.0, 0.0), CuboidShape(3.0, 3.0, 3.0)),
+            candidate("east", Vector(20.0, 65.0, 0.0), CuboidShape(3.0, 3.0, 3.0)),
+        )
+        val eye = Vector(0.0, 66.6, 0.0)
+
+        pickTargetedRegion(regions, eye, aimFrom(eye, Vector(-20.0, 65.0, 0.0)), range) shouldBe "west"
+        pickTargetedRegion(regions, eye, aimFrom(eye, Vector(20.0, 65.0, 0.0)), range) shouldBe "east"
+    }
+
+    test("a ray crossing two regions selects the nearer boundary") {
+        val regions = listOf(
+            candidate("near", Vector(10.0, 65.0, 0.0), CuboidShape(2.0, 2.0, 2.0)),
+            candidate("far", Vector(30.0, 65.0, 0.0), CuboidShape(2.0, 2.0, 2.0)),
+        )
+        val eye = Vector(0.0, 65.0, 0.0)
+
+        pickTargetedRegion(regions, eye, Vector(1.0, 0.0, 0.0), range) shouldBe "near"
+    }
+
+    test("aiming at a small region from inside a large one selects the small one") {
+        // The regression this pick exists for: the player stands inside a big region whose
+        // floor sits just below the ground. A slightly downward aim exits that floor after a
+        // few blocks, closer than the aimed at region's wall, and a plain nearest hit pick
+        // would select the surrounding region for every aim.
+        val regions = listOf(
+            candidate("surrounding", Vector(0.0, 63.0, 0.0), CuboidShape(50.0, 5.0, 50.0)),
+            candidate("aimed", Vector(25.0, 65.5, 0.0), CuboidShape(2.0, 2.0, 2.0)),
+        )
+        val eye = Vector(0.0, 66.6, 0.0)
+
+        val down = aimFrom(eye, Vector(25.0, 64.0, 0.0))
+        pickTargetedRegion(regions, eye, down, range) shouldBe "aimed"
+    }
+
+    test("aiming at nothing while inside a region selects that region through its exit") {
+        val regions = listOf(
+            candidate("surrounding", Vector(0.0, 63.0, 0.0), CuboidShape(30.0, 5.0, 30.0)),
+        )
+        val eye = Vector(0.0, 66.6, 0.0)
+
+        pickTargetedRegion(regions, eye, Vector(1.0, 0.0, 0.0), range) shouldBe "surrounding"
+    }
+
+    test("inside nested regions, the wall the aim leaves through decides") {
+        val regions = listOf(
+            candidate("outer", Vector(0.0, 65.0, 0.0), CuboidShape(20.0, 10.0, 20.0)),
+            candidate("inner", Vector(0.0, 65.0, 0.0), CuboidShape(5.0, 10.0, 5.0)),
+        )
+        val eye = Vector(0.0, 65.0, 0.0)
+
+        pickTargetedRegion(regions, eye, Vector(1.0, 0.0, 0.0), range) shouldBe "inner"
+
+        val eyeBetween = Vector(10.0, 65.0, 0.0)
+        pickTargetedRegion(regions, eyeBetween, Vector(1.0, 0.0, 0.0), range) shouldBe "outer"
+    }
+
+    test("a rotated region is hit through its rotated boundary") {
+        val regions = listOf(
+            candidate("rotated", Vector(20.0, 65.0, 0.0), CuboidShape(6.0, 3.0, 1.0), yaw = 45f),
+        )
+        val eye = Vector(20.0, 65.0, -10.0)
+
+        pickTargetedRegion(regions, eye, Vector(0.0, 0.0, 1.0), range) shouldBe "rotated"
+    }
+
+    test("a sphere behind the player is not selected") {
+        val regions = listOf(
+            candidate("behind", Vector(-20.0, 65.0, 0.0), SphereShape(3.0)),
+        )
+        val eye = Vector(0.0, 65.0, 0.0)
+
+        pickTargetedRegion(regions, eye, Vector(1.0, 0.0, 0.0), range).shouldBeNull()
+    }
+
+    test("no candidates yields no selection") {
+        pickTargetedRegion(emptyList(), Vector.ZERO, Vector(1.0, 0.0, 0.0), range).shouldBeNull()
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/data/RegionDefinitionSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/data/RegionDefinitionSpec.kt
@@ -1,0 +1,48 @@
+package com.typewritermc.region.data
+
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.core.utils.point.World
+import com.typewritermc.engine.paper.entry.entries.ComputeVar
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.region.shape.ConeShape
+import com.typewritermc.region.shape.CuboidShape
+import com.typewritermc.region.shape.PolygonShape
+import com.typewritermc.region.shape.SphereShape
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+class RegionDefinitionSpec : FunSpec({
+    val world = World("00000000-0000-0000-0000-000000000000")
+
+    test("an inline definition is named by where it stands") {
+        val inline = RegionDefinitionData(origin = ConstVar(Position(world, 128.4, 71.9, -33.2)))
+
+        inline.describeInLog() shouldBe "The inline region at 128, 71, -34"
+    }
+
+    test("an inline definition whose origin is a variable is named without one") {
+        val inline = RegionDefinitionData(origin = ComputeVar { _, _ -> Position(world, 0.0, 0.0, 0.0) })
+
+        inline.describeInLog() shouldContain "inline region"
+    }
+
+    test("a shape describing no volume is not usable") {
+        PolygonShape(points = emptyList()).usable shouldBe false
+        PolygonShape(
+            points = listOf(Vector(0.0, 0.0, 0.0), Vector(1.0, 0.0, 0.0), Vector(2.0, 0.0, 0.0)),
+        ).usable shouldBe false
+        CuboidShape(halfX = 5.0, halfY = 0.0, halfZ = 5.0).usable shouldBe false
+        SphereShape(radius = 0.0).usable shouldBe false
+        ConeShape(length = 0.0).usable shouldBe false
+    }
+
+    test("a shape a builder could stand in is usable") {
+        PolygonShape(
+            points = listOf(Vector(0.0, 0.0, 0.0), Vector(4.0, 0.0, 0.0), Vector(0.0, 0.0, 4.0)),
+        ).usable shouldBe true
+        CuboidShape(halfX = 0.5, halfY = 0.5, halfZ = 0.5).usable shouldBe true
+        SphereShape(radius = 0.5).usable shouldBe true
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/data/ResolvedTransformSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/data/ResolvedTransformSpec.kt
@@ -1,0 +1,58 @@
+package com.typewritermc.region.data
+
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.core.utils.point.World
+import com.typewritermc.region.shape.LocalBounds
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.shouldBe
+
+private const val TOLERANCE = 1e-9
+
+private infix fun Vector.shouldBeCloseTo(expected: Vector) {
+    x shouldBe (expected.x plusOrMinus TOLERANCE)
+    y shouldBe (expected.y plusOrMinus TOLERANCE)
+    z shouldBe (expected.z plusOrMinus TOLERANCE)
+}
+
+class ResolvedTransformSpec : FunSpec({
+    val world = World("test-world")
+
+    test("toLocal and toWorld are inverse under yaw and pitch") {
+        val transform = ResolvedTransform(world, Vector(10.0, 20.0, 30.0), 37f, -20f)
+        val points = listOf(
+            Vector(0.0, 0.0, 0.0),
+            Vector(1.0, 2.0, 3.0),
+            Vector(-4.5, 0.25, 12.0),
+        )
+        for (point in points) {
+            transform.toWorld(transform.toLocal(point)) shouldBeCloseTo point
+            transform.toLocal(transform.toWorld(point)) shouldBeCloseTo point
+        }
+    }
+
+    test("fromOriginAndOffset rotates only the horizontal offset components") {
+        val origin = Position(world, 10.0, 20.0, 30.0, 0f, 0f)
+        val transform = ResolvedTransform.fromOriginAndOffset(origin, Vector(1.0, 2.0, 3.0), 90f, 0f)
+        transform.worldOrigin shouldBeCloseTo Vector(7.0, 22.0, 31.0)
+    }
+
+    test("rotateLocalToWorld follows Minecraft's yaw and pitch convention") {
+        val plusZ = Vector(0.0, 0.0, 1.0)
+        ResolvedTransform(world, Vector.ZERO, 90f, 0f).rotateLocalToWorld(plusZ) shouldBeCloseTo
+                Vector(-1.0, 0.0, 0.0)
+        ResolvedTransform(world, Vector.ZERO, 0f, -90f).rotateLocalToWorld(plusZ) shouldBeCloseTo
+                Vector(0.0, 1.0, 0.0)
+    }
+
+    test("rotated local bounds swap the horizontal extents under a quarter turn") {
+        val rotated = LocalBounds(-1.0, -2.0, -3.0, 1.0, 2.0, 3.0).rotated(90f, 0f)
+        rotated.minX shouldBe (-3.0 plusOrMinus TOLERANCE)
+        rotated.maxX shouldBe (3.0 plusOrMinus TOLERANCE)
+        rotated.minY shouldBe (-2.0 plusOrMinus TOLERANCE)
+        rotated.maxY shouldBe (2.0 plusOrMinus TOLERANCE)
+        rotated.minZ shouldBe (-1.0 plusOrMinus TOLERANCE)
+        rotated.maxZ shouldBe (1.0 plusOrMinus TOLERANCE)
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/data/RotationMathSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/data/RotationMathSpec.kt
@@ -1,0 +1,58 @@
+package com.typewritermc.region.data
+
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.core.utils.point.World
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.shouldBe
+
+private infix fun Vector.shouldBeCloseTo(expected: Vector) {
+    x shouldBe (expected.x plusOrMinus 1e-6)
+    y shouldBe (expected.y plusOrMinus 1e-6)
+    z shouldBe (expected.z plusOrMinus 1e-6)
+}
+
+class RotationMathSpec : FunSpec({
+    val east = Vector(1.0, 0.0, 0.0)
+    val up = Vector(0.0, 1.0, 0.0)
+    val south = Vector(0.0, 0.0, 1.0)
+
+    test("a zero rotation is the identity") {
+        rotationMatrix(0f, 0f, 0f) * Vector(1.0, 2.0, 3.0) shouldBeCloseTo Vector(1.0, 2.0, 3.0)
+    }
+
+    test("without roll the matrix matches the transform's yaw and pitch convention") {
+        val world = World("rotation-world")
+        val transform = ResolvedTransform(world, Vector.ZERO, 37f, -20f)
+        val matrix = rotationMatrix(37f, -20f, 0f)
+        for (sample in listOf(east, up, south, Vector(1.0, -2.0, 3.0))) {
+            matrix * sample shouldBeCloseTo transform.rotateLocalToWorld(sample)
+        }
+    }
+
+    test("roll turns around the facing axis and leaves it in place") {
+        val matrix = rotationMatrix(0f, 0f, 45f)
+        matrix * south shouldBeCloseTo south
+        (matrix * up).y shouldBe (Math.cos(Math.toRadians(45.0)) plusOrMinus 1e-9)
+    }
+
+    test("the transposed product inverts the rotation") {
+        val matrix = rotationMatrix(51f, 33f, -70f)
+        val sample = Vector(1.5, -2.5, 0.75)
+        matrix.transposedTimes(matrix * sample) shouldBeCloseTo sample
+    }
+
+    test("the tilt readout ignores yaw and combines pitch with roll") {
+        tiltDegrees(30f, 0f) shouldBe (30.0 plusOrMinus 1e-6)
+        tiltDegrees(0f, 40f) shouldBe (40.0 plusOrMinus 1e-6)
+        val combined = Math.toDegrees(Math.acos(Math.cos(Math.toRadians(30.0)) * Math.cos(Math.toRadians(40.0))))
+        tiltDegrees(30f, 40f) shouldBe (combined plusOrMinus 1e-6)
+    }
+
+    test("a rolled transform still round trips between frames") {
+        val world = World("rotation-world")
+        val transform = ResolvedTransform(world, Vector(3.0, 4.0, 5.0), 20f, 35f, 50f)
+        val sample = Vector(1.0, 2.0, -3.0)
+        transform.toLocal(transform.toWorld(sample)) shouldBeCloseTo sample
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/entries/audience/RegionBarrierSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/entries/audience/RegionBarrierSpec.kt
@@ -1,0 +1,168 @@
+package com.typewritermc.region.entries.audience
+
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.World
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.interaction.PlayerSessionManager
+import com.typewritermc.region.content.RegionEditRegistry
+import com.typewritermc.region.data.DistanceMode
+import com.typewritermc.region.data.RegionDefinitionData
+import com.typewritermc.region.data.RegionReferenceData
+import com.typewritermc.region.shape.CuboidShape
+import com.typewritermc.region.tracker.RegionTracker
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.shouldBeGreaterThan
+import io.kotest.matchers.doubles.shouldBeLessThan
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.bukkit.Location
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.mockbukkit.mockbukkit.MockBukkit
+import org.mockbukkit.mockbukkit.ServerMock
+import org.mockbukkit.mockbukkit.world.WorldMock
+
+/**
+ * The barrier ramps its push across the last stretch on the side the player is allowed to be.
+ * A region standing on the terrain has its floor face right where players stand, so the ramp
+ * has to know the difference between somebody approaching a wall and somebody simply standing
+ * on the ground inside.
+ */
+class RegionBarrierSpec : FunSpec() {
+    private lateinit var server: ServerMock
+    private lateinit var world: WorldMock
+
+    init {
+        beforeSpec {
+            server = MockBukkit.mock()
+            world = server.addSimpleWorld("barrier-world")
+            startKoin {
+                modules(
+                    module {
+                        single { mockk<PlayerSessionManager>(relaxed = true) }
+                        single { RegionEditRegistry() }
+                    },
+                )
+            }
+        }
+
+        afterSpec {
+            stopKoin()
+            MockBukkit.unmock()
+        }
+
+        // A room 20 by 20, four blocks tall, whose floor face sits at y = 60.
+        val definition = RegionDefinitionData(
+            origin = ConstVar(Position(World(""), 0.0, 62.0, 0.0)),
+            shape = CuboidShape(10.0, 2.0, 10.0),
+        )
+
+        fun barrier(mode: BarrierMode) = RegionBarrierDisplay(
+            region = RegionReferenceData(),
+            mode = mode,
+            strength = ConstVar(0.6),
+            activationDistance = ConstVar(1.5),
+            distanceMode = DistanceMode.FULL,
+            entryId = null,
+        )
+
+        fun trackerIn(worldId: String): RegionTracker {
+            val anchored = definition.copy(origin = ConstVar(Position(World(worldId), 0.0, 62.0, 0.0)))
+            return RegionTracker(null, anchored).apply { refresh() }
+        }
+
+        test("a player standing on the floor of a KEEP_IN region is not pushed up") {
+            val tracker = trackerIn(world.uid.toString())
+            val player = server.addPlayer()
+            player.teleport(Location(world, 0.0, 60.0, 0.0))
+            player.isOnGround = true
+
+            barrier(BarrierMode.KEEP_IN).pushFor(player, tracker) shouldBe null
+        }
+
+        test("a player standing a block above that floor is not pushed up either") {
+            val tracker = trackerIn(world.uid.toString())
+            val player = server.addPlayer()
+            player.teleport(Location(world, 0.0, 61.0, 0.0))
+            player.isOnGround = true
+
+            barrier(BarrierMode.KEEP_IN).pushFor(player, tracker) shouldBe null
+        }
+
+        // A builder in creative flight is never on the ground, and bumping them upward every tick
+        // they descend towards the arena floor is the same nuisance the ground test spares
+        // everyone else.
+        test("a builder flying over that floor is not pushed up either") {
+            val tracker = trackerIn(world.uid.toString())
+            val player = server.addPlayer()
+            player.teleport(Location(world, 0.0, 61.0, 0.0))
+            player.isOnGround = false
+            player.allowFlight = true
+            player.isFlying = true
+
+            barrier(BarrierMode.KEEP_IN).pushFor(player, tracker) shouldBe null
+        }
+
+        // Nothing is holding a falling player up, so the ramp is the only thing between them and
+        // the face they are heading for.
+        test("a player falling towards the floor of a KEEP_IN region is still caught") {
+            val tracker = trackerIn(world.uid.toString())
+            val player = server.addPlayer()
+            player.teleport(Location(world, 0.0, 61.0, 0.0))
+            player.isOnGround = false
+
+            val push = barrier(BarrierMode.KEEP_IN).pushFor(player, tracker).shouldNotBeNull()
+            push.y shouldBeGreaterThan 0.0
+        }
+
+        test("a player dropping onto the roof of a KEEP_OUT region is pushed off it") {
+            val tracker = trackerIn(world.uid.toString())
+            val player = server.addPlayer()
+            player.teleport(Location(world, 0.0, 65.0, 0.0))
+            player.isOnGround = false
+
+            val push = barrier(BarrierMode.KEEP_OUT).pushFor(player, tracker).shouldNotBeNull()
+            push.y shouldBeGreaterThan 0.0
+        }
+
+        test("a player who left the region is still carried back in") {
+            val tracker = trackerIn(world.uid.toString())
+            val player = server.addPlayer()
+            player.teleport(Location(world, 11.0, 62.0, 0.0))
+
+            val push = barrier(BarrierMode.KEEP_IN).pushFor(player, tracker).shouldNotBeNull()
+            push.x shouldBeLessThan 0.0
+        }
+
+        test("a player approaching a wall from inside is still pushed off it") {
+            val tracker = trackerIn(world.uid.toString())
+            val player = server.addPlayer()
+            player.teleport(Location(world, 9.5, 62.0, 0.0))
+
+            val push = barrier(BarrierMode.KEEP_IN).pushFor(player, tracker).shouldNotBeNull()
+            push.x shouldBeLessThan 0.0
+        }
+
+        // The mirror of the arena floor: standing on the roof of a KEEP_OUT region is allowed,
+        // and lifting those players off it every tick is the same defect on the other face.
+        test("a KEEP_OUT barrier does not levitate someone standing on the region's roof") {
+            val tracker = trackerIn(world.uid.toString())
+            val player = server.addPlayer()
+            player.teleport(Location(world, 0.0, 64.5, 0.0))
+            player.isOnGround = true
+
+            barrier(BarrierMode.KEEP_OUT).pushFor(player, tracker) shouldBe null
+        }
+
+        test("a KEEP_OUT barrier still carries someone who got inside back out") {
+            val tracker = trackerIn(world.uid.toString())
+            val player = server.addPlayer()
+            player.teleport(Location(world, 9.0, 62.0, 0.0))
+
+            val push = barrier(BarrierMode.KEEP_OUT).pushFor(player, tracker).shouldNotBeNull()
+            push.x shouldBeGreaterThan 0.0
+        }
+    }
+}

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/entries/display/GroundLineAnimationSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/entries/display/GroundLineAnimationSpec.kt
@@ -1,0 +1,86 @@
+package com.typewritermc.region.entries.display
+
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.interaction.PlayerSessionManager
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.floats.plusOrMinus
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.bukkit.entity.Player
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import java.time.Duration
+
+/**
+ * A bare [Var.get] call resolves an interaction context through Koin (see
+ * [com.typewritermc.engine.paper.interaction.interactionContext]), even for a [ConstVar] whose
+ * value never depends on it, so this spec needs the same minimal Koin bootstrap
+ * `RegionEngineSpec` uses, not MockBukkit.
+ */
+class GroundLineAnimationSpec : FunSpec({
+    val player = mockk<Player>(relaxed = true)
+
+    beforeSpec {
+        startKoin {
+            modules(module { single { mockk<PlayerSessionManager>(relaxed = true) } })
+        }
+    }
+
+    afterSpec {
+        stopKoin()
+    }
+
+    fun point(x: Double, z: Double) = GroundOutlinePoint(Vector(x, 64.0, z), Vector.ZERO)
+
+    /** A square walked east, south, west, north: clockwise seen from above. */
+    fun square(): List<GroundOutlinePoint> {
+        val points = mutableListOf<GroundOutlinePoint>()
+        for (x in 0 until 10) points += point(x.toDouble(), 0.0)
+        for (z in 0 until 10) points += point(10.0, z.toDouble())
+        for (x in 10 downTo 1) points += point(x.toDouble(), 10.0)
+        for (z in 10 downTo 1) points += point(0.0, z.toDouble())
+        return points
+    }
+
+    val path = GroundLinePath(square())
+
+    test("a static line does not flow") {
+        val animation = StaticGroundLine()
+        animation.blocksPerSecond(player) shouldBe 0.0
+        groundLinePhase(animation, path, player, Duration.ofSeconds(5)) shouldBe 0.0
+    }
+
+    test("a clockwise line flows along a clockwise loop") {
+        ClockwiseGroundLine(ConstVar(2.0)).direction(path) shouldBe 1
+        CounterClockwiseGroundLine(ConstVar(2.0)).direction(path) shouldBe -1
+    }
+
+    test("a clockwise line flows against a counter clockwise loop") {
+        val reversed = GroundLinePath(square().reversed())
+        ClockwiseGroundLine(ConstVar(2.0)).direction(reversed) shouldBe -1
+    }
+
+    test("the phase advances at the configured speed") {
+        val animation = ClockwiseGroundLine(ConstVar(2.0))
+        groundLinePhase(animation, path, player, Duration.ofSeconds(3)) shouldBe (6.0 plusOrMinus 1e-6)
+        groundLinePhase(CounterClockwiseGroundLine(ConstVar(2.0)), path, player, Duration.ofSeconds(3)) shouldBe
+                (-6.0 plusOrMinus 1e-6)
+    }
+
+    test("outward and inward face opposite ways") {
+        val point = PathPoint(Vector(10.0, 64.0, 0.0), Vector(1.0, 0.0, 0.0), Vector(0.0, 0.0, 1.0))
+        FaceOutward().yaw(point, 1) shouldBe (-90f plusOrMinus 0.01f)
+        FaceInward().yaw(point, 1) shouldBe (90f plusOrMinus 0.01f)
+    }
+
+    test("along the line follows the way the entities travel") {
+        val point = PathPoint(Vector(10.0, 64.0, 0.0), Vector(1.0, 0.0, 0.0), Vector(0.0, 0.0, 1.0))
+        // A tangent pointing south is yaw 0 in Minecraft.
+        FaceAlongLine().yaw(point, 1) shouldBe (0f plusOrMinus 0.01f)
+        FaceAlongLine().yaw(point, -1) shouldBe (180f plusOrMinus 0.01f)
+        FaceAgainstLine().yaw(point, 1) shouldBe (180f plusOrMinus 0.01f)
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/entries/display/GroundLinePathSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/entries/display/GroundLinePathSpec.kt
@@ -1,0 +1,97 @@
+package com.typewritermc.region.entries.display
+
+import com.typewritermc.core.utils.point.Vector
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.doubles.shouldBeLessThan
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+class GroundLinePathSpec : FunSpec({
+    fun point(x: Double, z: Double) = GroundOutlinePoint(Vector(x, 64.0, z), Vector.ZERO)
+
+    /** A ten by ten square walked east, then south, then west, then north. */
+    fun square(step: Double = 1.0): List<GroundOutlinePoint> {
+        val points = mutableListOf<GroundOutlinePoint>()
+        var value = 0.0
+        while (value < 10.0) { points += point(value, 0.0); value += step }
+        value = 0.0
+        while (value < 10.0) { points += point(10.0, value); value += step }
+        value = 10.0
+        while (value > 0.0) { points += point(value, 10.0); value -= step }
+        value = 10.0
+        while (value > 0.0) { points += point(0.0, value); value -= step }
+        return points
+    }
+
+    test("walking east then south then west then north is clockwise seen from above") {
+        GroundLinePath(square()).clockwiseDirection shouldBe 1
+    }
+
+    test("the reversed loop is counter clockwise") {
+        GroundLinePath(square().reversed()).clockwiseDirection shouldBe -1
+    }
+
+    test("the arc length of the loop is its perimeter") {
+        GroundLinePath(square()).totalArc shouldBe (40.0 plusOrMinus 1e-6)
+    }
+
+    test("walking a full perimeter returns to the start") {
+        val path = GroundLinePath(square())
+        val start = path.pointAt(0.0).shouldNotBeNull()
+        val around = path.pointAt(path.totalArc - 1e-9).shouldNotBeNull()
+        (around.position - start.position).length shouldBeLessThan 0.01
+    }
+
+    test("an arc lands where the distance says it should") {
+        val path = GroundLinePath(square())
+        val quarter = path.pointAt(10.0).shouldNotBeNull()
+        quarter.position.x shouldBe (10.0 plusOrMinus 0.01)
+        quarter.position.z shouldBe (0.0 plusOrMinus 0.01)
+    }
+
+    test("the tangent along the first edge points east") {
+        val path = GroundLinePath(square())
+        val tangent = path.pointAt(5.0).shouldNotBeNull().tangent
+        tangent.x shouldBe (1.0 plusOrMinus 0.01)
+        tangent.z shouldBe (0.0 plusOrMinus 0.01)
+    }
+
+    test("a hole in the loop is never walked across") {
+        val broken = listOf(point(0.0, 0.0), point(1.0, 0.0), point(20.0, 0.0), point(21.0, 0.0))
+        val path = GroundLinePath(broken)
+        // The stretch from x=1 to x=20 is a hole, so an arc inside it has no point.
+        path.pointAt(5.0).shouldBeNull()
+        path.pointAt(0.5).shouldNotBeNull()
+    }
+
+    test("an arc landing exactly on the vertex that starts a hole returns that vertex") {
+        val broken = listOf(point(0.0, 0.0), point(1.0, 0.0), point(20.0, 0.0), point(21.0, 0.0))
+        val path = GroundLinePath(broken)
+        val vertex = path.pointAt(1.0).shouldNotBeNull()
+        vertex.position.x shouldBe (1.0 plusOrMinus 1e-9)
+        vertex.position.z shouldBe (0.0 plusOrMinus 1e-9)
+        path.pointAt(5.0).shouldBeNull()
+    }
+
+    test("a hole wrapping from the last vertex back to the first still blocks its interior") {
+        val broken = listOf(point(0.0, 0.0), point(1.0, 0.0), point(20.0, 0.0), point(21.0, 0.0))
+        val path = GroundLinePath(broken)
+        // The wrap from x=21 back to x=0 is also a hole, so an arc inside it has no point.
+        val lastVertex = path.pointAt(21.0).shouldNotBeNull()
+        lastVertex.position.x shouldBe (21.0 plusOrMinus 1e-9)
+        lastVertex.position.z shouldBe (0.0 plusOrMinus 1e-9)
+        path.pointAt(30.0).shouldBeNull()
+    }
+
+    test("a two point path has tangents along the segment, not zero") {
+        val path = GroundLinePath(listOf(point(0.0, 0.0), point(10.0, 0.0)))
+        val first = path.vertices[0].tangent
+        first.x shouldBe (1.0 plusOrMinus 1e-9)
+        first.z shouldBe (0.0 plusOrMinus 1e-9)
+        val second = path.vertices[1].tangent
+        second.x shouldBe (1.0 plusOrMinus 1e-9)
+        second.z shouldBe (0.0 plusOrMinus 1e-9)
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/entries/display/GroundLinePatternSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/entries/display/GroundLinePatternSpec.kt
@@ -1,0 +1,62 @@
+package com.typewritermc.region.entries.display
+
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.interaction.PlayerSessionManager
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.bukkit.entity.Player
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+
+/**
+ * A bare [com.typewritermc.engine.paper.entry.entries.Var.get] call resolves an interaction
+ * context through Koin, even for a [ConstVar] whose value never depends on it, so this spec
+ * needs the same minimal Koin bootstrap [GroundLineAnimationSpec] uses.
+ */
+class GroundLinePatternSpec : FunSpec({
+    val player = mockk<Player>(relaxed = true)
+
+    beforeSpec {
+        startKoin {
+            modules(module { single { mockk<PlayerSessionManager>(relaxed = true) } })
+        }
+    }
+
+    afterSpec {
+        stopKoin()
+    }
+
+    test("a solid line lights every point") {
+        val solid = SolidLine()
+        for (arc in 0..20) solid.emitsAt(arc.toDouble(), player) shouldBe true
+    }
+
+    test("dashes light the dash and skip the gap") {
+        val dashed = DashedLine(ConstVar(4.0), ConstVar(3.0))
+        dashed.emitsAt(0.0, player) shouldBe true
+        dashed.emitsAt(3.9, player) shouldBe true
+        dashed.emitsAt(4.0, player) shouldBe false
+        dashed.emitsAt(6.9, player) shouldBe false
+        dashed.emitsAt(7.0, player) shouldBe true
+    }
+
+    test("dashes light the expected share of the loop") {
+        val dashed = DashedLine(ConstVar(4.0), ConstVar(3.0))
+        val lit = (0 until 7000).count { dashed.emitsAt(it / 100.0, player) }
+        (lit / 7000.0) shouldBe (4.0 / 7.0 plusOrMinus 0.01)
+    }
+
+    test("a negative arc wraps into the pattern instead of going dark") {
+        val dashed = DashedLine(ConstVar(4.0), ConstVar(3.0))
+        dashed.emitsAt(-7.0, player) shouldBe true
+        dashed.emitsAt(-3.0, player) shouldBe false
+    }
+
+    test("a zero length dash never lights, and a zero gap always does") {
+        DashedLine(ConstVar(0.0), ConstVar(3.0)).emitsAt(0.0, player) shouldBe false
+        DashedLine(ConstVar(4.0), ConstVar(0.0)).emitsAt(99.0, player) shouldBe true
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/entries/display/GroundOutlineSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/entries/display/GroundOutlineSpec.kt
@@ -1,0 +1,228 @@
+package com.typewritermc.region.entries.display
+
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.core.utils.point.World
+import com.typewritermc.region.data.ResolvedTransform
+import com.typewritermc.region.shape.CuboidShape
+import com.typewritermc.region.shape.SphereShape
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.doubles.shouldBeGreaterThan
+import io.kotest.matchers.doubles.shouldBeLessThan
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.shouldBe
+import org.bukkit.Material
+import org.mockbukkit.mockbukkit.MockBukkit
+import org.mockbukkit.mockbukkit.ServerMock
+import org.mockbukkit.mockbukkit.world.WorldMock
+import kotlin.math.hypot
+import kotlin.math.sqrt
+
+class GroundOutlineSpec : FunSpec() {
+    private lateinit var server: ServerMock
+    private lateinit var world: WorldMock
+    private lateinit var terrain: WorldTerrain
+
+    private fun transformAt(x: Double, y: Double, z: Double, yawDegrees: Float = 0f) = ResolvedTransform(
+        world = World(world.uid.toString()),
+        worldOrigin = Vector(x, y, z),
+        yawDegrees = yawDegrees,
+        pitchDegrees = 0f,
+    )
+
+    /** Horizontal distances between consecutive points, wrap included, in list order. */
+    private fun loopGaps(points: List<GroundOutlinePoint>): List<Double> = points.indices.map { index ->
+        val a = points[index].position
+        val b = points[(index + 1) % points.size].position
+        hypot(b.x - a.x, b.z - a.z)
+    }
+
+    private fun placePlatform(minX: Int, maxX: Int, minZ: Int, maxZ: Int, y: Int) {
+        for (x in minX..maxX) for (z in minZ..maxZ) {
+            world.getBlockAt(x, y, z).type = Material.STONE
+        }
+        for (chunkX in (minX shr 4)..(maxX shr 4)) for (chunkZ in (minZ shr 4)..(maxZ shr 4)) {
+            world.loadChunk(chunkX, chunkZ)
+        }
+    }
+
+    init {
+        beforeSpec {
+            server = MockBukkit.mock()
+            world = server.addSimpleWorld("ground-world")
+            terrain = WorldTerrain(world)
+        }
+
+        afterSpec {
+            MockBukkit.unmock()
+        }
+
+        test("a grounded box outlines its footprint perimeter on the platform surface") {
+            placePlatform(90, 110, 90, 110, y = 99)
+            val shape = CuboidShape(3.0, 3.0, 3.0)
+            val transform = transformAt(100.0, 101.0, 100.0)
+            val points = sampleGroundOutline(shape, transform, world, terrain)
+
+            // Columns 97..102 on both axes are inside; a 6 by 6 square has 20 border columns.
+            points.size shouldBe 20
+            for ((position) in points) {
+                position.y shouldBe (99.0 + 1.0 + 0.05 plusOrMinus 1e-9)
+                // Every point hugs the silhouette, pulled slightly inside.
+                shape.signedDistanceHorizontal(transform.toLocal(position)) shouldBe (-0.05 plusOrMinus 0.05)
+            }
+
+            for (cornerX in listOf(97.05, 102.95)) for (cornerZ in listOf(97.05, 102.95)) {
+                points.minOf { hypot(it.position.x - cornerX, it.position.z - cornerZ) } shouldBeLessThan 0.1
+            }
+
+            val westEdge = points.minBy { hypot(it.position.x - 97.05, it.position.z - 100.5) }
+            westEdge.position.x shouldBe (97.05 plusOrMinus 0.01)
+            westEdge.outward.x shouldBe (-1.0 plusOrMinus 1e-6)
+            westEdge.outward.z shouldBe (0.0 plusOrMinus 1e-6)
+        }
+
+        test("a rotated box gets outline points at its silhouette tips") {
+            placePlatform(90, 110, 90, 110, y = 99)
+            val shape = CuboidShape(3.0, 3.0, 3.0)
+            val transform = transformAt(100.0, 101.0, 100.0, yawDegrees = 45f)
+            val points = sampleGroundOutline(shape, transform, world, terrain)
+
+            // At 45 degrees the footprint is a diamond; its tips fall between block
+            // columns, so only explicit corner recovery puts a point there.
+            val tipDistance = (3.0 - 0.05) * sqrt(2.0)
+            val tips = listOf(
+                Vector(100.0 + tipDistance, 0.0, 100.0),
+                Vector(100.0 - tipDistance, 0.0, 100.0),
+                Vector(100.0, 0.0, 100.0 + tipDistance),
+                Vector(100.0, 0.0, 100.0 - tipDistance),
+            )
+            for ((x, _, z) in tips) {
+                points.minOf { hypot(it.position.x - x, it.position.z - z) } shouldBeLessThan 0.3
+            }
+        }
+
+        test("where the ground ends under the region, the outline follows the cliff") {
+            placePlatform(90, 99, 120, 140, y = 99)
+            val shape = CuboidShape(3.0, 3.0, 3.0)
+            val points = sampleGroundOutline(shape, transformAt(100.0, 101.0, 130.0), world, terrain)
+
+            // Only columns 97..99 have ground; a 3 by 6 rectangle has 14 border columns.
+            points.size shouldBe 14
+            points.count { it.position.x > 99.5 } shouldBe 0
+        }
+
+        test("a canopy inside the region's span does not lift the line off the ground") {
+            placePlatform(190, 210, 190, 210, y = 99)
+            // A solid slab hanging inside the span, like a tree canopy or a roof.
+            placePlatform(196, 204, 196, 204, y = 104)
+            val shape = CuboidShape(4.0, 5.0, 4.0)
+            val transform = transformAt(200.0, 102.0, 200.0)
+            val points = sampleGroundOutline(shape, transform, world, terrain)
+
+            points.size shouldBeGreaterThanOrEqual 8
+            for ((position) in points) {
+                position.y shouldBe (99.0 + 1.0 + 0.05 plusOrMinus 1e-9)
+            }
+        }
+
+        test("a region hovering above the ground draws nothing") {
+            placePlatform(90, 110, 90, 110, y = 99)
+            val shape = CuboidShape(3.0, 3.0, 3.0)
+            sampleGroundOutline(shape, transformAt(100.0, 110.0, 100.0), world, terrain).shouldBeEmpty()
+        }
+
+        test("resampling spreads points evenly along each edge with a point on every corner") {
+            placePlatform(90, 110, 90, 110, y = 99)
+            val shape = CuboidShape(3.0, 3.0, 3.0)
+            val transform = transformAt(100.0, 101.0, 100.0)
+            val raw = sampleGroundOutline(shape, transform, world, terrain)
+            val points = resampleBySpacing(raw, 1.0, shape, transform, world, terrain)
+
+            for (cornerX in listOf(97.05, 102.95)) for (cornerZ in listOf(97.05, 102.95)) {
+                points.minOf { hypot(it.position.x - cornerX, it.position.z - cornerZ) } shouldBeLessThan 0.1
+            }
+            val gaps = loopGaps(points)
+            gaps.min() shouldBeGreaterThan 0.85
+            gaps.max() shouldBeLessThan 1.15
+        }
+
+        test("entity spacing is uniform around a rotated box, corners included") {
+            placePlatform(90, 110, 90, 110, y = 99)
+            val shape = CuboidShape(3.0, 3.0, 3.0)
+            val transform = transformAt(100.0, 101.0, 100.0, yawDegrees = 45f)
+            val raw = sampleGroundOutline(shape, transform, world, terrain)
+            val points = resampleBySpacing(raw, 3.0, shape, transform, world, terrain)
+
+            val tipDistance = (3.0 - 0.05) * sqrt(2.0)
+            val tips = listOf(
+                Vector(100.0 + tipDistance, 0.0, 100.0),
+                Vector(100.0 - tipDistance, 0.0, 100.0),
+                Vector(100.0, 0.0, 100.0 + tipDistance),
+                Vector(100.0, 0.0, 100.0 - tipDistance),
+            )
+            for ((x, _, z) in tips) {
+                points.minOf { hypot(it.position.x - x, it.position.z - z) } shouldBeLessThan 0.3
+            }
+            val gaps = loopGaps(points)
+            gaps.min() shouldBeGreaterThan 2.5
+            gaps.max() shouldBeLessThan 3.5
+        }
+
+        test("a cornerless loop resamples seamlessly, the closing gap matching the rest") {
+            placePlatform(90, 110, 90, 110, y = 99)
+            val shape = SphereShape(4.0)
+            val transform = transformAt(100.0, 100.0, 100.0)
+            val raw = sampleGroundOutline(shape, transform, world, terrain)
+            raw.none { it.corner } shouldBe true
+
+            val points = resampleBySpacing(raw, 3.0, shape, transform, world, terrain)
+            val gaps = loopGaps(points)
+            gaps.min() shouldBeGreaterThan 2.5
+            (gaps.max() / gaps.min()) shouldBeLessThan 1.2
+        }
+
+        test("a silhouette overhanging the footprint still resamples along the walkable line") {
+            placePlatform(90, 110, 90, 110, y = 99)
+            // The sphere's widest slice floats a block above the floor, so the silhouette
+            // is wider than what the floor can drape; the chord fallback keeps the line.
+            val shape = SphereShape(4.0)
+            val transform = transformAt(100.0, 101.0, 100.0)
+            val raw = sampleGroundOutline(shape, transform, world, terrain)
+            val points = resampleBySpacing(raw, 3.0, shape, transform, world, terrain)
+
+            points.size shouldBeGreaterThanOrEqual 6
+            val gaps = loopGaps(points)
+            gaps.min() shouldBeGreaterThan 2.0
+            gaps.max() shouldBeLessThan 4.5
+        }
+
+        test("corner coverage and even spacing hold across yaws") {
+            placePlatform(80, 120, 80, 120, y = 99)
+            val halfX = 3.0
+            val halfZ = 5.0
+            val shape = CuboidShape(halfX, 3.0, halfZ)
+            for (yawDegrees in 0..90 step 5) {
+                val transform = transformAt(100.0, 101.0, 100.0, yawDegrees = yawDegrees.toFloat())
+                val raw = sampleGroundOutline(shape, transform, world, terrain)
+                val points = resampleBySpacing(raw, 1.0, shape, transform, world, terrain)
+                val corners = listOf(
+                    Vector(halfX - 0.05, 0.0, halfZ - 0.05),
+                    Vector(-(halfX - 0.05), 0.0, halfZ - 0.05),
+                    Vector(halfX - 0.05, 0.0, -(halfZ - 0.05)),
+                    Vector(-(halfX - 0.05), 0.0, -(halfZ - 0.05)),
+                ).map { transform.toWorld(it) }
+
+                withClue("yaw $yawDegrees") {
+                    for ((x, _, z) in corners) {
+                        points.minOf { hypot(it.position.x - x, it.position.z - z) } shouldBeLessThan 0.35
+                    }
+                    val gaps = loopGaps(points)
+                    gaps.min() shouldBeGreaterThan 0.3
+                    gaps.max() shouldBeLessThan 1.6
+                }
+            }
+        }
+    }
+}

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/flag/BuildFlagHandlerSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/flag/BuildFlagHandlerSpec.kt
@@ -1,0 +1,166 @@
+package com.typewritermc.region.flag
+
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.core.utils.point.World as CoreWorld
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.interaction.PlayerSessionManager
+import com.typewritermc.engine.paper.utils.Color
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionDefinitionEntry
+import com.typewritermc.region.entries.modifier.BlockBreakModifierEntry
+import com.typewritermc.region.entries.modifier.BlockBreakModifierHandler
+import com.typewritermc.region.entries.modifier.RegionModifierEntry
+import com.typewritermc.region.shape.CuboidShape
+import com.typewritermc.region.shape.PolygonShape
+import com.typewritermc.region.shape.Shape
+import com.typewritermc.region.tracker.RegionTracker
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.bukkit.Material
+import org.bukkit.event.block.BlockBreakEvent
+import org.bukkit.event.block.BlockFadeEvent
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.mockbukkit.mockbukkit.MockBukkit
+import org.mockbukkit.mockbukkit.ServerMock
+import org.mockbukkit.mockbukkit.world.WorldMock
+import java.util.Optional
+
+class BuildFlagHandlerSpec : FunSpec() {
+    private lateinit var server: ServerMock
+    private lateinit var world: WorldMock
+
+    init {
+        beforeSpec {
+            server = MockBukkit.mock()
+            world = server.addSimpleWorld("flags")
+            startKoin { modules(module { single { mockk<PlayerSessionManager>(relaxed = true) } }) }
+        }
+
+        afterSpec {
+            stopKoin()
+            MockBukkit.unmock()
+        }
+
+        class TestRegion(
+            override val id: String,
+            override val name: String = id,
+            override val origin: Var<Position>,
+            override val modifiers: List<Ref<out RegionModifierEntry>> = emptyList(),
+            override val priorityOverride: Optional<Int> = Optional.empty(),
+            override val offset: Var<Vector> = RegionDefaults.OFFSET,
+            override val yaw: Var<Float> = RegionDefaults.YAW,
+            override val pitch: Var<Float> = RegionDefaults.PITCH,
+            override val roll: Var<Float> = RegionDefaults.ROLL,
+            override val rotateWithOrigin: Boolean = false,
+            override val color: Color = RegionDefaults.COLOR,
+            override val refreshRateTicks: Int = RegionDefaults.REFRESH_RATE_TICKS,
+            private val shape: Shape = CuboidShape(5.0, 5.0, 5.0),
+        ) : RegionDefinitionEntry {
+            override fun buildShape(): Shape = shape
+        }
+
+        fun indexDenyingBreaks(shape: Shape = CuboidShape(5.0, 5.0, 5.0)): RegionFlagIndex {
+            val entry = TestRegion(
+                id = "vault",
+                origin = ConstVar(Position(CoreWorld(world.uid.toString()), 0.0, 64.0, 0.0)),
+                shape = shape,
+            )
+            val tracker = RegionTracker(null, entry)
+            tracker.refresh()
+            val flag = BlockBreakModifierEntry(id = "no-break", name = "No Breaking", allowed = ConstVar(false))
+            val region = FlaggedRegion(
+                entry = entry,
+                priority = 0,
+                order = 0,
+                modifiers = mapOf(BlockBreakModifierEntry::class to flag),
+                tracker = tracker,
+                aabb = tracker.cachedAabb,
+            )
+            return RegionFlagIndex(listOf(region), engine = null)
+        }
+
+        test("breaking a block inside the region is cancelled") {
+            val handler = BlockBreakModifierHandler(indexDenyingBreaks())
+            val player = server.addPlayer()
+
+            val event = BlockBreakEvent(world.getBlockAt(2, 64, 2), player)
+            handler.onBreak(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("breaking a block outside the region is allowed") {
+            val handler = BlockBreakModifierHandler(indexDenyingBreaks())
+            val player = server.addPlayer()
+
+            val event = BlockBreakEvent(world.getBlockAt(50, 64, 50), player)
+            handler.onBreak(event)
+
+            event.isCancelled shouldBe false
+        }
+
+        test("a player standing outside cannot mine a block inside: the block decides, not the player") {
+            val handler = BlockBreakModifierHandler(indexDenyingBreaks())
+            val player = server.addPlayer()
+            player.teleport(world.getBlockAt(40, 64, 40).location)
+
+            val event = BlockBreakEvent(world.getBlockAt(0, 64, 0), player)
+            handler.onBreak(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        val diamond = PolygonShape(
+            listOf(Vector(4.2, 0.0, 0.0), Vector(0.0, 0.0, 4.2), Vector(-4.2, 0.0, 0.0), Vector(0.0, 0.0, -4.2)),
+            halfHeight = 5.0,
+        )
+
+        test("a block whose corner sticks out of a polygon region is still protected: the center decides") {
+            val handler = BlockBreakModifierHandler(indexDenyingBreaks(diamond))
+            val player = server.addPlayer()
+
+            val event = BlockBreakEvent(world.getBlockAt(-3, 64, -2), player)
+            handler.onBreak(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("a block whose center falls outside the polygon region is not protected") {
+            val handler = BlockBreakModifierHandler(indexDenyingBreaks(diamond))
+            val player = server.addPlayer()
+
+            val event = BlockBreakEvent(world.getBlockAt(-4, 64, -2), player)
+            handler.onBreak(event)
+
+            event.isCancelled shouldBe false
+        }
+
+        test("ice melting inside the region is refused") {
+            val handler = BlockBreakModifierHandler(indexDenyingBreaks())
+            val block = world.getBlockAt(2, 64, 2)
+            block.type = Material.ICE
+
+            val event = BlockFadeEvent(block, world.getBlockAt(2, 60, 2).state)
+            handler.onFade(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("fire burning out inside the region is left alone, so it cannot burn forever") {
+            val handler = BlockBreakModifierHandler(indexDenyingBreaks())
+            val block = world.getBlockAt(2, 64, 2)
+            block.type = Material.FIRE
+
+            val event = BlockFadeEvent(block, world.getBlockAt(2, 60, 2).state)
+            handler.onFade(event)
+
+            event.isCancelled shouldBe false
+        }
+    }
+}

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/flag/CombatFlagHandlerSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/flag/CombatFlagHandlerSpec.kt
@@ -1,0 +1,250 @@
+package com.typewritermc.region.flag
+
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.core.utils.point.World as CoreWorld
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.interaction.PlayerSessionManager
+import com.typewritermc.engine.paper.utils.Color
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionDefinitionEntry
+import com.typewritermc.region.entries.modifier.CombatModifierHandler
+import com.typewritermc.region.entries.modifier.MobDamageModifierEntry
+import com.typewritermc.region.entries.modifier.PlayerDamageModifierEntry
+import com.typewritermc.region.entries.modifier.PvpModifierEntry
+import com.typewritermc.region.entries.modifier.RegionModifierEntry
+import com.typewritermc.region.shape.CuboidShape
+import com.typewritermc.region.shape.Shape
+import com.typewritermc.region.tracker.RegionTracker
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.bukkit.entity.EntityType
+import org.bukkit.event.entity.EntityDamageEvent
+import org.bukkit.event.entity.EntityDamageByEntityEvent
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.mockbukkit.mockbukkit.MockBukkit
+import org.mockbukkit.mockbukkit.ServerMock
+import org.mockbukkit.mockbukkit.world.WorldMock
+import java.util.Optional
+import kotlin.reflect.KClass
+
+class CombatFlagHandlerSpec : FunSpec() {
+    private lateinit var server: ServerMock
+    private lateinit var world: WorldMock
+
+    init {
+        beforeSpec {
+            server = MockBukkit.mock()
+            world = server.addSimpleWorld("combat")
+            startKoin { modules(module { single { mockk<PlayerSessionManager>(relaxed = true) } }) }
+        }
+
+        afterSpec {
+            stopKoin()
+            MockBukkit.unmock()
+        }
+
+        class TestRegion(
+            override val id: String,
+            override val name: String = id,
+            override val origin: Var<Position>,
+            override val modifiers: List<Ref<out RegionModifierEntry>> = emptyList(),
+            override val priorityOverride: Optional<Int> = Optional.empty(),
+            override val offset: Var<Vector> = RegionDefaults.OFFSET,
+            override val yaw: Var<Float> = RegionDefaults.YAW,
+            override val pitch: Var<Float> = RegionDefaults.PITCH,
+            override val roll: Var<Float> = RegionDefaults.ROLL,
+            override val rotateWithOrigin: Boolean = false,
+            override val color: Color = RegionDefaults.COLOR,
+            override val refreshRateTicks: Int = RegionDefaults.REFRESH_RATE_TICKS,
+        ) : RegionDefinitionEntry {
+            override fun buildShape(): Shape = CuboidShape(5.0, 5.0, 5.0)
+        }
+
+        fun indexWith(flags: Map<KClass<out RegionModifierEntry>, RegionModifierEntry>): RegionFlagIndex {
+            val entry = TestRegion(
+                id = "safe-zone",
+                origin = ConstVar(Position(CoreWorld(world.uid.toString()), 0.0, 64.0, 0.0)),
+            )
+            val tracker = RegionTracker(null, entry)
+            tracker.refresh()
+            val region = FlaggedRegion(entry, 0, 0, flags, tracker, tracker.cachedAabb)
+            return RegionFlagIndex(listOf(region), engine = null)
+        }
+
+        fun noPvpIndex() = indexWith(
+            mapOf(PvpModifierEntry::class to PvpModifierEntry(allowed = ConstVar(false)))
+        )
+
+        fun noMobDamageIndex() = indexWith(
+            mapOf(MobDamageModifierEntry::class to MobDamageModifierEntry(allowed = ConstVar(false)))
+        )
+
+        fun noPlayerDamageIndex() = indexWith(
+            mapOf(PlayerDamageModifierEntry::class to PlayerDamageModifierEntry(allowed = ConstVar(false)))
+        )
+
+        test("a player attacked inside the region is protected") {
+            val handler = CombatModifierHandler(noPvpIndex())
+            val victim = server.addPlayer()
+            val attacker = server.addPlayer()
+            victim.teleport(world.getBlockAt(2, 64, 2).location)
+            attacker.teleport(world.getBlockAt(3, 64, 3).location)
+
+            val event = EntityDamageByEntityEvent(
+                attacker,
+                victim,
+                EntityDamageEvent.DamageCause.ENTITY_ATTACK,
+                4.0,
+            )
+            handler.onDamage(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("an attacker outside the region cannot shoot in: the victim's location decides") {
+            val handler = CombatModifierHandler(noPvpIndex())
+            val victim = server.addPlayer()
+            val attacker = server.addPlayer()
+            victim.teleport(world.getBlockAt(2, 64, 2).location)
+            attacker.teleport(world.getBlockAt(60, 64, 60).location)
+
+            val event = EntityDamageByEntityEvent(
+                attacker,
+                victim,
+                EntityDamageEvent.DamageCause.ENTITY_ATTACK,
+                4.0,
+            )
+            handler.onDamage(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("a player attacked outside the region is not protected") {
+            val handler = CombatModifierHandler(noPvpIndex())
+            val victim = server.addPlayer()
+            val attacker = server.addPlayer()
+            victim.teleport(world.getBlockAt(60, 64, 60).location)
+            attacker.teleport(world.getBlockAt(61, 64, 61).location)
+
+            val event = EntityDamageByEntityEvent(
+                attacker,
+                victim,
+                EntityDamageEvent.DamageCause.ENTITY_ATTACK,
+                4.0,
+            )
+            handler.onDamage(event)
+
+            event.isCancelled shouldBe false
+        }
+
+        test("a mob attacking a player is not PvP") {
+            val handler = CombatModifierHandler(noPvpIndex())
+            val victim = server.addPlayer()
+            victim.teleport(world.getBlockAt(2, 64, 2).location)
+            val zombie = world.spawnEntity(
+                world.getBlockAt(3, 64, 3).location,
+                org.bukkit.entity.EntityType.ZOMBIE,
+            )
+
+            val event = EntityDamageByEntityEvent(
+                zombie,
+                victim,
+                EntityDamageEvent.DamageCause.ENTITY_ATTACK,
+                4.0,
+            )
+            handler.onDamage(event)
+
+            event.isCancelled shouldBe false
+        }
+
+        test("a zombie hurting a player inside a denying region is cancelled") {
+            val handler = CombatModifierHandler(noMobDamageIndex())
+            val victim = server.addPlayer()
+            victim.teleport(world.getBlockAt(2, 64, 2).location)
+            val zombie = world.spawnEntity(world.getBlockAt(3, 64, 3).location, EntityType.ZOMBIE)
+
+            val event = EntityDamageByEntityEvent(
+                zombie,
+                victim,
+                EntityDamageEvent.DamageCause.ENTITY_ATTACK,
+                4.0,
+            )
+            handler.onDamage(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("a player hurting a player inside the same region is not this handler's business") {
+            val handler = CombatModifierHandler(noMobDamageIndex())
+            val victim = server.addPlayer()
+            val attacker = server.addPlayer()
+            victim.teleport(world.getBlockAt(2, 64, 2).location)
+            attacker.teleport(world.getBlockAt(3, 64, 3).location)
+
+            val event = EntityDamageByEntityEvent(
+                attacker,
+                victim,
+                EntityDamageEvent.DamageCause.ENTITY_ATTACK,
+                4.0,
+            )
+            handler.onDamage(event)
+
+            event.isCancelled shouldBe false
+        }
+
+        test("a zombie hurting a player outside the region is not cancelled") {
+            val handler = CombatModifierHandler(noMobDamageIndex())
+            val victim = server.addPlayer()
+            victim.teleport(world.getBlockAt(60, 64, 60).location)
+            val zombie = world.spawnEntity(world.getBlockAt(61, 64, 61).location, EntityType.ZOMBIE)
+
+            val event = EntityDamageByEntityEvent(
+                zombie,
+                victim,
+                EntityDamageEvent.DamageCause.ENTITY_ATTACK,
+                4.0,
+            )
+            handler.onDamage(event)
+
+            event.isCancelled shouldBe false
+        }
+
+        test("fall damage to a player inside a denying region is cancelled") {
+            val handler = CombatModifierHandler(noPlayerDamageIndex())
+            val victim = server.addPlayer()
+            victim.teleport(world.getBlockAt(2, 64, 2).location)
+
+            val event = EntityDamageEvent(victim, EntityDamageEvent.DamageCause.FALL, 4.0)
+            handler.onDamage(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("fall damage to a player outside the region is not cancelled") {
+            val handler = CombatModifierHandler(noPlayerDamageIndex())
+            val victim = server.addPlayer()
+            victim.teleport(world.getBlockAt(60, 64, 60).location)
+
+            val event = EntityDamageEvent(victim, EntityDamageEvent.DamageCause.FALL, 4.0)
+            handler.onDamage(event)
+
+            event.isCancelled shouldBe false
+        }
+
+        test("damage to a non player entity inside the region is not this flag's business") {
+            val handler = CombatModifierHandler(noPlayerDamageIndex())
+            val zombie = world.spawnEntity(world.getBlockAt(2, 64, 2).location, EntityType.ZOMBIE)
+
+            val event = EntityDamageEvent(zombie, EntityDamageEvent.DamageCause.FALL, 4.0)
+            handler.onDamage(event)
+
+            event.isCancelled shouldBe false
+        }
+    }
+}

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/flag/DamagePrecedenceSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/flag/DamagePrecedenceSpec.kt
@@ -1,0 +1,281 @@
+package com.typewritermc.region.flag
+
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.core.utils.point.World as CoreWorld
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.interaction.PlayerSessionManager
+import com.typewritermc.engine.paper.utils.Color
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionDefinitionEntry
+import com.typewritermc.region.entries.modifier.CombatModifierHandler
+import com.typewritermc.region.entries.modifier.MobDamageModifierEntry
+import com.typewritermc.region.entries.modifier.PlayerDamageModifierEntry
+import com.typewritermc.region.entries.modifier.PvpModifierEntry
+import com.typewritermc.region.entries.modifier.RegionModifierEntry
+import com.typewritermc.region.shape.CuboidShape
+import com.typewritermc.region.shape.Shape
+import com.typewritermc.region.tracker.RegionTracker
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.bukkit.event.entity.EntityDamageByEntityEvent
+import org.bukkit.event.entity.EntityDamageEvent
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.mockbukkit.mockbukkit.MockBukkit
+import org.mockbukkit.mockbukkit.ServerMock
+import org.mockbukkit.mockbukkit.world.WorldMock
+import java.util.Optional
+import kotlin.reflect.KClass
+
+class DamagePrecedenceSpec : FunSpec() {
+    private lateinit var server: ServerMock
+    private lateinit var world: WorldMock
+
+    init {
+        beforeSpec {
+            server = MockBukkit.mock()
+            world = server.addSimpleWorld("damage-precedence")
+            startKoin { modules(module { single { mockk<PlayerSessionManager>(relaxed = true) } }) }
+        }
+
+        afterSpec {
+            stopKoin()
+            MockBukkit.unmock()
+        }
+
+        class TestRegion(
+            override val id: String,
+            override val name: String = id,
+            override val origin: Var<Position>,
+            val half: Double = 5.0,
+            override val modifiers: List<Ref<out RegionModifierEntry>> = emptyList(),
+            override val priorityOverride: Optional<Int> = Optional.empty(),
+            override val offset: Var<Vector> = RegionDefaults.OFFSET,
+            override val yaw: Var<Float> = RegionDefaults.YAW,
+            override val pitch: Var<Float> = RegionDefaults.PITCH,
+            override val roll: Var<Float> = RegionDefaults.ROLL,
+            override val rotateWithOrigin: Boolean = false,
+            override val color: Color = RegionDefaults.COLOR,
+            override val refreshRateTicks: Int = RegionDefaults.REFRESH_RATE_TICKS,
+        ) : RegionDefinitionEntry {
+            override fun buildShape(): Shape = CuboidShape(half, half, half)
+        }
+
+        /** A hub at the origin (priority 0) and an arena inside it (priority 10). */
+        fun index(
+            hubFlags: Map<KClass<out RegionModifierEntry>, RegionModifierEntry>,
+            arenaFlags: Map<KClass<out RegionModifierEntry>, RegionModifierEntry>,
+        ): RegionFlagIndex {
+            val coreWorld = CoreWorld(world.uid.toString())
+            val hubEntry = TestRegion(id = "hub", origin = ConstVar(Position(coreWorld, 0.0, 64.0, 0.0)), half = 30.0)
+            val arenaEntry = TestRegion(id = "arena", origin = ConstVar(Position(coreWorld, 0.0, 64.0, 0.0)), half = 5.0)
+            val hubTracker = RegionTracker(null, hubEntry).also { it.refresh() }
+            val arenaTracker = RegionTracker(null, arenaEntry).also { it.refresh() }
+            return RegionFlagIndex(
+                listOf(
+                    FlaggedRegion(hubEntry, 0, 0, hubFlags, hubTracker, hubTracker.cachedAabb),
+                    FlaggedRegion(arenaEntry, 10, 1, arenaFlags, arenaTracker, arenaTracker.cachedAabb),
+                ),
+                engine = null,
+            )
+        }
+
+        test("an arena that allows PvP beats a hub that denies all player damage") {
+            val index = index(
+                hubFlags = mapOf(
+                    PlayerDamageModifierEntry::class to PlayerDamageModifierEntry(allowed = ConstVar(false))
+                ),
+                arenaFlags = mapOf(PvpModifierEntry::class to PvpModifierEntry(allowed = ConstVar(true))),
+            )
+            val victim = server.addPlayer()
+            val attacker = server.addPlayer()
+            victim.teleport(world.getBlockAt(2, 64, 2).location)
+
+            val event = EntityDamageByEntityEvent(
+                attacker, victim, EntityDamageEvent.DamageCause.ENTITY_ATTACK, 4.0,
+            )
+            CombatModifierHandler(index).onDamage(event)
+
+            event.isCancelled shouldBe false
+        }
+
+        test("a hub that denies all player damage still stops fall damage in the arena") {
+            val index = index(
+                hubFlags = mapOf(
+                    PlayerDamageModifierEntry::class to PlayerDamageModifierEntry(allowed = ConstVar(false))
+                ),
+                arenaFlags = mapOf(PvpModifierEntry::class to PvpModifierEntry(allowed = ConstVar(true))),
+            )
+            val victim = server.addPlayer()
+            victim.teleport(world.getBlockAt(2, 64, 2).location)
+
+            val event = EntityDamageEvent(victim, EntityDamageEvent.DamageCause.FALL, 6.0)
+            CombatModifierHandler(index).onDamage(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("an arena that denies all player damage beats a hub that allows PvP") {
+            val index = index(
+                hubFlags = mapOf(PvpModifierEntry::class to PvpModifierEntry(allowed = ConstVar(true))),
+                arenaFlags = mapOf(
+                    PlayerDamageModifierEntry::class to PlayerDamageModifierEntry(allowed = ConstVar(false))
+                ),
+            )
+            val victim = server.addPlayer()
+            val attacker = server.addPlayer()
+            victim.teleport(world.getBlockAt(2, 64, 2).location)
+
+            val event = EntityDamageByEntityEvent(
+                attacker, victim, EntityDamageEvent.DamageCause.ENTITY_ATTACK, 4.0,
+            )
+            CombatModifierHandler(index).onDamage(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("one region holding both flags lets the specific one win") {
+            val index = index(
+                hubFlags = emptyMap(),
+                arenaFlags = mapOf(
+                    PvpModifierEntry::class to PvpModifierEntry(allowed = ConstVar(true)),
+                    PlayerDamageModifierEntry::class to PlayerDamageModifierEntry(allowed = ConstVar(false)),
+                ),
+            )
+            val victim = server.addPlayer()
+            val attacker = server.addPlayer()
+            victim.teleport(world.getBlockAt(2, 64, 2).location)
+
+            val pvpEvent = EntityDamageByEntityEvent(
+                attacker, victim, EntityDamageEvent.DamageCause.ENTITY_ATTACK, 4.0,
+            )
+            CombatModifierHandler(index).onDamage(pvpEvent)
+            pvpEvent.isCancelled shouldBe false
+
+            val fallEvent = EntityDamageEvent(victim, EntityDamageEvent.DamageCause.FALL, 6.0)
+            CombatModifierHandler(index).onDamage(fallEvent)
+            fallEvent.isCancelled shouldBe true
+        }
+
+        test("a cause list narrows the flag to the causes it names") {
+            val index = index(
+                hubFlags = mapOf(
+                    PlayerDamageModifierEntry::class to PlayerDamageModifierEntry(
+                        allowed = ConstVar(false),
+                        causes = listOf(EntityDamageEvent.DamageCause.FALL),
+                    )
+                ),
+                arenaFlags = emptyMap(),
+            )
+            val victim = server.addPlayer()
+            victim.teleport(world.getBlockAt(2, 64, 2).location)
+
+            val fall = EntityDamageEvent(victim, EntityDamageEvent.DamageCause.FALL, 6.0)
+            CombatModifierHandler(index).onDamage(fall)
+            fall.isCancelled shouldBe true
+
+            val fire = EntityDamageEvent(victim, EntityDamageEvent.DamageCause.FIRE, 2.0)
+            CombatModifierHandler(index).onDamage(fire)
+            fire.isCancelled shouldBe false
+        }
+
+        test("damage a player set in motion is that player's doing, not a mob's") {
+            val index = index(
+                hubFlags = emptyMap(),
+                arenaFlags = mapOf(
+                    PvpModifierEntry::class to PvpModifierEntry(allowed = ConstVar(false)),
+                    MobDamageModifierEntry::class to MobDamageModifierEntry(allowed = ConstVar(true)),
+                ),
+            )
+            val victim = server.addPlayer()
+            val attacker = server.addPlayer()
+            victim.teleport(world.getBlockAt(2, 64, 2).location)
+
+            // TNT is not a projectile, so matching on Projectile alone let a player kill in a
+            // region that denies PvP by priming a block of it instead of swinging.
+            val tnt = world.spawn(world.getBlockAt(2, 64, 2).location, org.bukkit.entity.TNTPrimed::class.java)
+            tnt.source = attacker
+
+            val event = EntityDamageByEntityEvent(
+                tnt, victim, EntityDamageEvent.DamageCause.ENTITY_EXPLOSION,
+                org.bukkit.damage.DamageSource.builder(org.bukkit.damage.DamageType.EXPLOSION)
+                    .withDirectEntity(tnt)
+                    .withCausingEntity(attacker)
+                    .build(),
+                4.0,
+            )
+            CombatModifierHandler(index).onDamage(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("a narrow flag on top of a blanket one defers to it instead of switching it off") {
+            // The parkour box wants fall damage back, and says nothing about anything else. It
+            // must not take lava, fire and explosions out of the hub's safe zone with it.
+            val index = index(
+                hubFlags = mapOf(
+                    PlayerDamageModifierEntry::class to PlayerDamageModifierEntry(allowed = ConstVar(false))
+                ),
+                arenaFlags = mapOf(
+                    PlayerDamageModifierEntry::class to PlayerDamageModifierEntry(
+                        allowed = ConstVar(true),
+                        causes = listOf(EntityDamageEvent.DamageCause.FALL),
+                    )
+                ),
+            )
+            val victim = server.addPlayer()
+            victim.teleport(world.getBlockAt(2, 64, 2).location)
+
+            val lava = EntityDamageEvent(victim, EntityDamageEvent.DamageCause.LAVA, 4.0)
+            CombatModifierHandler(index).onDamage(lava)
+            lava.isCancelled shouldBe true
+
+            val fall = EntityDamageEvent(victim, EntityDamageEvent.DamageCause.FALL, 6.0)
+            CombatModifierHandler(index).onDamage(fall)
+            fall.isCancelled shouldBe false
+        }
+
+        test("machinery nobody owns is still PvP, not a mob") {
+            // Vanilla only records an owner for TNT a player lit by hand, so a cannon fired by a
+            // lever arrives with none. A truce zone carrying only PvP has to cover it anyway.
+            val index = index(
+                hubFlags = mapOf(PvpModifierEntry::class to PvpModifierEntry(allowed = ConstVar(false))),
+                arenaFlags = emptyMap(),
+            )
+            val victim = server.addPlayer()
+            victim.teleport(world.getBlockAt(2, 64, 2).location)
+            val tnt = world.spawn(world.getBlockAt(2, 64, 2).location, org.bukkit.entity.TNTPrimed::class.java)
+
+            val event = EntityDamageByEntityEvent(
+                tnt, victim, EntityDamageEvent.DamageCause.ENTITY_EXPLOSION, 4.0,
+            )
+            CombatModifierHandler(index).onDamage(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("with nobody carrying PvP, the blunt flag still stops a fight") {
+            val index = index(
+                hubFlags = mapOf(
+                    PlayerDamageModifierEntry::class to PlayerDamageModifierEntry(allowed = ConstVar(false))
+                ),
+                arenaFlags = emptyMap(),
+            )
+            val victim = server.addPlayer()
+            val attacker = server.addPlayer()
+            victim.teleport(world.getBlockAt(2, 64, 2).location)
+
+            val event = EntityDamageByEntityEvent(
+                attacker, victim, EntityDamageEvent.DamageCause.ENTITY_ATTACK, 4.0,
+            )
+            CombatModifierHandler(index).onDamage(event)
+
+            event.isCancelled shouldBe true
+        }
+    }
+}

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/flag/ExplosionAndMobFlagHandlerSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/flag/ExplosionAndMobFlagHandlerSpec.kt
@@ -1,0 +1,175 @@
+package com.typewritermc.region.flag
+
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.core.utils.point.World as CoreWorld
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.utils.Color
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionDefinitionEntry
+import com.typewritermc.region.entries.modifier.ExplosionModifierEntry
+import com.typewritermc.region.entries.modifier.ExplosionModifierHandler
+import com.typewritermc.region.entries.modifier.MobGriefModifierEntry
+import com.typewritermc.region.entries.modifier.MobGriefModifierHandler
+import com.typewritermc.region.entries.modifier.MobSpawnModifierEntry
+import com.typewritermc.region.entries.modifier.MobSpawnModifierHandler
+import com.typewritermc.region.entries.modifier.RegionModifierEntry
+import com.typewritermc.region.shape.CuboidShape
+import com.typewritermc.region.shape.Shape
+import com.typewritermc.region.tracker.RegionTracker
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import org.bukkit.ExplosionResult
+import org.bukkit.Material
+import org.bukkit.block.Block
+import org.bukkit.entity.EntityType
+import org.bukkit.entity.LivingEntity
+import org.bukkit.event.entity.CreatureSpawnEvent
+import org.bukkit.event.entity.EntityChangeBlockEvent
+import org.bukkit.event.entity.EntityExplodeEvent
+import org.mockbukkit.mockbukkit.MockBukkit
+import org.mockbukkit.mockbukkit.ServerMock
+import org.mockbukkit.mockbukkit.world.WorldMock
+import java.util.Optional
+import kotlin.reflect.KClass
+
+class ExplosionAndMobFlagHandlerSpec : FunSpec() {
+    private lateinit var server: ServerMock
+    private lateinit var world: WorldMock
+
+    init {
+        beforeSpec {
+            server = MockBukkit.mock()
+            world = server.addSimpleWorld("explosions")
+        }
+
+        afterSpec { MockBukkit.unmock() }
+
+        class TestRegion(
+            override val id: String,
+            override val name: String = id,
+            override val origin: Var<Position>,
+            override val modifiers: List<Ref<out RegionModifierEntry>> = emptyList(),
+            override val priorityOverride: Optional<Int> = Optional.empty(),
+            override val offset: Var<Vector> = RegionDefaults.OFFSET,
+            override val yaw: Var<Float> = RegionDefaults.YAW,
+            override val pitch: Var<Float> = RegionDefaults.PITCH,
+            override val roll: Var<Float> = RegionDefaults.ROLL,
+            override val rotateWithOrigin: Boolean = false,
+            override val color: Color = RegionDefaults.COLOR,
+            override val refreshRateTicks: Int = RegionDefaults.REFRESH_RATE_TICKS,
+        ) : RegionDefinitionEntry {
+            override fun buildShape(): Shape = CuboidShape(5.0, 5.0, 5.0)
+        }
+
+        fun indexWith(flags: Map<KClass<out RegionModifierEntry>, RegionModifierEntry>): RegionFlagIndex {
+            val entry = TestRegion(
+                id = "town",
+                origin = ConstVar(Position(CoreWorld(world.uid.toString()), 0.0, 64.0, 0.0)),
+            )
+            val tracker = RegionTracker(null, entry)
+            tracker.refresh()
+            val region = FlaggedRegion(entry, 0, 0, flags, tracker, tracker.cachedAabb)
+            return RegionFlagIndex(listOf(region), engine = null)
+        }
+
+        test("an explosion spares the blocks inside the region and keeps the rest") {
+            val index = indexWith(mapOf(ExplosionModifierEntry::class to ExplosionModifierEntry(allowed = false)))
+            val handler = ExplosionModifierHandler(index)
+
+            val inside = world.getBlockAt(2, 64, 2)
+            val outside = world.getBlockAt(40, 64, 40)
+            val creeper = world.spawnEntity(world.getBlockAt(20, 64, 20).location, EntityType.CREEPER)
+            val event = EntityExplodeEvent(
+                creeper,
+                creeper.location,
+                mutableListOf<Block>(inside, outside),
+                1.0f,
+                ExplosionResult.DESTROY,
+            )
+            handler.onEntityExplode(event)
+
+            event.isCancelled shouldBe false
+            event.blockList() shouldContainExactly listOf(outside)
+        }
+
+        test("an explosion that touches nothing protected is left alone") {
+            val index = indexWith(mapOf(ExplosionModifierEntry::class to ExplosionModifierEntry(allowed = false)))
+            val handler = ExplosionModifierHandler(index)
+
+            val outside = world.getBlockAt(40, 64, 40)
+            val creeper = world.spawnEntity(world.getBlockAt(41, 64, 41).location, EntityType.CREEPER)
+            val event = EntityExplodeEvent(
+                creeper,
+                creeper.location,
+                mutableListOf<Block>(outside),
+                1.0f,
+                ExplosionResult.DESTROY,
+            )
+            handler.onEntityExplode(event)
+
+            event.blockList() shouldContainExactly listOf(outside)
+        }
+
+        test("a mob spawning inside the region is cancelled") {
+            val index = indexWith(mapOf(MobSpawnModifierEntry::class to MobSpawnModifierEntry(allowed = false)))
+            val handler = MobSpawnModifierHandler(index)
+
+            val zombie = world.spawnEntity(world.getBlockAt(2, 64, 2).location, EntityType.ZOMBIE) as LivingEntity
+            val event = CreatureSpawnEvent(zombie, CreatureSpawnEvent.SpawnReason.NATURAL)
+            handler.onSpawn(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("a mob spawning outside the region is allowed") {
+            val index = indexWith(mapOf(MobSpawnModifierEntry::class to MobSpawnModifierEntry(allowed = false)))
+            val handler = MobSpawnModifierHandler(index)
+
+            val zombie = world.spawnEntity(world.getBlockAt(50, 64, 50).location, EntityType.ZOMBIE) as LivingEntity
+            val event = CreatureSpawnEvent(zombie, CreatureSpawnEvent.SpawnReason.NATURAL)
+            handler.onSpawn(event)
+
+            event.isCancelled shouldBe false
+        }
+
+        test("an enderman changing a block inside a denying region is cancelled") {
+            val index = indexWith(mapOf(MobGriefModifierEntry::class to MobGriefModifierEntry(allowed = false)))
+            val handler = MobGriefModifierHandler(index)
+
+            val block = world.getBlockAt(2, 64, 2)
+            val enderman = world.spawnEntity(world.getBlockAt(2, 65, 2).location, EntityType.ENDERMAN)
+            val event = EntityChangeBlockEvent(enderman, block, Material.AIR.createBlockData())
+            handler.onChangeBlock(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("sand settling inside the region is the build flag's business, not this one's") {
+            val index = indexWith(mapOf(MobGriefModifierEntry::class to MobGriefModifierEntry(allowed = false)))
+            val handler = MobGriefModifierHandler(index)
+
+            val block = world.getBlockAt(2, 64, 2)
+            val sand = world.spawnFallingBlock(world.getBlockAt(2, 70, 2).location, Material.SAND.createBlockData())
+            val event = EntityChangeBlockEvent(sand, block, Material.SAND.createBlockData())
+            handler.onChangeBlock(event)
+
+            event.isCancelled shouldBe false
+        }
+
+        test("a player changing a block inside the same region is not this flag's business") {
+            val index = indexWith(mapOf(MobGriefModifierEntry::class to MobGriefModifierEntry(allowed = false)))
+            val handler = MobGriefModifierHandler(index)
+
+            val block = world.getBlockAt(2, 64, 2)
+            val player = server.addPlayer()
+            val event = EntityChangeBlockEvent(player, block, Material.AIR.createBlockData())
+            handler.onChangeBlock(event)
+
+            event.isCancelled shouldBe false
+        }
+    }
+}

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/flag/FlagReportSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/flag/FlagReportSpec.kt
@@ -1,0 +1,163 @@
+package com.typewritermc.region.flag
+
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.core.utils.point.World as CoreWorld
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.interaction.PlayerSessionManager
+import com.typewritermc.engine.paper.utils.Color
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionDefinitionEntry
+import com.typewritermc.region.entries.modifier.BlockBreakModifierEntry
+import com.typewritermc.region.entries.modifier.PistonModifierEntry
+import com.typewritermc.region.entries.modifier.RegionModifierEntry
+import com.typewritermc.region.shape.CuboidShape
+import com.typewritermc.region.shape.Shape
+import com.typewritermc.region.tracker.RegionTracker
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.mockk
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.mockbukkit.mockbukkit.MockBukkit
+import org.mockbukkit.mockbukkit.ServerMock
+import org.mockbukkit.mockbukkit.world.WorldMock
+import java.util.Optional
+import kotlin.reflect.KClass
+
+class FlagReportSpec : FunSpec() {
+    private lateinit var server: ServerMock
+    private lateinit var world: WorldMock
+
+    init {
+        beforeSpec {
+            server = MockBukkit.mock()
+            world = server.addSimpleWorld("flag-report")
+            startKoin { modules(module { single { mockk<PlayerSessionManager>(relaxed = true) } }) }
+        }
+
+        afterSpec {
+            stopKoin()
+            MockBukkit.unmock()
+        }
+
+        class TestRegion(
+            override val id: String,
+            override val name: String = id,
+            override val origin: Var<Position>,
+            val half: Double,
+            override val modifiers: List<Ref<out RegionModifierEntry>> = emptyList(),
+            override val priorityOverride: Optional<Int> = Optional.empty(),
+            override val offset: Var<Vector> = RegionDefaults.OFFSET,
+            override val yaw: Var<Float> = RegionDefaults.YAW,
+            override val pitch: Var<Float> = RegionDefaults.PITCH,
+            override val roll: Var<Float> = RegionDefaults.ROLL,
+            override val rotateWithOrigin: Boolean = false,
+            override val color: Color = RegionDefaults.COLOR,
+            override val refreshRateTicks: Int = RegionDefaults.REFRESH_RATE_TICKS,
+        ) : RegionDefinitionEntry {
+            override fun buildShape(): Shape = CuboidShape(half, half, half)
+        }
+
+        fun regionAt(
+            id: String,
+            half: Double,
+            priority: Int,
+            order: Int,
+            flags: Map<KClass<out RegionModifierEntry>, RegionModifierEntry>,
+        ): FlaggedRegion {
+            val entry = TestRegion(
+                id = id,
+                origin = ConstVar(Position(CoreWorld(world.uid.toString()), 0.0, 64.0, 0.0)),
+                half = half,
+            )
+            val tracker = RegionTracker(null, entry)
+            tracker.refresh()
+            return FlaggedRegion(entry, priority, order, flags, tracker, tracker.cachedAabb)
+        }
+
+        fun at(x: Double) = Position(CoreWorld(world.uid.toString()), x, 64.0, 0.0)
+
+        fun twoRegionIndex(): RegionFlagIndex {
+            val hub = regionAt(
+                id = "hub", half = 20.0, priority = 0, order = 0,
+                flags = mapOf(BlockBreakModifierEntry::class to BlockBreakModifierEntry(allowed = ConstVar(false))),
+            )
+            val arena = regionAt(
+                id = "arena", half = 5.0, priority = 10, order = 1,
+                flags = mapOf(BlockBreakModifierEntry::class to BlockBreakModifierEntry(allowed = ConstVar(true))),
+            )
+            return RegionFlagIndex(listOf(hub, arena), engine = null)
+        }
+
+        test("every flag type in handlerFactories has a report label") {
+            FLAG_LABELS.keys shouldBe handlerFactories.keys
+        }
+
+        test("flagReport names the arena as deciding block break where it overlaps the hub") {
+            val index = twoRegionIndex()
+            val player = server.addPlayer()
+
+            val breakLine = flagReport(index, at(2.0), player).first { it.contains("Block Break") }
+
+            breakLine shouldContain "arena"
+            breakLine shouldContain "allowed"
+        }
+
+        test("flagReport falls through to the hub outside the arena") {
+            val index = twoRegionIndex()
+            val player = server.addPlayer()
+
+            val breakLine = flagReport(index, at(15.0), player).first { it.contains("Block Break") }
+
+            breakLine shouldContain "hub"
+            breakLine shouldContain "denied"
+        }
+
+        test("flags nobody carries collapse into one trailing counter with the names on hover") {
+            val index = twoRegionIndex()
+            val player = server.addPlayer()
+
+            val lines = flagReport(index, at(2.0), player)
+
+            lines.size shouldBe 2
+            lines.last() shouldContain "+ 17 undecided flags"
+            lines.last() shouldContain "hover:show_text"
+            lines.last() shouldContain "Piston"
+        }
+
+        test("a block no region decides gets a single quiet line") {
+            val index = twoRegionIndex()
+            val player = server.addPlayer()
+
+            flagReport(index, at(500.0), player) shouldBe
+                    listOf("<gray>No region decides any flag at this block.")
+        }
+
+        test("standingReport lists every containing region highest priority first, one line each") {
+            val index = twoRegionIndex()
+            val player = server.addPlayer()
+
+            val lines = standingReport(index, at(2.0), player)
+
+            lines.size shouldBe 2
+            lines[0] shouldContain "arena"
+            lines[0] shouldContain "Block Break</white> <green>✔</green>"
+            lines[1] shouldContain "hub"
+            lines[1] shouldContain "Block Break</white> <red>✘</red>"
+        }
+
+        test("standingReport says so when the position is in no flagged region") {
+            val index = twoRegionIndex()
+            val player = server.addPlayer()
+
+            standingReport(index, at(500.0), player) shouldBe
+                    listOf("<gray>No flagged region contains this position.")
+        }
+    }
+}

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/flag/MechanicalFlagHandlerSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/flag/MechanicalFlagHandlerSpec.kt
@@ -1,0 +1,255 @@
+package com.typewritermc.region.flag
+
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.core.utils.point.World as CoreWorld
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.utils.Color
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionDefinitionEntry
+import com.typewritermc.region.entries.modifier.FireSpreadModifierEntry
+import com.typewritermc.region.entries.modifier.FireSpreadModifierHandler
+import com.typewritermc.region.entries.modifier.FluidFlowModifierEntry
+import com.typewritermc.region.entries.modifier.FluidFlowModifierHandler
+import com.typewritermc.region.entries.modifier.PistonModifierEntry
+import com.typewritermc.region.entries.modifier.PistonModifierHandler
+import com.typewritermc.region.entries.modifier.RedstoneModifierEntry
+import com.typewritermc.region.entries.modifier.RedstoneModifierHandler
+import com.typewritermc.region.entries.modifier.RegionModifierEntry
+import com.typewritermc.region.shape.CuboidShape
+import com.typewritermc.region.shape.Shape
+import com.typewritermc.region.tracker.RegionTracker
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.bukkit.block.BlockFace
+import org.bukkit.entity.Entity
+import org.bukkit.event.block.BlockBurnEvent
+import org.bukkit.event.block.BlockFromToEvent
+import org.bukkit.event.block.BlockIgniteEvent
+import org.bukkit.event.block.BlockPistonExtendEvent
+import org.bukkit.event.block.BlockPistonRetractEvent
+import org.bukkit.event.block.BlockRedstoneEvent
+import org.mockbukkit.mockbukkit.MockBukkit
+import org.mockbukkit.mockbukkit.ServerMock
+import org.mockbukkit.mockbukkit.world.WorldMock
+import java.util.Optional
+import kotlin.reflect.KClass
+
+class MechanicalFlagHandlerSpec : FunSpec() {
+    private lateinit var server: ServerMock
+    private lateinit var world: WorldMock
+
+    init {
+        beforeSpec {
+            server = MockBukkit.mock()
+            world = server.addSimpleWorld("mechanical")
+        }
+
+        afterSpec { MockBukkit.unmock() }
+
+        class TestRegion(
+            override val id: String,
+            override val name: String = id,
+            override val origin: Var<Position>,
+            override val modifiers: List<Ref<out RegionModifierEntry>> = emptyList(),
+            override val priorityOverride: Optional<Int> = Optional.empty(),
+            override val offset: Var<Vector> = RegionDefaults.OFFSET,
+            override val yaw: Var<Float> = RegionDefaults.YAW,
+            override val pitch: Var<Float> = RegionDefaults.PITCH,
+            override val roll: Var<Float> = RegionDefaults.ROLL,
+            override val rotateWithOrigin: Boolean = false,
+            override val color: Color = RegionDefaults.COLOR,
+            override val refreshRateTicks: Int = RegionDefaults.REFRESH_RATE_TICKS,
+        ) : RegionDefinitionEntry {
+            override fun buildShape(): Shape = CuboidShape(5.0, 5.0, 5.0)
+        }
+
+        /** A region at the origin, five blocks in every direction, carrying [flags]. */
+        fun indexWith(flags: Map<KClass<out RegionModifierEntry>, RegionModifierEntry>): RegionFlagIndex {
+            val entry = TestRegion(
+                id = "vault",
+                origin = ConstVar(Position(CoreWorld(world.uid.toString()), 0.0, 64.0, 0.0)),
+            )
+            val tracker = RegionTracker(null, entry)
+            tracker.refresh()
+            val region = FlaggedRegion(entry, 0, 0, flags, tracker, tracker.cachedAabb)
+            return RegionFlagIndex(listOf(region), engine = null)
+        }
+
+        test("a piston pushing a block into the region is cancelled whole") {
+            val index = indexWith(mapOf(PistonModifierEntry::class to PistonModifierEntry(allowed = false)))
+            val handler = PistonModifierHandler(index)
+
+            val piston = world.getBlockAt(20, 64, 0)
+            val outside = world.getBlockAt(19, 64, 0)
+            val inside = world.getBlockAt(2, 64, 0)
+            val event = BlockPistonExtendEvent(piston, listOf(outside, inside), BlockFace.WEST)
+            handler.onExtend(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("a piston moving only blocks outside the region is left alone") {
+            val index = indexWith(mapOf(PistonModifierEntry::class to PistonModifierEntry(allowed = false)))
+            val handler = PistonModifierHandler(index)
+
+            val piston = world.getBlockAt(40, 64, 0)
+            val outside = world.getBlockAt(39, 64, 0)
+            val event = BlockPistonExtendEvent(piston, listOf(outside), BlockFace.WEST)
+            handler.onExtend(event)
+
+            event.isCancelled shouldBe false
+        }
+
+        test("a piston is allowed when the region says so") {
+            val index = indexWith(mapOf(PistonModifierEntry::class to PistonModifierEntry(allowed = true)))
+            val handler = PistonModifierHandler(index)
+
+            val piston = world.getBlockAt(20, 64, 0)
+            val inside = world.getBlockAt(2, 64, 0)
+            val event = BlockPistonExtendEvent(piston, listOf(inside), BlockFace.WEST)
+            handler.onExtend(event)
+
+            event.isCancelled shouldBe false
+        }
+
+        // A sticky piston standing inside the region drags whatever is stuck to its head in from
+        // outside, and the block it pulls is listed where it stands rather than where it lands.
+        test("a sticky piston pulling a block into the region is cancelled") {
+            val index = indexWith(mapOf(PistonModifierEntry::class to PistonModifierEntry(allowed = false)))
+            val handler = PistonModifierHandler(index)
+
+            val piston = world.getBlockAt(3, 64, 0)
+            val pulled = world.getBlockAt(5, 64, 0)
+            val event = BlockPistonRetractEvent(piston, listOf(pulled), BlockFace.WEST)
+            handler.onRetract(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("a sticky piston pulling a block nowhere near the region is left alone") {
+            val index = indexWith(mapOf(PistonModifierEntry::class to PistonModifierEntry(allowed = false)))
+            val handler = PistonModifierHandler(index)
+
+            val piston = world.getBlockAt(30, 64, 0)
+            val pulled = world.getBlockAt(32, 64, 0)
+            val event = BlockPistonRetractEvent(piston, listOf(pulled), BlockFace.WEST)
+            handler.onRetract(event)
+
+            event.isCancelled shouldBe false
+        }
+
+        test("redstone inside the region is held at its old current") {
+            val index = indexWith(mapOf(RedstoneModifierEntry::class to RedstoneModifierEntry(allowed = false)))
+            val handler = RedstoneModifierHandler(index)
+
+            val event = BlockRedstoneEvent(world.getBlockAt(2, 64, 2), 0, 15)
+            handler.onRedstone(event)
+
+            event.newCurrent shouldBe 0
+        }
+
+        test("redstone outside the region is left alone") {
+            val index = indexWith(mapOf(RedstoneModifierEntry::class to RedstoneModifierEntry(allowed = false)))
+            val handler = RedstoneModifierHandler(index)
+
+            val event = BlockRedstoneEvent(world.getBlockAt(50, 64, 50), 0, 15)
+            handler.onRedstone(event)
+
+            event.newCurrent shouldBe 15
+        }
+
+        test("fire spreading into a denying region is cancelled") {
+            val index = indexWith(mapOf(FireSpreadModifierEntry::class to FireSpreadModifierEntry(allowed = false)))
+            val handler = FireSpreadModifierHandler(index)
+
+            val inside = world.getBlockAt(2, 64, 0)
+            val event = BlockIgniteEvent(inside, BlockIgniteEvent.IgniteCause.SPREAD, null as Entity?)
+            handler.onIgnite(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("fire spreading outside the region is left alone") {
+            val index = indexWith(mapOf(FireSpreadModifierEntry::class to FireSpreadModifierEntry(allowed = false)))
+            val handler = FireSpreadModifierHandler(index)
+
+            val outside = world.getBlockAt(40, 64, 40)
+            val event = BlockIgniteEvent(outside, BlockIgniteEvent.IgniteCause.SPREAD, null as Entity?)
+            handler.onIgnite(event)
+
+            event.isCancelled shouldBe false
+        }
+
+        test("a player lighting a fire with flint and steel is not this flag's business") {
+            val index = indexWith(mapOf(FireSpreadModifierEntry::class to FireSpreadModifierEntry(allowed = false)))
+            val handler = FireSpreadModifierHandler(index)
+
+            val inside = world.getBlockAt(2, 64, 0)
+            val player = server.addPlayer()
+            val event = BlockIgniteEvent(inside, BlockIgniteEvent.IgniteCause.FLINT_AND_STEEL, player)
+            handler.onIgnite(event)
+
+            event.isCancelled shouldBe false
+        }
+
+        test("a player throwing a fire charge is not this flag's business either") {
+            val index = indexWith(mapOf(FireSpreadModifierEntry::class to FireSpreadModifierEntry(allowed = false)))
+            val handler = FireSpreadModifierHandler(index)
+
+            val inside = world.getBlockAt(2, 64, 0)
+            val event = BlockIgniteEvent(inside, BlockIgniteEvent.IgniteCause.FIREBALL, server.addPlayer())
+            handler.onIgnite(event)
+
+            event.isCancelled shouldBe false
+        }
+
+        test("a ghast's fireball is, since no ignite flag can ever see it") {
+            val index = indexWith(mapOf(FireSpreadModifierEntry::class to FireSpreadModifierEntry(allowed = false)))
+            val handler = FireSpreadModifierHandler(index)
+
+            val inside = world.getBlockAt(2, 64, 0)
+            val event = BlockIgniteEvent(inside, BlockIgniteEvent.IgniteCause.FIREBALL, null as Entity?)
+            handler.onIgnite(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("a block burning inside the region is cancelled") {
+            val index = indexWith(mapOf(FireSpreadModifierEntry::class to FireSpreadModifierEntry(allowed = false)))
+            val handler = FireSpreadModifierHandler(index)
+
+            val inside = world.getBlockAt(2, 64, 0)
+            val event = BlockBurnEvent(inside)
+            handler.onBurn(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("a fluid flowing into a denying region is cancelled even though its source is outside") {
+            val index = indexWith(mapOf(FluidFlowModifierEntry::class to FluidFlowModifierEntry(allowed = false)))
+            val handler = FluidFlowModifierHandler(index)
+
+            val source = world.getBlockAt(40, 64, 0)
+            val destination = world.getBlockAt(2, 64, 0)
+            val event = BlockFromToEvent(source, destination)
+            handler.onFlow(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("a fluid flowing out of the region is left alone") {
+            val index = indexWith(mapOf(FluidFlowModifierEntry::class to FluidFlowModifierEntry(allowed = false)))
+            val handler = FluidFlowModifierHandler(index)
+
+            val source = world.getBlockAt(2, 64, 0)
+            val destination = world.getBlockAt(40, 64, 0)
+            val event = BlockFromToEvent(source, destination)
+            handler.onFlow(event)
+
+            event.isCancelled shouldBe false
+        }
+    }
+}

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/flag/ProtectionFlagHandlerSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/flag/ProtectionFlagHandlerSpec.kt
@@ -1,0 +1,267 @@
+package com.typewritermc.region.flag
+
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.core.utils.point.World as CoreWorld
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.interaction.PlayerSessionManager
+import com.typewritermc.engine.paper.utils.Color
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionDefinitionEntry
+import com.typewritermc.region.entries.modifier.BucketModifierEntry
+import com.typewritermc.region.entries.modifier.BucketModifierHandler
+import com.typewritermc.region.entries.modifier.EntityDamageModifierEntry
+import com.typewritermc.region.entries.modifier.EntityDamageModifierHandler
+import com.typewritermc.region.entries.modifier.IgniteModifierEntry
+import com.typewritermc.region.entries.modifier.IgniteModifierHandler
+import com.typewritermc.region.entries.modifier.RegionModifierEntry
+import com.typewritermc.region.entries.modifier.TrampleModifierEntry
+import com.typewritermc.region.entries.modifier.TrampleModifierHandler
+import com.typewritermc.region.shape.CuboidShape
+import com.typewritermc.region.shape.Shape
+import com.typewritermc.region.tracker.RegionTracker
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.bukkit.Material
+import org.bukkit.block.BlockFace
+import org.bukkit.block.data.Directional
+import org.bukkit.entity.EntityType
+import org.bukkit.event.block.Action
+import org.bukkit.event.block.BlockDispenseEvent
+import org.bukkit.event.block.BlockIgniteEvent
+import org.bukkit.event.entity.EntityDamageByEntityEvent
+import org.bukkit.event.entity.EntityDamageEvent
+import org.bukkit.event.player.PlayerBucketEmptyEvent
+import org.bukkit.event.player.PlayerBucketFillEvent
+import org.bukkit.event.player.PlayerInteractEvent
+import org.bukkit.inventory.EquipmentSlot
+import org.bukkit.inventory.ItemStack
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.mockbukkit.mockbukkit.MockBukkit
+import org.mockbukkit.mockbukkit.ServerMock
+import org.mockbukkit.mockbukkit.world.WorldMock
+import java.util.Optional
+import kotlin.reflect.KClass
+
+class ProtectionFlagHandlerSpec : FunSpec() {
+    private lateinit var server: ServerMock
+    private lateinit var world: WorldMock
+
+    init {
+        beforeSpec {
+            server = MockBukkit.mock()
+            world = server.addSimpleWorld("protection")
+            startKoin { modules(module { single { mockk<PlayerSessionManager>(relaxed = true) } }) }
+        }
+
+        afterSpec {
+            stopKoin()
+            MockBukkit.unmock()
+        }
+
+        class TestRegion(
+            override val id: String,
+            override val name: String = id,
+            override val origin: Var<Position>,
+            override val modifiers: List<Ref<out RegionModifierEntry>> = emptyList(),
+            override val priorityOverride: Optional<Int> = Optional.empty(),
+            override val offset: Var<Vector> = RegionDefaults.OFFSET,
+            override val yaw: Var<Float> = RegionDefaults.YAW,
+            override val pitch: Var<Float> = RegionDefaults.PITCH,
+            override val roll: Var<Float> = RegionDefaults.ROLL,
+            override val rotateWithOrigin: Boolean = false,
+            override val color: Color = RegionDefaults.COLOR,
+            override val refreshRateTicks: Int = RegionDefaults.REFRESH_RATE_TICKS,
+        ) : RegionDefinitionEntry {
+            override fun buildShape(): Shape = CuboidShape(5.0, 5.0, 5.0)
+        }
+
+        fun indexWith(flags: Map<KClass<out RegionModifierEntry>, RegionModifierEntry>): RegionFlagIndex {
+            val entry = TestRegion(
+                id = "safe-zone",
+                origin = ConstVar(Position(CoreWorld(world.uid.toString()), 0.0, 64.0, 0.0)),
+            )
+            val tracker = RegionTracker(null, entry)
+            tracker.refresh()
+            val region = FlaggedRegion(entry, 0, 0, flags, tracker, tracker.cachedAabb)
+            return RegionFlagIndex(listOf(region), engine = null)
+        }
+
+        test("emptying a bucket inside the region is stopped") {
+            val handler = BucketModifierHandler(
+                indexWith(mapOf(BucketModifierEntry::class to BucketModifierEntry(allowed = ConstVar(false))))
+            )
+            val player = server.addPlayer()
+
+            val event = PlayerBucketEmptyEvent(
+                player,
+                world.getBlockAt(2, 64, 2),
+                world.getBlockAt(2, 63, 2),
+                BlockFace.UP,
+                Material.LAVA_BUCKET,
+                ItemStack(Material.LAVA_BUCKET),
+                EquipmentSlot.HAND,
+            )
+            handler.onEmpty(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("filling a bucket inside the region is stopped, and it is a different handler list") {
+            val handler = BucketModifierHandler(
+                indexWith(mapOf(BucketModifierEntry::class to BucketModifierEntry(allowed = ConstVar(false))))
+            )
+            val player = server.addPlayer()
+
+            val event = PlayerBucketFillEvent(
+                player,
+                world.getBlockAt(2, 64, 2),
+                world.getBlockAt(2, 63, 2),
+                BlockFace.UP,
+                Material.BUCKET,
+                ItemStack(Material.BUCKET),
+                EquipmentSlot.HAND,
+            )
+            handler.onFill(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("a bucket outside the region is left alone") {
+            val handler = BucketModifierHandler(
+                indexWith(mapOf(BucketModifierEntry::class to BucketModifierEntry(allowed = ConstVar(false))))
+            )
+            val player = server.addPlayer()
+
+            val event = PlayerBucketEmptyEvent(
+                player,
+                world.getBlockAt(50, 64, 50),
+                world.getBlockAt(50, 63, 50),
+                BlockFace.UP,
+                Material.LAVA_BUCKET,
+                ItemStack(Material.LAVA_BUCKET),
+                EquipmentSlot.HAND,
+            )
+            handler.onEmpty(event)
+
+            event.isCancelled shouldBe false
+        }
+
+        test("a dispenser outside the region cannot pour a mob bucket into it") {
+            val handler = BucketModifierHandler(
+                indexWith(mapOf(BucketModifierEntry::class to BucketModifierEntry(allowed = ConstVar(false))))
+            )
+            val dispenser = world.getBlockAt(5, 64, 2)
+            dispenser.type = Material.DISPENSER
+            dispenser.blockData = (dispenser.blockData as Directional).apply { facing = BlockFace.WEST }
+
+            val event = BlockDispenseEvent(dispenser, ItemStack(Material.AXOLOTL_BUCKET), org.bukkit.util.Vector())
+            handler.onDispense(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("breaking an item frame inside the region is stopped") {
+            val handler = EntityDamageModifierHandler(
+                indexWith(
+                    mapOf(EntityDamageModifierEntry::class to EntityDamageModifierEntry(allowed = ConstVar(false)))
+                )
+            )
+            val player = server.addPlayer()
+            val frame = world.spawnEntity(world.getBlockAt(2, 64, 2).location, EntityType.ITEM_FRAME)
+
+            val event = EntityDamageByEntityEvent(
+                player, frame, EntityDamageEvent.DamageCause.ENTITY_ATTACK, 1.0,
+            )
+            handler.onDamage(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("hurting a player is not the entity damage flag's business") {
+            val handler = EntityDamageModifierHandler(
+                indexWith(
+                    mapOf(EntityDamageModifierEntry::class to EntityDamageModifierEntry(allowed = ConstVar(false)))
+                )
+            )
+            val attacker = server.addPlayer()
+            val victim = server.addPlayer()
+            victim.teleport(world.getBlockAt(2, 64, 2).location)
+
+            val event = EntityDamageByEntityEvent(
+                attacker, victim, EntityDamageEvent.DamageCause.ENTITY_ATTACK, 4.0,
+            )
+            handler.onDamage(event)
+
+            event.isCancelled shouldBe false
+        }
+
+        test("trampling farmland inside the region is stopped") {
+            val handler = TrampleModifierHandler(
+                indexWith(mapOf(TrampleModifierEntry::class to TrampleModifierEntry(allowed = ConstVar(false))))
+            )
+            val player = server.addPlayer()
+            val farmland = world.getBlockAt(2, 64, 2)
+            farmland.type = Material.FARMLAND
+
+            val event = PlayerInteractEvent(
+                player, Action.PHYSICAL, ItemStack(Material.AIR), farmland, BlockFace.UP,
+            )
+            handler.onPhysical(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("a pressure plate inside the region still works") {
+            val handler = TrampleModifierHandler(
+                indexWith(mapOf(TrampleModifierEntry::class to TrampleModifierEntry(allowed = ConstVar(false))))
+            )
+            val player = server.addPlayer()
+            val plate = world.getBlockAt(2, 64, 2)
+            plate.type = Material.STONE_PRESSURE_PLATE
+
+            val event = PlayerInteractEvent(
+                player, Action.PHYSICAL, ItemStack(Material.AIR), plate, BlockFace.UP,
+            )
+            handler.onPhysical(event)
+
+            event.isCancelled shouldBe false
+        }
+
+        test("lighting a fire inside the region is stopped") {
+            val handler = IgniteModifierHandler(
+                indexWith(mapOf(IgniteModifierEntry::class to IgniteModifierEntry(allowed = ConstVar(false))))
+            )
+            val player = server.addPlayer()
+
+            val event = BlockIgniteEvent(
+                world.getBlockAt(2, 64, 2),
+                BlockIgniteEvent.IgniteCause.FLINT_AND_STEEL,
+                player,
+            )
+            handler.onIgnite(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("fire spreading is not the ignite flag's business") {
+            val handler = IgniteModifierHandler(
+                indexWith(mapOf(IgniteModifierEntry::class to IgniteModifierEntry(allowed = ConstVar(false))))
+            )
+
+            val event = BlockIgniteEvent(
+                world.getBlockAt(2, 64, 2),
+                BlockIgniteEvent.IgniteCause.SPREAD,
+                null as org.bukkit.entity.Entity?,
+            )
+            handler.onIgnite(event)
+
+            event.isCancelled shouldBe false
+        }
+    }
+}

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/flag/RegionFlagIndexSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/flag/RegionFlagIndexSpec.kt
@@ -1,0 +1,216 @@
+package com.typewritermc.region.flag
+
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.core.utils.point.World
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.utils.Color
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionDefinitionEntry
+import com.typewritermc.region.entries.modifier.RegionModifierEntry
+import com.typewritermc.region.shape.CuboidShape
+import com.typewritermc.region.shape.Shape
+import com.typewritermc.region.tracker.RegionTracker
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import java.util.Optional
+import kotlin.reflect.KClass
+
+class RegionFlagIndexSpec : FunSpec({
+    val world = World("flag-world")
+
+    class BreakFlag(
+        override val id: String = "",
+        override val name: String = "",
+        val allowed: Boolean = false,
+    ) : RegionModifierEntry
+
+    class PvpFlag(
+        override val id: String = "",
+        override val name: String = "",
+    ) : RegionModifierEntry
+
+    class TestRegion(
+        override val id: String,
+        override val name: String = id,
+        override val origin: Var<Position>,
+        val half: Double,
+        override val modifiers: List<Ref<out RegionModifierEntry>> = emptyList(),
+        override val priorityOverride: Optional<Int> = Optional.empty(),
+        override val offset: Var<Vector> = RegionDefaults.OFFSET,
+        override val yaw: Var<Float> = RegionDefaults.YAW,
+        override val pitch: Var<Float> = RegionDefaults.PITCH,
+        override val roll: Var<Float> = RegionDefaults.ROLL,
+        override val rotateWithOrigin: Boolean = false,
+        override val color: Color = RegionDefaults.COLOR,
+        override val refreshRateTicks: Int = RegionDefaults.REFRESH_RATE_TICKS,
+    ) : RegionDefinitionEntry {
+        override fun buildShape(): Shape = CuboidShape(half, half, half)
+    }
+
+    fun regionAt(
+        id: String,
+        x: Double,
+        half: Double,
+        priority: Int,
+        order: Int,
+        flags: Map<KClass<out RegionModifierEntry>, RegionModifierEntry>,
+    ): FlaggedRegion {
+        val entry = TestRegion(id = id, origin = ConstVar(Position(world, x, 64.0, 0.0)), half = half)
+        val tracker = RegionTracker(null, entry)
+        tracker.refresh()
+        return FlaggedRegion(entry, priority, order, flags, tracker, tracker.cachedAabb)
+    }
+
+    fun at(x: Double, y: Double = 64.0, z: Double = 0.0) = Position(world, x, y, z)
+
+    val deny = BreakFlag(id = "deny", allowed = false)
+    val allow = BreakFlag(id = "allow", allowed = true)
+
+    test("a region carrying the flag decides for a point inside it") {
+        val index = RegionFlagIndex(
+            listOf(regionAt("city", 0.0, 10.0, priority = 0, order = 0, flags = mapOf(BreakFlag::class to deny))),
+            engine = null,
+        )
+
+        val resolved = index.resolve(BreakFlag::class, at(3.0), null).shouldNotBeNull()
+        resolved.allowed shouldBe false
+    }
+
+    test("a point in no region resolves to nothing") {
+        val index = RegionFlagIndex(
+            listOf(regionAt("city", 0.0, 10.0, priority = 0, order = 0, flags = mapOf(BreakFlag::class to deny))),
+            engine = null,
+        )
+
+        index.resolve(BreakFlag::class, at(500.0), null).shouldBeNull()
+    }
+
+    test("the higher priority region wins, so an arena re-allows what the city forbids") {
+        val city = regionAt("city", 0.0, 20.0, priority = 0, order = 0, flags = mapOf(BreakFlag::class to deny))
+        val arena = regionAt("arena", 0.0, 5.0, priority = 10, order = 1, flags = mapOf(BreakFlag::class to allow))
+        val index = RegionFlagIndex(listOf(city, arena), engine = null)
+
+        index.resolve(BreakFlag::class, at(2.0), null).shouldNotBeNull().allowed shouldBe true
+        index.resolve(BreakFlag::class, at(15.0), null).shouldNotBeNull().allowed shouldBe false
+    }
+
+    test("a higher priority region without the flag falls through to a lower one that has it") {
+        val city = regionAt("city", 0.0, 20.0, priority = 0, order = 0, flags = mapOf(BreakFlag::class to deny))
+        val plaza = regionAt("plaza", 0.0, 5.0, priority = 10, order = 1, flags = mapOf(PvpFlag::class to PvpFlag()))
+        val index = RegionFlagIndex(listOf(city, plaza), engine = null)
+
+        index.resolve(BreakFlag::class, at(2.0), null).shouldNotBeNull().allowed shouldBe false
+    }
+
+    test("equal priorities resolve to the region declared later") {
+        val older = regionAt("older", 0.0, 10.0, priority = 5, order = 0, flags = mapOf(BreakFlag::class to deny))
+        val newer = regionAt("newer", 0.0, 10.0, priority = 5, order = 1, flags = mapOf(BreakFlag::class to allow))
+        val index = RegionFlagIndex(listOf(older, newer), engine = null)
+
+        index.resolve(BreakFlag::class, at(0.0), null).shouldNotBeNull().allowed shouldBe true
+    }
+
+    test("a region too large to index is still found, through the oversized bucket") {
+        val huge = regionAt("huge", 0.0, 6000.0, priority = 0, order = 0, flags = mapOf(BreakFlag::class to deny))
+        val index = RegionFlagIndex(listOf(huge), engine = null)
+
+        index.oversizedCount shouldBe 1
+        index.resolve(BreakFlag::class, at(1000.0), null).shouldNotBeNull().allowed shouldBe false
+    }
+
+    test("a normal region is indexed by chunk, not scanned") {
+        val index = RegionFlagIndex(
+            listOf(regionAt("city", 0.0, 10.0, priority = 0, order = 0, flags = mapOf(BreakFlag::class to deny))),
+            engine = null,
+        )
+
+        index.oversizedCount shouldBe 0
+    }
+
+    test("a block in a chunk no region touches tests no region at all") {
+        val regions = (0 until 200).map { index ->
+            regionAt("r$index", index * 64.0, 8.0, priority = 0, order = index, flags = mapOf(BreakFlag::class to deny))
+        }
+        val index = RegionFlagIndex(regions, engine = null)
+
+        // Far from every region's chunks. The index must not consult a single region here: this is
+        // the redstone contraption case, and the whole design exists to make it free.
+        index.resolve(BreakFlag::class, at(100_000.0), null).shouldBeNull()
+        index.candidatesTouched shouldBe 0
+    }
+
+    test("a lookup inside one region touches only the regions sharing its chunk") {
+        val regions = (0 until 200).map { index ->
+            regionAt("r$index", index * 64.0, 8.0, priority = 0, order = index, flags = mapOf(BreakFlag::class to deny))
+        }
+        val index = RegionFlagIndex(regions, engine = null)
+
+        index.resolve(BreakFlag::class, at(0.0), null).shouldNotBeNull()
+        index.candidatesTouched shouldBe 1
+    }
+
+    // The index and the lookup must round a coordinate to a chunk the same way. They round
+    // differently for negatives if either side uses a plain division, and the region's flags then
+    // silently stop applying across half the world.
+    test("a region on the negative side of an axis still decides") {
+        val index = RegionFlagIndex(
+            listOf(regionAt("west", -200.0, 10.0, priority = 0, order = 0, flags = mapOf(BreakFlag::class to deny))),
+            engine = null,
+        )
+
+        index.resolve(BreakFlag::class, at(-200.0), null).shouldNotBeNull().allowed shouldBe false
+        index.resolve(BreakFlag::class, at(-195.0), null).shouldNotBeNull().allowed shouldBe false
+        index.resolve(BreakFlag::class, at(-160.0), null).shouldBeNull()
+    }
+
+    test("a region straddling the origin decides on both sides of it") {
+        val index = RegionFlagIndex(
+            listOf(regionAt("center", 0.0, 20.0, priority = 0, order = 0, flags = mapOf(BreakFlag::class to deny))),
+            engine = null,
+        )
+
+        index.resolve(BreakFlag::class, at(-18.0, 64.0, -18.0), null).shouldNotBeNull().allowed shouldBe false
+        index.resolve(BreakFlag::class, at(18.0, 64.0, 18.0), null).shouldNotBeNull().allowed shouldBe false
+    }
+
+    test("a decision names the region that made it") {
+        val city = regionAt("city", 0.0, 20.0, priority = 0, order = 0, flags = mapOf(BreakFlag::class to deny))
+        val arena = regionAt("arena", 0.0, 5.0, priority = 10, order = 1, flags = mapOf(BreakFlag::class to allow))
+        val index = RegionFlagIndex(listOf(city, arena), engine = null)
+
+        val decision = index.resolveDecision(BreakFlag::class, at(2.0), null).shouldNotBeNull()
+        decision.flag.allowed shouldBe true
+        decision.regionName shouldBe "arena"
+        decision.priority shouldBe 10
+
+        val outer = index.resolveDecision(BreakFlag::class, at(15.0), null).shouldNotBeNull()
+        outer.regionName shouldBe "city"
+        outer.priority shouldBe 0
+    }
+
+    test("resolve agrees with resolveDecision, because it is the same walk") {
+        val city = regionAt("city", 0.0, 20.0, priority = 0, order = 0, flags = mapOf(BreakFlag::class to deny))
+        val arena = regionAt("arena", 0.0, 5.0, priority = 10, order = 1, flags = mapOf(BreakFlag::class to allow))
+        val index = RegionFlagIndex(listOf(city, arena), engine = null)
+
+        index.resolve(BreakFlag::class, at(2.0), null) shouldBe
+                index.resolveDecision(BreakFlag::class, at(2.0), null)?.flag
+        index.resolve(BreakFlag::class, at(500.0), null) shouldBe
+                index.resolveDecision(BreakFlag::class, at(500.0), null)?.flag
+    }
+
+    test("regionsAt lists every containing region, highest priority first") {
+        val city = regionAt("city", 0.0, 20.0, priority = 0, order = 0, flags = mapOf(BreakFlag::class to deny))
+        val arena = regionAt("arena", 0.0, 5.0, priority = 10, order = 1, flags = mapOf(BreakFlag::class to allow))
+        val index = RegionFlagIndex(listOf(city, arena), engine = null)
+
+        index.regionsAt(at(2.0), null).map { it.entry.name } shouldBe listOf("arena", "city")
+        index.regionsAt(at(15.0), null).map { it.entry.name } shouldBe listOf("city")
+        index.regionsAt(at(500.0), null).map { it.entry.name } shouldBe emptyList()
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/flag/RegionFlagManagerSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/flag/RegionFlagManagerSpec.kt
@@ -1,0 +1,136 @@
+package com.typewritermc.region.flag
+
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.core.utils.point.World
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.utils.Color
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionDefinitionEntry
+import com.typewritermc.region.entries.modifier.EntityDamageModifierEntry
+import com.typewritermc.region.entries.modifier.RegionModifierEntry
+import com.typewritermc.region.shape.CuboidShape
+import com.typewritermc.region.shape.Shape
+import com.typewritermc.region.tracker.RegionTracker
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import java.util.Optional
+
+class RegionFlagManagerSpec : FunSpec({
+    val world = World("flag-world")
+
+    class BreakFlag(override val id: String = "break", override val name: String = "No Breaking") : RegionModifierEntry
+    class PistonFlag(override val id: String = "piston", override val name: String = "No Pistons") : RegionModifierEntry
+
+    class TestRegion(
+        override val id: String,
+        override val name: String = id,
+        override val origin: Var<Position>,
+        override val modifiers: List<Ref<out RegionModifierEntry>> = emptyList(),
+        override val priorityOverride: Optional<Int> = Optional.empty(),
+        override val offset: Var<Vector> = RegionDefaults.OFFSET,
+        override val yaw: Var<Float> = RegionDefaults.YAW,
+        override val pitch: Var<Float> = RegionDefaults.PITCH,
+        override val roll: Var<Float> = RegionDefaults.ROLL,
+        override val rotateWithOrigin: Boolean = false,
+        override val color: Color = RegionDefaults.COLOR,
+        override val refreshRateTicks: Int = RegionDefaults.REFRESH_RATE_TICKS,
+    ) : RegionDefinitionEntry {
+        override fun buildShape(): Shape = CuboidShape(5.0, 5.0, 5.0)
+    }
+
+    fun staticRegion(id: String) = TestRegion(id = id, origin = ConstVar(Position(world, 0.0, 64.0, 0.0)))
+
+    test("a viewerless flag on a variable placed region is reported, because it can never apply") {
+        val dynamic = FlaggedRegion(
+            entry = staticRegion("cone"),
+            priority = 0,
+            order = 0,
+            modifiers = mapOf(PistonFlag::class to PistonFlag()),
+            tracker = null,
+            aabb = null,
+        )
+
+        val warnings = viewerlessFlagsOnDynamicRegions(listOf(dynamic), setOf(PistonFlag::class))
+
+        warnings shouldHaveSize 1
+        warnings.first().first shouldBe "cone"
+        warnings.first().second shouldBe "No Pistons"
+    }
+
+    test("a player decided flag on a variable placed region is not reported") {
+        val dynamic = FlaggedRegion(
+            entry = staticRegion("cone"),
+            priority = 0,
+            order = 0,
+            modifiers = mapOf(BreakFlag::class to BreakFlag()),
+            tracker = null,
+            aabb = null,
+        )
+
+        viewerlessFlagsOnDynamicRegions(listOf(dynamic), setOf(PistonFlag::class)).shouldBeEmpty()
+    }
+
+    test("a viewerless flag on a constant placed region is not reported") {
+        val entry = staticRegion("city")
+        val tracker = RegionTracker(null, entry)
+        tracker.refresh()
+        val region = FlaggedRegion(
+            entry = entry,
+            priority = 0,
+            order = 0,
+            modifiers = mapOf(PistonFlag::class to PistonFlag()),
+            tracker = tracker,
+            aabb = tracker.cachedAabb,
+        )
+
+        viewerlessFlagsOnDynamicRegions(listOf(region), setOf(PistonFlag::class)).shouldBeEmpty()
+    }
+
+    val entityDamageFlag = EntityDamageModifierEntry(id = "entity_damage", name = "No Entity Damage")
+
+    test("a partly viewerless flag on a variable placed region is reported, because it only partly applies") {
+        val dynamic = FlaggedRegion(
+            entry = staticRegion("museum"),
+            priority = 0,
+            order = 0,
+            modifiers = mapOf(EntityDamageModifierEntry::class to entityDamageFlag),
+            tracker = null,
+            aabb = null,
+        )
+
+        val warnings = viewerlessFlagsOnDynamicRegions(listOf(dynamic), PARTLY_VIEWERLESS_FLAGS)
+
+        warnings shouldHaveSize 1
+        warnings.first().first shouldBe "museum"
+        warnings.first().second shouldBe "No Entity Damage"
+    }
+
+    test("a partly viewerless flag on a constant placed region is not reported") {
+        val entry = staticRegion("museum")
+        val tracker = RegionTracker(null, entry)
+        tracker.refresh()
+        val region = FlaggedRegion(
+            entry = entry,
+            priority = 0,
+            order = 0,
+            modifiers = mapOf(EntityDamageModifierEntry::class to entityDamageFlag),
+            tracker = tracker,
+            aabb = tracker.cachedAabb,
+        )
+
+        viewerlessFlagsOnDynamicRegions(listOf(region), PARTLY_VIEWERLESS_FLAGS).shouldBeEmpty()
+    }
+
+    test("buildFlaggedRegions skips a region with no flags, and resolves a tracker for a static one") {
+        val flagged = TestRegion(id = "city", origin = ConstVar(Position(world, 0.0, 64.0, 0.0)))
+        val plain = TestRegion(id = "plain", origin = ConstVar(Position(world, 0.0, 64.0, 0.0)))
+
+        // A region whose modifier refs resolve to nothing carries no flags and must not be indexed.
+        buildFlaggedRegions(listOf(flagged, plain)).shouldBeEmpty()
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/flag/VariableAllowanceSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/flag/VariableAllowanceSpec.kt
@@ -1,0 +1,179 @@
+package com.typewritermc.region.flag
+
+import com.typewritermc.core.entries.Ref
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.core.utils.point.World as CoreWorld
+import com.typewritermc.engine.paper.entry.entries.ComputeVar
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.entry.entries.Var
+import com.typewritermc.engine.paper.interaction.PlayerSessionManager
+import com.typewritermc.engine.paper.utils.Color
+import com.typewritermc.region.data.RegionDefaults
+import com.typewritermc.region.data.RegionDefinitionEntry
+import com.typewritermc.region.entries.modifier.BlockBreakModifierEntry
+import com.typewritermc.region.entries.modifier.BlockBreakModifierHandler
+import com.typewritermc.region.entries.modifier.BlockPlaceModifierEntry
+import com.typewritermc.region.entries.modifier.BlockPlaceModifierHandler
+import com.typewritermc.region.entries.modifier.RegionModifierEntry
+import com.typewritermc.region.shape.CuboidShape
+import com.typewritermc.region.shape.Shape
+import com.typewritermc.region.tracker.RegionTracker
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.bukkit.event.block.BlockBreakEvent
+import org.bukkit.event.block.BlockGrowEvent
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.mockbukkit.mockbukkit.MockBukkit
+import org.mockbukkit.mockbukkit.ServerMock
+import org.mockbukkit.mockbukkit.world.WorldMock
+import java.util.Optional
+
+/**
+ * A flag whose allowance is bound to a variable cannot answer for an event with no player behind
+ * it. It has to step aside there rather than read as a denial: a region that means "members may
+ * build here" would otherwise stop its own crops from growing, for good and without saying so.
+ */
+class VariableAllowanceSpec : FunSpec() {
+    private lateinit var server: ServerMock
+    private lateinit var world: WorldMock
+
+    init {
+        beforeSpec {
+            server = MockBukkit.mock()
+            world = server.addSimpleWorld("allowance")
+            startKoin { modules(module { single { mockk<PlayerSessionManager>(relaxed = true) } }) }
+        }
+
+        afterSpec {
+            stopKoin()
+            MockBukkit.unmock()
+        }
+
+        class TestRegion(
+            override val id: String,
+            override val name: String = id,
+            override val origin: Var<Position>,
+            override val modifiers: List<Ref<out RegionModifierEntry>> = emptyList(),
+            override val priorityOverride: Optional<Int> = Optional.empty(),
+            override val offset: Var<Vector> = RegionDefaults.OFFSET,
+            override val yaw: Var<Float> = RegionDefaults.YAW,
+            override val pitch: Var<Float> = RegionDefaults.PITCH,
+            override val roll: Var<Float> = RegionDefaults.ROLL,
+            override val rotateWithOrigin: Boolean = false,
+            override val color: Color = RegionDefaults.COLOR,
+            override val refreshRateTicks: Int = RegionDefaults.REFRESH_RATE_TICKS,
+            private val shape: Shape = CuboidShape(5.0, 5.0, 5.0),
+        ) : RegionDefinitionEntry {
+            override fun buildShape(): Shape = shape
+        }
+
+        fun region(
+            id: String,
+            priority: Int,
+            flag: RegionModifierEntry,
+            type: kotlin.reflect.KClass<out RegionModifierEntry>,
+        ): FlaggedRegion {
+            val entry = TestRegion(
+                id = id,
+                origin = ConstVar(Position(CoreWorld(world.uid.toString()), 0.0, 64.0, 0.0)),
+            )
+            val tracker = RegionTracker(null, entry)
+            tracker.refresh()
+            return FlaggedRegion(
+                entry = entry,
+                priority = priority,
+                order = priority,
+                modifiers = mapOf(type to flag),
+                tracker = tracker,
+                aabb = tracker.cachedAabb,
+            )
+        }
+
+        test("a crop keeps growing under a flag whose allowance needs a player") {
+            val flag = BlockPlaceModifierEntry(
+                id = "members-only",
+                name = "Members Only",
+                allowed = ComputeVar { _, _ -> true },
+            )
+            val index = RegionFlagIndex(
+                listOf(region("farm", 0, flag, BlockPlaceModifierEntry::class)),
+                engine = null,
+            )
+            val block = world.getBlockAt(2, 64, 2)
+
+            val event = BlockGrowEvent(block, block.state)
+            BlockPlaceModifierHandler(index).onGrow(event)
+
+            event.isCancelled shouldBe false
+        }
+
+        test("a player is still decided about by the same flag") {
+            val flag = BlockBreakModifierEntry(
+                id = "members-only",
+                name = "Members Only",
+                allowed = ComputeVar { _, _ -> false },
+            )
+            val index = RegionFlagIndex(
+                listOf(region("vault", 0, flag, BlockBreakModifierEntry::class)),
+                engine = null,
+            )
+
+            val event = BlockBreakEvent(world.getBlockAt(2, 64, 2), server.addPlayer())
+            BlockBreakModifierHandler(index).onBreak(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("the region below decides when the one on top cannot") {
+            val members = BlockPlaceModifierEntry(
+                id = "members-only",
+                name = "Members Only",
+                allowed = ComputeVar { _, _ -> true },
+            )
+            val sealed = BlockPlaceModifierEntry(
+                id = "sealed",
+                name = "Sealed",
+                allowed = ConstVar(false),
+            )
+            val index = RegionFlagIndex(
+                listOf(
+                    region("plot", 10, members, BlockPlaceModifierEntry::class),
+                    region("world-guard", 0, sealed, BlockPlaceModifierEntry::class),
+                ),
+                engine = null,
+            )
+            val block = world.getBlockAt(2, 64, 2)
+
+            val event = BlockGrowEvent(block, block.state)
+            BlockPlaceModifierHandler(index).onGrow(event)
+
+            event.isCancelled shouldBe true
+        }
+
+        test("the console names the region whose allowance cannot cover every case") {
+            val flag = BlockPlaceModifierEntry(
+                id = "members-only",
+                name = "Members Only",
+                allowed = ComputeVar { _, _ -> true },
+            )
+            val reported = variableAllowancesOnViewerlessFlags(
+                listOf(region("farm", 0, flag, BlockPlaceModifierEntry::class)),
+            )
+
+            reported shouldBe listOf("farm" to "Members Only")
+        }
+
+        test("a constant allowance is not reported") {
+            val flag = BlockPlaceModifierEntry(id = "sealed", name = "Sealed", allowed = ConstVar(false))
+            val reported = variableAllowancesOnViewerlessFlags(
+                listOf(region("plot", 0, flag, BlockPlaceModifierEntry::class)),
+            )
+
+            reported.isEmpty() shouldBe true
+        }
+    }
+}

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/handler/CrossingRefusalSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/handler/CrossingRefusalSpec.kt
@@ -1,0 +1,392 @@
+package com.typewritermc.region.handler
+
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.interaction.PlayerSessionManager
+import com.typewritermc.region.data.CrossingCause
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.mockbukkit.mockbukkit.MockBukkit
+import org.mockbukkit.mockbukkit.ServerMock
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+
+/**
+ * A cancelled crossing is rolled back by the engine, so the next move presents the same
+ * crossing again. Without a memory of the refusal the entry fires its whole trigger pipeline
+ * every tick a player leans on the boundary.
+ */
+class CrossingRefusalSpec : FunSpec() {
+    private lateinit var server: ServerMock
+
+    init {
+        beforeSpec {
+            server = MockBukkit.mock()
+            server.addSimpleWorld("refusal-world")
+            startKoin {
+                modules(module { single { mockk<PlayerSessionManager>(relaxed = true) } })
+            }
+        }
+
+        afterSpec {
+            stopKoin()
+            MockBukkit.unmock()
+        }
+
+
+        /**
+         * The move event the engine hands a handler for a walked crossing. A refusal only means
+         * anything when there is an event to cancel, so the specs that exercise one pass a real
+         * one; the specs about a crossing that stands pass `null`, like the vehicle path does.
+         */
+        fun walk(player: org.bukkit.entity.Player): org.bukkit.event.player.PlayerMoveEvent =
+            org.bukkit.event.player.PlayerMoveEvent(player, player.location, player.location)
+
+        test("a refused enter fires once, however many times the crossing is retried") {
+            val player = server.addPlayer()
+            var fires = 0
+            val handler = EnterExitHandler(owner = "test", onEnter = { _, _, _ -> fires++; true })
+
+            repeat(5) {
+                handler.onClassification(player, -1.0, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe true
+                // What the engine does after cancelling: roll the membership back to the outside.
+                handler.resync(player, 1.0)
+                handler.refuse(player)
+            }
+
+            fires shouldBe 1
+        }
+
+        test("a handler that never asked to cancel does not start blocking moves") {
+            val player = server.addPlayer()
+            var fires = 0
+            val handler = EnterExitHandler(owner = "test", onEnter = { _, _, _ -> fires++; false })
+
+            // The engine refuses every handler it touched, including the ones that let the
+            // crossing through, because the cancellation rolled all of them back.
+            handler.onClassification(player, -1.0, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe false
+            handler.resync(player, 1.0)
+            handler.refuse(player)
+
+            handler.onClassification(player, -1.0, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe false
+            fires shouldBe 1
+        }
+
+        test("a refusal is lifted once the engine reports the move landed") {
+            val player = server.addPlayer()
+            var fires = 0
+            val handler = EnterExitHandler(owner = "test", onEnter = { _, _, _ -> fires++; false })
+
+            handler.onClassification(player, -1.0, CrossingCause.PLAYER_MOVED, walk(player))
+            handler.resync(player, 1.0)
+            handler.refuse(player)
+            handler.clearRefusal(player)
+
+            handler.onClassification(player, -1.0, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe false
+            fires shouldBe 2
+        }
+
+        test("an engulf landing between a dispatch and its resync does not lose the refusal") {
+            val player = server.addPlayer()
+            var fires = 0
+            val handler = EnterExitHandler(owner = "test", onEnter = { _, _, _ -> fires++; false })
+
+            handler.onClassification(player, -1.0, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe false
+            // The async reconcile classifies the same player before the engine rolls the move back.
+            handler.onClassification(player, -1.0, CrossingCause.ENGULFED, null) shouldBe false
+            handler.refuse(player)
+            handler.resync(player, 1.0)
+
+            handler.onClassification(player, -1.0, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe false
+            fires shouldBe 1
+        }
+
+        test("a region engulfing a refused player still fires, since nothing can roll that back") {
+            val player = server.addPlayer()
+            var fires = 0
+            val handler = EnterExitHandler(owner = "test", onEnter = { _, _, _ -> fires++; true })
+
+            handler.onClassification(player, -1.0, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe true
+            handler.resync(player, 1.0)
+            handler.refuse(player)
+
+            handler.onClassification(player, -1.0, CrossingCause.ENGULFED, null)
+            fires shouldBe 2
+            handler.tracks(player) shouldBe true
+        }
+
+        test("moving clear of the boundary arms the enter again") {
+            val player = server.addPlayer()
+            var fires = 0
+            val handler = EnterExitHandler(owner = "test", onEnter = { _, _, _ -> fires++; true })
+
+            handler.onClassification(player, -1.0, CrossingCause.PLAYER_MOVED, walk(player))
+            handler.resync(player, 1.0)
+            handler.refuse(player)
+
+            handler.onClassification(player, 4.0, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe false
+            handler.onClassification(player, -1.0, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe true
+
+            fires shouldBe 2
+        }
+
+        test("two classifications of the same crossing only fire once") {
+            val player = server.addPlayer()
+            var enters = 0
+            var leaves = 0
+            val handler = EnterExitHandler(
+                owner = "test",
+                onEnter = { _, _, _ -> enters++; false },
+                onLeave = { _, _, _ -> leaves++; false },
+            )
+
+            // The move listener and the async reconcile can classify the same player at once.
+            handler.onClassification(player, -1.0, CrossingCause.PLAYER_MOVED, null)
+            handler.onClassification(player, -1.0, CrossingCause.ENGULFED, null)
+            handler.onClassification(player, 1.0, CrossingCause.PLAYER_MOVED, null)
+            handler.onClassification(player, 1.0, CrossingCause.ENGULFED, null)
+
+            enters shouldBe 1
+            leaves shouldBe 1
+        }
+
+        // The engine resyncs a cancelled crossing against the position the player is left at,
+        // which is the one they crossed from. With a boundary inset that position sits inside
+        // the hysteresis band, so the side the handler thinks they were on decides whether the
+        // refusal still holds on their next step.
+        test("a refused enter still holds when the region has a boundary inset") {
+            val player = server.addPlayer()
+            var fires = 0
+            val handler = EnterExitHandler(
+                owner = "test",
+                boundaryInset = ConstVar(0.5),
+                onEnter = { _, _, _ -> fires++; true },
+            )
+
+            // Walking in from just outside: refused, and rolled back to where they came from.
+            handler.onClassification(player, -0.1, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe true
+            handler.resync(player, 0.2)
+            handler.refuse(player)
+            handler.tracks(player) shouldBe false
+
+            // The same step again, and every step after it.
+            handler.onClassification(player, -0.1, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe true
+            handler.onClassification(player, -0.4, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe true
+            fires shouldBe 1
+            handler.tracks(player) shouldBe false
+        }
+
+        test("a refused exit still holds when the region has a boundary inset") {
+            val player = server.addPlayer()
+            var fires = 0
+            val handler = EnterExitHandler(
+                owner = "test",
+                boundaryInset = ConstVar(0.5),
+                onLeave = { _, _, _ -> fires++; true },
+            )
+
+            handler.onClassification(player, -1.0, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe false
+            handler.tracks(player) shouldBe true
+
+            // Stepping past the inset: refused, and rolled back into the band they came from.
+            handler.onClassification(player, 0.6, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe true
+            handler.resync(player, 0.5)
+            handler.refuse(player)
+            handler.tracks(player) shouldBe true
+
+            handler.onClassification(player, 0.6, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe true
+            handler.onClassification(player, 0.9, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe true
+            fires shouldBe 1
+            handler.tracks(player) shouldBe true
+        }
+
+        // The engine only dispatches when the player's block changes, but membership goes by
+        // their whole body, so the position a cancelled move is rolled back to is usually one
+        // the region already counts as inside. The refusal has to hold there anyway.
+        test("a refused enter holds when the player is rolled back to a spot the region counts as inside") {
+            val player = server.addPlayer()
+            var fires = 0
+            val handler = EnterExitHandler(owner = "test", onEnter = { _, _, _ -> fires++; true })
+
+            // Their body reaches into the region a fraction before their feet do.
+            handler.onClassification(player, -0.35, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe true
+            handler.resync(player, -0.05)
+            handler.refuse(player)
+            handler.tracks(player) shouldBe false
+
+            // Pushing on, tick after tick, from that same spot.
+            handler.onClassification(player, -0.35, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe true
+            handler.onClassification(player, -0.35, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe true
+            fires shouldBe 1
+            handler.tracks(player) shouldBe false
+        }
+
+        test("backing off the boundary arms the refused enter again and fires no leave") {
+            val player = server.addPlayer()
+            var enters = 0
+            var leaves = 0
+            val handler = EnterExitHandler(
+                owner = "test",
+                onEnter = { _, _, _ -> enters++; true },
+                onLeave = { _, _, _ -> leaves++; false },
+            )
+
+            handler.onClassification(player, -0.35, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe true
+            handler.resync(player, -0.05)
+            handler.refuse(player)
+
+            // Walking away: no exit for a crossing that was refused, and no cancel either.
+            handler.onClassification(player, 2.0, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe false
+            leaves shouldBe 0
+
+            handler.onClassification(player, -0.35, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe true
+            enters shouldBe 2
+        }
+
+        // The engine refuses every handler on every tracker it touched during a cancelled move,
+        // including the ones that were nowhere near a boundary of their own.
+        test("a handler that did not cross is not held to the refusal of one that did") {
+            val player = server.addPlayer()
+            var leaves = 0
+            val town = EnterExitHandler(owner = "test", onLeave = { _, _, _ -> leaves++; false })
+
+            // The player is a member of the town, and stays one while a vault inside it refuses.
+            town.onClassification(player, -5.0, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe false
+            town.onClassification(player, -4.0, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe false
+            town.resync(player, -4.0)
+            town.refuse(player)
+
+            // Later they walk out of the town for real.
+            town.onClassification(player, 1.0, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe false
+            leaves shouldBe 1
+            town.tracks(player) shouldBe false
+        }
+
+        // The reconcile of a moving region runs off the main thread, so an engulf can land in the
+        // middle of a refused move. It fires, because nothing rolls an engulf back, and the player
+        // is inside for real once it has: the crossing they were refused has happened to them.
+        test("an engulf that reaches a refused player takes the crossing over") {
+            val player = server.addPlayer()
+            var enters = 0
+            var leaves = 0
+            val handler = EnterExitHandler(
+                owner = "test",
+                onEnter = { _, _, _ -> enters++; true },
+                onLeave = { _, _, _ -> leaves++; false },
+            )
+
+            handler.onClassification(player, -0.35, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe true
+            // The region catches up with them before the engine has rolled the move back.
+            handler.onClassification(player, -0.35, CrossingCause.ENGULFED, null)
+            handler.resync(player, -0.05)
+            handler.refuse(player)
+            enters shouldBe 2
+            handler.tracks(player) shouldBe true
+
+            // Still held to the refusal, every move from inside would be cancelled and the player
+            // could never walk back out of the region that engulfed them.
+            handler.onClassification(player, -0.35, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe false
+            handler.onClassification(player, 1.0, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe false
+            leaves shouldBe 1
+            handler.tracks(player) shouldBe false
+        }
+
+        // The engulf that changes nothing is the other half of it: the region shifting under a
+        // player who is still standing where the rollback left them settles nothing at all.
+        test("an engulf that carries nobody across leaves the refusal in place") {
+            val player = server.addPlayer()
+            var fires = 0
+            val handler = EnterExitHandler(owner = "test", onEnter = { _, _, _ -> fires++; true })
+
+            handler.onClassification(player, -0.35, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe true
+            handler.resync(player, -0.05)
+            handler.refuse(player)
+
+            handler.onClassification(player, 0.5, CrossingCause.ENGULFED, null) shouldBe false
+
+            handler.onClassification(player, -0.35, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe true
+            fires shouldBe 1
+        }
+
+        // A vehicle's movement cannot be refused, so a crossing on a horse stands whatever the
+        // entry answered, and the membership has to stand with it.
+        test("a cancelling enter with no event to cancel keeps the player a member") {
+            val player = server.addPlayer()
+            var enters = 0
+            var leaves = 0
+            val handler = EnterExitHandler(
+                owner = "test",
+                onEnter = { _, _, _ -> enters++; true },
+                onLeave = { _, _, _ -> leaves++; false },
+            )
+
+            handler.onClassification(player, -1.0, CrossingCause.PLAYER_MOVED, null)
+            handler.tracks(player) shouldBe true
+
+            handler.onClassification(player, 1.0, CrossingCause.PLAYER_MOVED, null)
+            enters shouldBe 1
+            leaves shouldBe 1
+            handler.tracks(player) shouldBe false
+        }
+
+        // A crossing nothing can roll back is not a refusal, so it must not answer for the next
+        // move the player makes.
+        test("an engulfing enter that asked to cancel does not block the next walk out") {
+            val player = server.addPlayer()
+            var leaves = 0
+            val handler = EnterExitHandler(
+                owner = "test",
+                onEnter = { _, _, _ -> true },
+                onLeave = { _, _, _ -> leaves++; false },
+            )
+
+            handler.onClassification(player, -1.0, CrossingCause.ENGULFED, null)
+            handler.tracks(player) shouldBe true
+
+            handler.onClassification(player, 1.0, CrossingCause.PLAYER_MOVED, null) shouldBe false
+            leaves shouldBe 1
+            handler.tracks(player) shouldBe false
+        }
+
+        // An audience filter pushes its state from the callback, so the rollback has to reach it:
+        // the enter it already answered is being taken back, and the player is left standing on the
+        // side they came from, where no later crossing would correct it.
+        test("a rolled back crossing reports the membership it was put back to") {
+            val player = server.addPlayer()
+            val reported = mutableListOf<Boolean>()
+            val handler = EnterExitHandler(
+                owner = "test",
+                onEnter = { _, _, _ -> false },
+                onResync = { _, member -> reported += member },
+            )
+
+            handler.onClassification(player, -1.0, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe false
+            handler.resync(player, 1.0)
+            handler.refuse(player)
+            reported shouldBe listOf(false)
+
+            // A resync that settles on the membership the handler already holds says nothing.
+            handler.resync(player, 1.0)
+            reported shouldBe listOf(false)
+        }
+
+        test("a refused proximity band behaves the same way") {
+            val player = server.addPlayer()
+            var fires = 0
+            val handler = ProximityHandler(
+                owner = "test",
+                distance = ConstVar(5.0),
+                onEnterBand = { _, _, _ -> fires++; true },
+            )
+
+            repeat(4) {
+                handler.onClassification(player, 2.0, CrossingCause.PLAYER_MOVED, walk(player)) shouldBe true
+                handler.resync(player, 40.0)
+                handler.refuse(player)
+            }
+
+            fires shouldBe 1
+        }
+    }
+}

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/shape/BoundarySampleAssertions.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/shape/BoundarySampleAssertions.kt
@@ -1,0 +1,24 @@
+package com.typewritermc.region.shape
+
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.doubles.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import kotlin.math.abs
+
+internal fun Shape.shouldSampleOnBoundary(density: Double = 0.5, tolerance: Double = 1e-6) {
+    val samples = sampleBoundary(density).toList()
+    samples.shouldNotBeEmpty()
+    val bounds = localBounds
+    for (sample in samples) {
+        abs(signedDistance(sample)) shouldBeLessThan tolerance
+        (sample.x in bounds.minX - tolerance..bounds.maxX + tolerance) shouldBe true
+        (sample.y in bounds.minY - tolerance..bounds.maxY + tolerance) shouldBe true
+        (sample.z in bounds.minZ - tolerance..bounds.maxZ + tolerance) shouldBe true
+    }
+
+    val distinct = samples.mapTo(HashSet()) { Triple(it.x, it.y, it.z) }
+    withClue("$this emitted ${samples.size} samples but only ${distinct.size} distinct points") {
+        distinct.size shouldBe samples.size
+    }
+}

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/shape/CapsuleShapeSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/shape/CapsuleShapeSpec.kt
@@ -1,0 +1,42 @@
+package com.typewritermc.region.shape
+
+import com.typewritermc.core.utils.point.Vector
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.shouldBe
+
+private const val TOLERANCE = 1e-9
+
+class CapsuleShapeSpec : FunSpec({
+    val shape = CapsuleShape(radius = 1.0, halfHeight = 2.0)
+
+    test("contains inside, cap, and outside points") {
+        shape.contains(Vector(0.0, 0.0, 0.0)) shouldBe true
+        shape.contains(Vector(0.0, 2.9, 0.0)) shouldBe true
+        shape.contains(Vector(0.0, 3.1, 0.0)) shouldBe false
+        shape.contains(Vector(1.0, 0.0, 0.0)) shouldBe true
+    }
+
+    test("signed distance measures from the spine") {
+        shape.signedDistance(Vector(0.0, 0.0, 0.0)) shouldBe (-1.0 plusOrMinus TOLERANCE)
+        shape.signedDistance(Vector(0.0, 3.5, 0.0)) shouldBe (0.5 plusOrMinus TOLERANCE)
+        shape.signedDistance(Vector(2.0, 0.0, 0.0)) shouldBe (1.0 plusOrMinus TOLERANCE)
+    }
+
+    test("horizontal distance uses the silhouette circle") {
+        shape.signedDistanceHorizontal(Vector(0.0, 10.0, 0.0)) shouldBe (-1.0 plusOrMinus TOLERANCE)
+        shape.signedDistanceHorizontal(Vector(2.0, 10.0, 0.0)) shouldBe (1.0 plusOrMinus TOLERANCE)
+    }
+
+    test("nearest outside projects onto the surface") {
+        shape.nearestOutside(Vector(0.5, 0.0, 0.0)) shouldBe Vector(1.0, 0.0, 0.0)
+    }
+
+    test("normals point away from the spine") {
+        shape.outwardNormals(Vector(0.0, 3.0, 0.0)) shouldBe listOf(Vector(0.0, 1.0, 0.0))
+    }
+
+    test("boundary samples lie on the boundary") {
+        shape.shouldSampleOnBoundary()
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/shape/ConeShapeSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/shape/ConeShapeSpec.kt
@@ -1,0 +1,68 @@
+package com.typewritermc.region.shape
+
+import com.typewritermc.core.utils.point.Vector
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.shouldBe
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sqrt
+
+private const val TOLERANCE = 1e-9
+
+class ConeShapeSpec : FunSpec({
+    val shape = ConeShape(length = 8.0, halfAngleDegrees = 30.0)
+
+    test("contains the apex, the axis, and rejects points behind or beside") {
+        shape.contains(Vector(0.0, 0.0, 0.0)) shouldBe true
+        shape.contains(Vector(0.0, 0.0, 1.0)) shouldBe true
+        shape.contains(Vector(0.0, 0.0, 8.0)) shouldBe true
+        shape.contains(Vector(0.0, 0.0, -0.1)) shouldBe false
+        shape.contains(Vector(1.0, 0.0, 1.0)) shouldBe false
+        shape.contains(Vector(0.0, 0.0, 8.1)) shouldBe false
+    }
+
+    test("signed distance inside takes the closer of cap and lateral surface") {
+        shape.signedDistance(Vector(0.0, 0.0, 4.0)) shouldBe (-2.0 plusOrMinus TOLERANCE)
+        shape.signedDistance(Vector(0.0, 0.0, 9.0)) shouldBe (1.0 plusOrMinus TOLERANCE)
+    }
+
+    test("horizontal distance equals the meridian slice distance") {
+        shape.signedDistanceHorizontal(Vector(0.0, 5.0, 4.0)) shouldBe (-2.0 plusOrMinus TOLERANCE)
+        shape.signedDistanceHorizontal(Vector(0.0, 5.0, 9.0)) shouldBe (1.0 plusOrMinus TOLERANCE)
+    }
+
+    test("the apex normal points away from the solid, not into it") {
+        shape.outwardNormals(Vector(0.0, 0.0, 0.0)) shouldBe listOf(Vector(0.0, 0.0, -1.0))
+    }
+
+    test("a point past the cap gets the cap's normal, not the lateral surface's") {
+        val normal = shape.outwardNormals(Vector(0.01, 0.0, 8.1)).single()
+        normal.z shouldBe (0.99999 plusOrMinus 1e-4)
+        normal.x shouldBe (0.00123 plusOrMinus 1e-4)
+    }
+
+    test("distance behind the apex measures to the apex, not to the extended surface") {
+        val narrow = ConeShape(length = 10.0, halfAngleDegrees = 5.0)
+        narrow.signedDistance(Vector(0.0, 0.0, -2.0)) shouldBe (2.0 plusOrMinus TOLERANCE)
+        ConeShape(length = 5.0, halfAngleDegrees = 30.0)
+            .signedDistance(Vector(0.0, 0.0, -5.0)) shouldBe (5.0 plusOrMinus TOLERANCE)
+    }
+
+    test("distance beside the cap measures to the rim") {
+        ConeShape(length = 5.0, halfAngleDegrees = 30.0)
+            .signedDistance(Vector(10.0, 0.0, 0.0)) shouldBe (sqrt(75.0) plusOrMinus TOLERANCE)
+    }
+
+    test("nearest outside lands on the boundary it measured to") {
+        val narrow = ConeShape(length = 10.0, halfAngleDegrees = 5.0)
+        narrow.nearestOutside(Vector(0.0, 0.0, -2.0)) shouldBe Vector.ZERO
+        val beside = ConeShape(length = 5.0, halfAngleDegrees = 30.0).nearestOutside(Vector(10.0, 0.0, 0.0))
+        beside.x shouldBe (2.5 plusOrMinus TOLERANCE)
+        beside.z shouldBe (5.0 * cos(PI / 6) plusOrMinus TOLERANCE)
+    }
+
+    test("boundary samples lie on the spherical cap boundary") {
+        shape.shouldSampleOnBoundary(tolerance = 1e-6)
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/shape/CuboidShapeSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/shape/CuboidShapeSpec.kt
@@ -1,0 +1,81 @@
+package com.typewritermc.region.shape
+
+import com.typewritermc.core.utils.point.Vector
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.shouldBe
+import kotlin.math.sqrt
+
+private const val TOLERANCE = 1e-9
+
+class CuboidShapeSpec : FunSpec({
+    val shape = CuboidShape(2.0, 1.0, 3.0)
+
+    test("contains inside, boundary, and outside points") {
+        shape.contains(Vector(0.0, 0.0, 0.0)) shouldBe true
+        shape.contains(Vector(2.0, 1.0, 3.0)) shouldBe true
+        shape.contains(Vector(2.1, 0.0, 0.0)) shouldBe false
+    }
+
+    test("signed distance is negative inside and euclidean outside") {
+        shape.signedDistance(Vector(0.0, 0.0, 0.0)) shouldBe (-1.0 plusOrMinus TOLERANCE)
+        shape.signedDistance(Vector(3.0, 0.0, 0.0)) shouldBe (1.0 plusOrMinus TOLERANCE)
+        shape.signedDistance(Vector(3.0, 2.0, 0.0)) shouldBe (sqrt(2.0) plusOrMinus TOLERANCE)
+    }
+
+    test("horizontal distance ignores floor and ceiling") {
+        shape.signedDistanceHorizontal(Vector(0.0, 0.0, 0.0)) shouldBe (-2.0 plusOrMinus TOLERANCE)
+        shape.signedDistanceHorizontal(Vector(0.0, 50.0, 0.0)) shouldBe (-2.0 plusOrMinus TOLERANCE)
+        shape.signedDistanceHorizontal(Vector(3.0, 50.0, 0.0)) shouldBe (1.0 plusOrMinus TOLERANCE)
+    }
+
+    test("a flat room reports the lateral distance horizontally") {
+        val room = CuboidShape(10.0, 1.0, 10.0)
+        room.signedDistance(Vector.ZERO) shouldBe (-1.0 plusOrMinus TOLERANCE)
+        room.signedDistanceHorizontal(Vector.ZERO) shouldBe (-10.0 plusOrMinus TOLERANCE)
+    }
+
+    test("nearest outside projects onto the closest face") {
+        shape.nearestOutside(Vector(1.5, 0.0, 0.0)) shouldBe Vector(2.0, 0.0, 0.0)
+        shape.nearestOutside(Vector(5.0, 0.0, 0.0)) shouldBe Vector(2.0, 0.0, 0.0)
+    }
+
+    test("corners return one normal per touching face") {
+        shape.outwardNormals(Vector(2.0, 1.0, 3.0)).size shouldBe 3
+        shape.outwardNormals(Vector(1.99, 0.0, 0.0)) shouldBe listOf(Vector(1.0, 0.0, 0.0))
+    }
+
+    test("a point past an edge points away from the edge, not between the two faces") {
+        val room = CuboidShape(10.0, 5.0, 10.0)
+        val normals = room.outwardNormals(Vector(10.001, 8.0, 0.0))
+        normals.size shouldBe 1
+
+        val direction = normals.single()
+        direction.y shouldBe (1.0 plusOrMinus 1e-3)
+        direction.x shouldBe (0.0 plusOrMinus 1e-3)
+        direction.length shouldBe (1.0 plusOrMinus TOLERANCE)
+    }
+
+    test("the normal does not swing as a player crosses a face plane") {
+        val room = CuboidShape(10.0, 5.0, 10.0)
+        val inside = room.outwardNormals(Vector(9.999, 8.0, 0.0)).single()
+        val outside = room.outwardNormals(Vector(10.001, 8.0, 0.0)).single()
+
+        outside.x shouldBe (inside.x plusOrMinus 1e-3)
+        outside.y shouldBe (inside.y plusOrMinus 1e-3)
+    }
+
+    test("boundary samples lie on the boundary") {
+        shape.shouldSampleOnBoundary()
+    }
+
+    test("boundary samples cover every corner exactly once for uneven sizes") {
+        val uneven = CuboidShape(3.7, 1.3, 2.9)
+        uneven.shouldSampleOnBoundary()
+
+        val samples = uneven.sampleBoundary(0.5).toList()
+        for (cornerX in listOf(-3.7, 3.7)) for (cornerY in listOf(-1.3, 1.3)) for (cornerZ in listOf(-2.9, 2.9)) {
+            samples.count { it.x == cornerX && it.y == cornerY && it.z == cornerZ } shouldBe 1
+        }
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/shape/EllipsoidShapeSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/shape/EllipsoidShapeSpec.kt
@@ -1,0 +1,113 @@
+package com.typewritermc.region.shape
+
+import com.typewritermc.core.utils.point.Vector
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.shouldBe
+
+private const val TOLERANCE = 1e-9
+
+class EllipsoidShapeSpec : FunSpec({
+    val shape = EllipsoidShape(2.0, 1.0, 3.0)
+
+    test("contains inside, boundary, and outside points") {
+        shape.contains(Vector(0.0, 0.0, 0.0)) shouldBe true
+        shape.contains(Vector(2.0, 0.0, 0.0)) shouldBe true
+        shape.contains(Vector(0.0, 1.1, 0.0)) shouldBe false
+    }
+
+    test("signed distance is exact along every axis") {
+        shape.signedDistance(Vector(0.0, 0.0, 0.0)) shouldBe (-1.0 plusOrMinus TOLERANCE)
+        shape.signedDistance(Vector(4.0, 0.0, 0.0)) shouldBe (2.0 plusOrMinus TOLERANCE)
+        shape.signedDistance(Vector(0.0, 3.0, 0.0)) shouldBe (2.0 plusOrMinus TOLERANCE)
+        shape.signedDistance(Vector(0.0, 0.0, 7.0)) shouldBe (4.0 plusOrMinus TOLERANCE)
+    }
+
+    test("a flattened ellipsoid reports blocks, not blocks scaled by the axis ratio") {
+        val flat = EllipsoidShape(10.0, 1.5, 10.0)
+        flat.signedDistance(Vector(0.0, 0.0, 14.0)) shouldBe (4.0 plusOrMinus TOLERANCE)
+        EllipsoidShape(10.0, 1.0, 1.0)
+            .signedDistance(Vector(20.0, 0.0, 0.0)) shouldBe (10.0 plusOrMinus TOLERANCE)
+    }
+
+    test("a uniform ellipsoid agrees with the sphere exactly") {
+        val uniform = EllipsoidShape(4.0, 4.0, 4.0)
+        val sphere = SphereShape(4.0)
+        for (point in listOf(Vector(9.0, 0.0, 0.0), Vector(1.0, 2.0, 3.0), Vector(-7.0, 5.0, 2.0))) {
+            uniform.signedDistance(point) shouldBe (sphere.signedDistance(point) plusOrMinus TOLERANCE)
+        }
+    }
+
+    test("horizontal distance uses the silhouette ellipse") {
+        shape.signedDistanceHorizontal(Vector(0.0, 9.0, 0.0)) shouldBe (-2.0 plusOrMinus TOLERANCE)
+        shape.signedDistanceHorizontal(Vector(4.0, 9.0, 0.0)) shouldBe (2.0 plusOrMinus TOLERANCE)
+    }
+
+    test("nearest outside projects onto the surface") {
+        shape.nearestOutside(Vector(4.0, 0.0, 0.0)) shouldBe Vector(2.0, 0.0, 0.0)
+    }
+
+    test("normals point outward") {
+        shape.outwardNormals(Vector(0.0, 2.0, 0.0)) shouldBe listOf(Vector(0.0, 1.0, 0.0))
+    }
+
+    test("boundary samples lie on the boundary") {
+        shape.shouldSampleOnBoundary()
+    }
+
+    test("depth inside is measured against the nearest surface, not the longest axis") {
+        val pancake = EllipsoidShape(20.0, 2.0, 20.0)
+        pancake.signedDistance(Vector(0.001, 0.0, 0.0)) shouldBe (-2.0 plusOrMinus 1e-3)
+        pancake.signedDistance(Vector(19.0, 0.0, 0.0)) shouldBe (-0.5945884 plusOrMinus 1e-5)
+        pancake.signedDistance(Vector(0.0, 1.5, 0.0)) shouldBe (-0.5 plusOrMinus TOLERANCE)
+    }
+
+    test("depth is continuous through the center") {
+        val pancake = EllipsoidShape(20.0, 2.0, 20.0)
+        val atCenter = pancake.signedDistance(Vector.ZERO)
+        val besideCenter = pancake.signedDistance(Vector(1e-5, 0.0, 0.0))
+        atCenter shouldBe (-2.0 plusOrMinus TOLERANCE)
+        besideCenter shouldBe (atCenter plusOrMinus 1e-4)
+    }
+
+    test("distance outside is measured to the closest point, not along the ray from the center") {
+        val pancake = EllipsoidShape(20.0, 2.0, 20.0)
+        pancake.signedDistance(Vector(42.43, 4.243, 0.0)) shouldBe (22.8247 plusOrMinus 1e-3)
+        pancake.signedDistance(Vector(21.0, 1.0, 0.0)) shouldBe (1.3558 plusOrMinus 1e-3)
+    }
+
+    test("the nearest surface at the center is on the shortest axis") {
+        val pancake = EllipsoidShape(20.0, 2.0, 20.0)
+        pancake.nearestOutside(Vector.ZERO) shouldBe Vector(0.0, 2.0, 0.0)
+        pancake.outwardNormals(Vector.ZERO) shouldBe listOf(Vector(0.0, 1.0, 0.0))
+        // A hair off center answers the same way, so a barrier does not swing between the two.
+        val beside = Vector(9e-4, 0.0, 0.0)
+        val besideCenter = pancake.nearestOutside(beside)
+        besideCenter.y shouldBe (2.0 plusOrMinus 1e-6)
+        (besideCenter - beside).length shouldBe (2.0 plusOrMinus 1e-4)
+    }
+
+    test("a point a rounding error off the flat axis stays finite") {
+        val pancake = EllipsoidShape(20.0, 2.0, 20.0)
+        for (y in listOf(1e-16, 2e-16, 1e-15, 5e-16)) {
+            val point = Vector(1e-9, y, 1e-9)
+            val distance = pancake.signedDistance(point)
+            distance.isFinite() shouldBe true
+            distance shouldBe (-2.0 plusOrMinus 1e-6)
+
+            val surface = pancake.nearestOutside(point)
+            surface.y.isFinite() shouldBe true
+            pancake.outwardNormals(point).single().length shouldBe (1.0 plusOrMinus 1e-9)
+        }
+    }
+
+    test("the reported distance is the distance to the reported nearest point") {
+        val pancake = EllipsoidShape(20.0, 2.0, 20.0)
+        for (point in listOf(Vector(25.0, 6.0, 3.0), Vector(-30.0, 1.0, 12.0), Vector(0.5, 0.2, 0.1))) {
+            val surface = pancake.nearestOutside(point)
+            val gap = (surface - point).length
+            kotlin.math.abs(pancake.signedDistance(point)) shouldBe (gap plusOrMinus 1e-6)
+            pancake.signedDistance(surface) shouldBe (0.0 plusOrMinus 1e-6)
+        }
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/shape/HitboxSamplingSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/shape/HitboxSamplingSpec.kt
@@ -1,0 +1,54 @@
+package com.typewritermc.region.shape
+
+import com.typewritermc.core.utils.point.Vector
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+class HitboxSamplingSpec : FunSpec({
+    test("produces the full lattice including the bottom center") {
+        val offsets = hitboxSampleOffsets(0.3, 1.8)
+        offsets.size shouldBe 45
+        offsets shouldContain Vector(0.0, 0.0, 0.0)
+        offsets shouldContain Vector(0.3, 1.8, 0.3)
+        offsets shouldContain Vector(-0.3, 0.9, -0.3)
+        for ((x, y, z) in offsets) {
+            (x in -0.3..0.3) shouldBe true
+            (y in 0.0..1.8) shouldBe true
+            (z in -0.3..0.3) shouldBe true
+        }
+    }
+
+    test("no gap between samples is wide enough to hide a half block thick shape") {
+        val offsets = hitboxSampleOffsets(0.3, 1.8)
+        for (axis in listOf<(Vector) -> Double>({ it.x }, { it.y }, { it.z })) {
+            val levels = offsets.map(axis).distinct().sorted()
+            levels.zipWithNext { low, high -> (high - low <= 0.5) shouldBe true }
+        }
+    }
+
+    test("a standing player's chest is sampled, so a narrow cone through it registers") {
+        // A 5 degree cone 3 blocks from its apex is a disc about 0.5 blocks across. Aimed
+        // through the chest of a player standing at the origin, some sample must land in it.
+        val cone = ConeShape(length = 20.0, halfAngleDegrees = 5.0)
+        val apexHeight = 1.2
+        val inside = hitboxSampleOffsets(0.3, 1.8).any { offset ->
+            cone.contains(Vector(offset.x, offset.y - apexHeight, offset.z + 3.0))
+        }
+        inside shouldBe true
+    }
+
+    test("a giant player's lattice stays bounded, at a coarser spacing") {
+        // The vanilla scale attribute reaches 16, which is a box 9.6 wide and 28.8 tall. At the
+        // normal spacing that is twenty six thousand samples per tracker per move.
+        val giant = hitboxSampleOffsets(4.8, 28.8)
+        (giant.size <= 125) shouldBe true
+        giant.isNotEmpty() shouldBe true
+    }
+
+    test("rejects negative dimensions") {
+        shouldThrow<IllegalArgumentException> { hitboxSampleOffsets(-0.1, 1.8) }
+        shouldThrow<IllegalArgumentException> { hitboxSampleOffsets(0.3, -1.0) }
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/shape/OutlineSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/shape/OutlineSpec.kt
@@ -1,0 +1,78 @@
+package com.typewritermc.region.shape
+
+import com.typewritermc.core.utils.point.Vector
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.doubles.shouldBeLessThan
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.shouldBe
+import kotlin.math.abs
+
+class OutlineSpec : FunSpec({
+    fun Shape.outlinePointsLieOnBoundary(tolerance: Double = 1e-6) {
+        val polylines = outlinePolylines()
+        polylines.shouldNotBeEmpty()
+        for ((points) in polylines) {
+            for (point in points) {
+                abs(signedDistance(point)) shouldBeLessThan tolerance
+            }
+        }
+    }
+
+    test("cuboid edges lie on the boundary") {
+        CuboidShape(2.0, 3.0, 4.0).outlinePointsLieOnBoundary()
+    }
+
+    test("cuboid outline is two rectangles and four verticals") {
+        val polylines = CuboidShape(2.0, 3.0, 4.0).outlinePolylines()
+        polylines.count { it.closed } shouldBe 2
+        polylines.count { !it.closed } shouldBe 4
+    }
+
+    test("sphere rings lie on the boundary") {
+        SphereShape(5.0).outlinePointsLieOnBoundary()
+    }
+
+    test("ellipsoid rings lie on the boundary") {
+        EllipsoidShape(2.0, 5.0, 3.0).outlinePointsLieOnBoundary()
+    }
+
+    test("capsule rings and profile loops lie on the boundary") {
+        CapsuleShape(1.5, 3.0).outlinePointsLieOnBoundary(1e-6)
+    }
+
+    test("cone rim, generatrices and cap arcs lie on the boundary") {
+        ConeShape(10.0, 30.0).outlinePointsLieOnBoundary(1e-6)
+    }
+
+    test("the cone outline draws lines from the apex to the rim") {
+        val polylines = ConeShape(10.0, 30.0).outlinePolylines()
+        val generatrices = polylines.filter { !it.closed && it.points.first() == Vector.ZERO }
+        generatrices.size shouldBeGreaterThanOrEqual 4
+        for ((points) in generatrices) {
+            points.last().z shouldBe 10.0 * kotlin.math.cos(Math.toRadians(30.0))
+        }
+    }
+
+    test("polygon prism edges lie on the boundary") {
+        val shape = PolygonShape(
+            listOf(Vector(-3.0, 0.0, -3.0), Vector(3.0, 0.0, -3.0), Vector(3.0, 0.0, 3.0), Vector(-3.0, 0.0, 3.0)),
+            2.0,
+        )
+        shape.outlinePointsLieOnBoundary()
+    }
+
+    test("a degenerate polygon has no outline") {
+        PolygonShape(emptyList(), 2.0).outlinePolylines() shouldBe emptyList()
+    }
+
+    test("closed polylines connect back to the start in their segments") {
+        val square = OutlinePolyline(
+            listOf(Vector(0, 0, 0), Vector(1, 0, 0), Vector(1, 0, 1), Vector(0, 0, 1)),
+            closed = true,
+        )
+        val segments = square.segments()
+        segments.size shouldBe 4
+        segments.last() shouldBe (Vector(0, 0, 1) to Vector(0, 0, 0))
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/shape/PolygonShapeSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/shape/PolygonShapeSpec.kt
@@ -1,0 +1,88 @@
+package com.typewritermc.region.shape
+
+import com.typewritermc.core.utils.point.Vector
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.doubles.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+
+private const val TOLERANCE = 1e-9
+
+class PolygonShapeSpec : FunSpec({
+    val square = PolygonShape(
+        points = listOf(
+            Vector(-2.0, 0.0, -2.0),
+            Vector(2.0, 0.0, -2.0),
+            Vector(2.0, 0.0, 2.0),
+            Vector(-2.0, 0.0, 2.0),
+        ),
+        halfHeight = 1.0,
+    )
+
+    test("a star's tip points out of the star, not along one of its edges") {
+        val star = PolygonShape(
+            points = (0 until 10).map { index ->
+                val radius = if (index % 2 == 0) 10.0 else 4.0
+                val angle = 2 * kotlin.math.PI * index / 10
+                Vector(kotlin.math.cos(angle) * radius, 0.0, kotlin.math.sin(angle) * radius)
+            },
+            halfHeight = 3.0,
+        )
+        val tip = Vector(10.0, 0.0, 0.0)
+        val normal = star.outwardNormals(tip).single()
+
+        normal.x shouldBeGreaterThan 0.9
+        // Stepping out along it leaves the star, and stepping in along it enters.
+        star.signedDistance(tip + normal * 0.5) shouldBeGreaterThan 0.0
+        (star.signedDistance(tip - normal * 0.5) < 0.0) shouldBe true
+    }
+
+    test("a vertex dropped on one already placed does not turn the corner's normal along a wall") {
+        val doubled = PolygonShape(
+            points = listOf(
+                Vector(0.0, 0.0, 0.0),
+                Vector(10.0, 0.0, 0.0),
+                Vector(10.0, 0.0, 0.0),
+                Vector(10.0, 0.0, 10.0),
+                Vector(0.0, 0.0, 10.0),
+            ),
+            halfHeight = 2.0,
+        )
+        val corner = Vector(10.0, 0.0, 0.0)
+        val normal = doubled.outwardNormals(corner).single()
+
+        normal.x shouldBeGreaterThan 0.5
+        (normal.z < -0.5) shouldBe true
+        doubled.signedDistance(corner + normal * 0.5) shouldBeGreaterThan 0.0
+    }
+
+    test("contains respects the outline and the height") {
+        square.contains(Vector(0.0, 0.0, 0.0)) shouldBe true
+        square.contains(Vector(0.0, 1.5, 0.0)) shouldBe false
+        square.contains(Vector(3.0, 0.0, 0.0)) shouldBe false
+    }
+
+    test("signed distance combines lateral and vertical parts") {
+        square.signedDistance(Vector(0.0, 0.0, 0.0)) shouldBe (-1.0 plusOrMinus TOLERANCE)
+        square.signedDistance(Vector(0.0, 0.0, 3.0)) shouldBe (1.0 plusOrMinus TOLERANCE)
+    }
+
+    test("horizontal distance ignores the caps entirely") {
+        square.signedDistanceHorizontal(Vector(0.0, 0.0, 0.0)) shouldBe (-2.0 plusOrMinus TOLERANCE)
+        square.signedDistanceHorizontal(Vector(0.0, 40.0, 0.0)) shouldBe (-2.0 plusOrMinus TOLERANCE)
+        square.signedDistanceHorizontal(Vector(0.0, 0.0, 3.0)) shouldBe (1.0 plusOrMinus TOLERANCE)
+    }
+
+    test("a degenerate polygon contains nothing and reports far distances") {
+        val degenerate = PolygonShape(points = emptyList(), halfHeight = 1.0)
+        degenerate.contains(Vector(0.0, 0.0, 0.0)) shouldBe false
+        degenerate.signedDistance(Vector(0.0, 0.0, 0.0)) shouldBeGreaterThan 1.0e8
+        degenerate.signedDistanceHorizontal(Vector(0.0, 0.0, 0.0)) shouldBeGreaterThan 1.0e8
+        degenerate.sampleBoundary(0.5).toList().shouldBeEmpty()
+    }
+
+    test("boundary samples lie on the boundary") {
+        square.shouldSampleOnBoundary()
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/shape/RayCastSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/shape/RayCastSpec.kt
@@ -1,0 +1,85 @@
+package com.typewritermc.region.shape
+
+import com.typewritermc.core.utils.point.Vector
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.doubles.shouldBeLessThan
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlin.math.abs
+
+class RayCastSpec : FunSpec({
+    val box = CuboidShape(10.0, 5.0, 10.0)
+    val sphere = SphereShape(6.0)
+    val cone = ConeShape(length = 5.0, halfAngleDegrees = 30.0)
+
+    val east = Vector(1.0, 0.0, 0.0)
+    val west = Vector(-1.0, 0.0, 0.0)
+
+    test("a ray from inside leaves through the face it is aimed at") {
+        val hit = box.raycastBoundary(Vector.ZERO, east).shouldNotBeNull()
+        hit.x shouldBe (10.0 plusOrMinus 0.01)
+        abs(box.signedDistance(hit)) shouldBeLessThan 0.01
+    }
+
+    test("a ray from outside stops at the near face, not the far one") {
+        val hit = box.raycastBoundary(Vector(-40.0, 0.0, 0.0), east).shouldNotBeNull()
+        hit.x shouldBe (-10.0 plusOrMinus 0.01)
+    }
+
+    test("a ray aimed away from the region reports a miss") {
+        box.raycastBoundary(Vector(-40.0, 0.0, 0.0), west).shouldBeNull()
+    }
+
+    test("a ray beyond the reach of the march reports a miss") {
+        box.raycastBoundary(Vector(-500.0, 0.0, 0.0), east).shouldBeNull()
+    }
+
+    test("a ray grazing the silhouette is not stepped over") {
+        // The chord here is 0.2 blocks, shorter than the march step, so the coarse samples
+        // both land outside and only the refinement finds the pair of crossings.
+        val hit = sphere.raycastBoundary(Vector(5.995, 0.0, -20.0), Vector(0.0, 0.0, 1.0)).shouldNotBeNull()
+        abs(sphere.signedDistance(hit)) shouldBeLessThan 0.01
+    }
+
+    test("a ray across a narrow cone near its apex is not stepped over") {
+        val narrow = ConeShape(length = 20.0, halfAngleDegrees = 5.0)
+        val hit = narrow.raycastBoundary(Vector(-5.1, 0.0, 1.0), east).shouldNotBeNull()
+        abs(narrow.signedDistance(hit)) shouldBeLessThan 0.01
+    }
+
+    test("a curved boundary is hit on its surface") {
+        val hit = sphere.raycastBoundary(Vector(0.0, 0.0, -20.0), Vector(0.0, 0.0, 1.0)).shouldNotBeNull()
+        abs(sphere.signedDistance(hit)) shouldBeLessThan 0.01
+    }
+
+    test("the nearest boundary point of an interior point lands on the surface") {
+        val nearest = sphere.nearestBoundaryPoint(Vector(1.0, 0.0, 0.0)).shouldNotBeNull()
+        nearest.length shouldBe (6.0 plusOrMinus 0.05)
+        abs(sphere.signedDistance(nearest)) shouldBeLessThan 0.05
+    }
+
+    test("the nearest boundary point of an outside point pulls back to the surface") {
+        val nearest = sphere.nearestBoundaryPoint(Vector(0.0, 30.0, 0.0)).shouldNotBeNull()
+        nearest.y shouldBe (6.0 plusOrMinus 0.05)
+    }
+
+    test("a converging projection on a bound, not exact, signed distance still lands on the boundary") {
+        // The cone's signed distance is a bound rather than an exact field, but a typical
+        // point off the singular apex still converges within the iteration budget.
+        val nearest = cone.nearestBoundaryPoint(Vector(3.0, 0.0, 3.0)).shouldNotBeNull()
+        abs(cone.signedDistance(nearest)) shouldBeLessThan 0.05
+    }
+
+    test("a projection with no gradient to follow refuses instead of guessing") {
+        // At the exact center of a sphere the signed distance is the same in every direction,
+        // so the numeric gradient vanishes and there is no step to take.
+        sphere.nearestBoundaryPoint(Vector.ZERO).shouldBeNull()
+    }
+
+    test("straight behind the cone's apex projects onto the apex") {
+        val nearest = cone.nearestBoundaryPoint(Vector(0.0, 0.0, -5.0)).shouldNotBeNull()
+        nearest.length shouldBeLessThan 0.05
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/shape/SampleBudgetSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/shape/SampleBudgetSpec.kt
@@ -1,0 +1,141 @@
+package com.typewritermc.region.shape
+
+import com.typewritermc.core.utils.point.Vector
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.system.measureTimeMillis
+
+/**
+ * A boundary sample becomes a fake entity, a block packet or a particle, so the count has to
+ * stay bounded whatever a builder types into the panel. The step length alone does not bound
+ * it: a shape sampled edge by edge or ring by ring emits at least one column per edge.
+ */
+class SampleBudgetSpec : FunSpec({
+    fun polygon(vertices: Int, radius: Double, halfHeight: Double): PolygonShape {
+        val points = List(vertices) { index ->
+            val angle = 2 * PI * index / vertices
+            Vector(cos(angle) * radius, 0.0, sin(angle) * radius)
+        }
+        return PolygonShape(points, halfHeight)
+    }
+
+    test("a traced town outline stays within the budget") {
+        for (shape in listOf(polygon(40, 50.0, 160.0), polygon(120, 50.0, 160.0), polygon(60, 30.0, 30.0))) {
+            (shape.sampleBoundary(0.5).count() <= MAX_BOUNDARY_SAMPLES) shouldBe true
+        }
+    }
+
+    test("a polygon whose vertex count alone breaches the budget is truncated at it") {
+        // One column per edge is the floor whatever the step is, so enough vertices exceed the
+        // budget on their own and only the hard stop can bound them.
+        polygon(2000, 500.0, 500.0).sampleBoundary(0.5).count() shouldBe MAX_BOUNDARY_SAMPLES
+    }
+
+    test("a needle cuboid stays within the budget") {
+        (CuboidShape(1.0, 20000.0, 1.0).sampleBoundary(0.5).count() <= MAX_BOUNDARY_SAMPLES) shouldBe true
+        (CuboidShape(1.0, 1000000.0, 1.0).sampleBoundary(0.5).count() <= MAX_BOUNDARY_SAMPLES) shouldBe true
+    }
+
+    test("a long cone and a long capsule stay within the budget") {
+        for (length in listOf(300.0, 1000.0, 2000.0)) {
+            (ConeShape(length, 30.0).sampleBoundary(0.5).count() <= MAX_BOUNDARY_SAMPLES) shouldBe true
+            (ConeShape(length, 10.0).sampleBoundary(0.5).count() <= MAX_BOUNDARY_SAMPLES) shouldBe true
+        }
+        (CapsuleShape(1.0, 1000000.0).sampleBoundary(0.5).count() <= MAX_BOUNDARY_SAMPLES) shouldBe true
+        (CapsuleShape(2000.0, 1.0).sampleBoundary(0.5).count() <= MAX_BOUNDARY_SAMPLES) shouldBe true
+    }
+
+    test("a wide capsule keeps its caps rather than losing them to the budget") {
+        // Truncation drops the tail of the sequence, and the caps are emitted last, so sizing a
+        // polar ring like the equator spends the budget before reaching the poles.
+        for (radius in listOf(60.0, 100.0, 150.0)) {
+            val capsule = CapsuleShape(radius, 0.0)
+            val samples = capsule.sampleBoundary(0.5).toList()
+            (samples.size <= MAX_BOUNDARY_SAMPLES) shouldBe true
+            val highest = samples.maxOf { it.y }
+            (highest > radius * 0.98) shouldBe true
+            (samples.minOf { it.y } < -radius * 0.98) shouldBe true
+        }
+    }
+
+    test("a plaza sized cuboid keeps every face rather than losing the last ones to truncation") {
+        val plaza = CuboidShape(100.0, 5.0, 100.0)
+        val samples = plaza.sampleBoundary(0.5).toList()
+        (samples.size < MAX_BOUNDARY_SAMPLES) shouldBe true
+        for (y in listOf(-5.0, -2.5, 0.0, 2.5, 5.0)) {
+            samples.any { abs(it.y - y) < 1.5 && (abs(abs(it.x) - 100.0) < 1e-6 || abs(abs(it.z) - 100.0) < 1e-6) } shouldBe true
+        }
+        samples.any { it.y == 5.0 } shouldBe true
+        samples.any { it.y == -5.0 } shouldBe true
+    }
+
+    test("a traced town outline keeps its floor and its ceiling") {
+        val samples = polygon(40, 50.0, 160.0).sampleBoundary(0.5).toList()
+        (samples.size < MAX_BOUNDARY_SAMPLES) shouldBe true
+        samples.any { it.y == 160.0 } shouldBe true
+        samples.any { it.y == -160.0 } shouldBe true
+    }
+
+    test("the cap fill covers exactly the lattice points inside the outline") {
+        val square = PolygonShape(
+            points = listOf(
+                Vector(-2.0, 0.0, -2.0),
+                Vector(2.0, 0.0, -2.0),
+                Vector(2.0, 0.0, 2.0),
+                Vector(-2.0, 0.0, 2.0),
+            ),
+            halfHeight = 1.0,
+        )
+        // Step 1.0 over a 4 by 4 outline: nine lattice points lie strictly inside, and each of
+        // them belongs to both the floor and the ceiling.
+        val caps = square.sampleBoundary(1.0).filter { square.signedDistanceHorizontal(it) < -1e-9 }.toList()
+        caps.size shouldBe 18
+        caps.all { abs(abs(it.y) - 1.0) < 1e-9 } shouldBe true
+    }
+
+    test("the cap fill skips a concave outline's notch") {
+        val ell = PolygonShape(
+            points = listOf(
+                Vector(0.0, 0.0, 0.0),
+                Vector(6.0, 0.0, 0.0),
+                Vector(6.0, 0.0, 2.0),
+                Vector(2.0, 0.0, 2.0),
+                Vector(2.0, 0.0, 6.0),
+                Vector(0.0, 0.0, 6.0),
+            ),
+            halfHeight = 1.0,
+        )
+        val samples = ell.sampleBoundary(1.0).toList()
+        samples.none { it.x > 2.0 + 1e-9 && it.z > 2.0 + 1e-9 } shouldBe true
+        samples.any { abs(it.x - 1.0) < 1e-9 && abs(it.z - 1.0) < 1e-9 && abs(it.y - 1.0) < 1e-9 } shouldBe true
+    }
+
+    test("a diagonal band costs its own area rather than its bounding box's") {
+        // The budget counts samples emitted, and a lattice point outside the outline is rejected
+        // for free, so walking the whole bounding box is work no budget bounds. This outline fills
+        // a thousandth of its box: testing every point in it is tens of millions of outline tests,
+        // and the boundary displays run this per player per render.
+        val half = 7071.0
+        val band = PolygonShape(
+            points = listOf(
+                Vector(-half, 0.0, -half),
+                Vector(-half + 1.0, 0.0, -half),
+                Vector(half, 0.0, half - 1.0),
+                Vector(half, 0.0, half),
+            ),
+            halfHeight = 0.5,
+        )
+        val elapsed = measureTimeMillis { band.sampleBoundary(0.5).count() }
+        (elapsed < 3000) shouldBe true
+    }
+
+    test("an ordinary region is not truncated") {
+        val samples = SphereShape(10.0).sampleBoundary(0.5).count()
+        (samples in 100..MAX_BOUNDARY_SAMPLES) shouldBe true
+        (CuboidShape(5.0, 3.0, 5.0).sampleBoundary(0.5).count() < MAX_BOUNDARY_SAMPLES) shouldBe true
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/shape/ShapeSerializationSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/shape/ShapeSerializationSpec.kt
@@ -1,0 +1,62 @@
+package com.typewritermc.region.shape
+
+import com.google.gson.JsonParser
+import com.typewritermc.core.serialization.createDataSerializerGson
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.engine.paper.loader.serializers.VectorSerializer
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+
+/**
+ * An inline region definition is the only place a [Shape] is serialized: a definition entry
+ * builds its shape in code. Everything a shape derives from its own fields has to survive
+ * that round trip, and must never become a field a user can write.
+ */
+class ShapeSerializationSpec : FunSpec({
+    val gson = createDataSerializerGson(listOf(VectorSerializer()))
+
+    test("a shape writes only the fields that describe it") {
+        val json = gson.toJsonTree(SphereShape(5.0), Shape::class.java).asJsonObject
+
+        json["case"].asString shouldBe "sphere_shape"
+        json["value"].asJsonObject.keySet() shouldContainExactlyInAnyOrder setOf("radius")
+    }
+
+    test("a cone writes only the fields that describe it") {
+        val json = gson.toJsonTree(ConeShape(10.0, 30.0), Shape::class.java).asJsonObject
+
+        json["value"].asJsonObject.keySet() shouldContainExactlyInAnyOrder setOf("length", "halfAngleDegrees")
+    }
+
+    test("a sphere read back from json derives its bounds from its radius") {
+        val json = JsonParser.parseString("""{"case":"sphere_shape","value":{"radius":5.0}}""")
+
+        val shape = gson.fromJson(json, Shape::class.java)
+
+        shape.localBounds shouldBe LocalBounds(-5.0, -5.0, -5.0, 5.0, 5.0, 5.0)
+    }
+
+    test("a cone read back from json still classifies its own points") {
+        val json = JsonParser.parseString("""{"case":"cone_shape","value":{"length":10.0,"halfAngleDegrees":30.0}}""")
+
+        val shape = gson.fromJson(json, Shape::class.java)
+
+        shape.contains(Vector(0.0, 0.0, 5.0)).shouldBeTrue()
+        shape.localBounds.maxZ shouldBe 10.0
+    }
+
+    test("bounds saved by an older panel are ignored, not trusted") {
+        val json = JsonParser.parseString(
+            """
+            {"case":"sphere_shape","value":{"radius":5.0,"localBounds":{
+            "minX":0.0,"minY":0.0,"minZ":0.0,"maxX":0.0,"maxY":0.0,"maxZ":0.0}}}
+            """.trimIndent(),
+        )
+
+        val shape = gson.fromJson(json, Shape::class.java)
+
+        shape.localBounds shouldBe LocalBounds(-5.0, -5.0, -5.0, 5.0, 5.0, 5.0)
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/shape/SphereShapeSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/shape/SphereShapeSpec.kt
@@ -1,0 +1,40 @@
+package com.typewritermc.region.shape
+
+import com.typewritermc.core.utils.point.Vector
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.shouldBe
+
+private const val TOLERANCE = 1e-9
+
+class SphereShapeSpec : FunSpec({
+    val shape = SphereShape(2.0)
+
+    test("contains inside, boundary, and outside points") {
+        shape.contains(Vector(0.0, 0.0, 0.0)) shouldBe true
+        shape.contains(Vector(2.0, 0.0, 0.0)) shouldBe true
+        shape.contains(Vector(2.1, 0.0, 0.0)) shouldBe false
+    }
+
+    test("signed distance") {
+        shape.signedDistance(Vector(0.0, 0.0, 0.0)) shouldBe (-2.0 plusOrMinus TOLERANCE)
+        shape.signedDistance(Vector(3.0, 0.0, 0.0)) shouldBe (1.0 plusOrMinus TOLERANCE)
+    }
+
+    test("horizontal distance uses the silhouette circle") {
+        shape.signedDistanceHorizontal(Vector(0.0, 5.0, 0.0)) shouldBe (-2.0 plusOrMinus TOLERANCE)
+        shape.signedDistanceHorizontal(Vector(3.0, 5.0, 0.0)) shouldBe (1.0 plusOrMinus TOLERANCE)
+    }
+
+    test("nearest outside projects onto the surface") {
+        shape.nearestOutside(Vector(1.0, 0.0, 0.0)) shouldBe Vector(2.0, 0.0, 0.0)
+    }
+
+    test("normals point radially outward") {
+        shape.outwardNormals(Vector(0.0, 3.0, 0.0)) shouldBe listOf(Vector(0.0, 1.0, 0.0))
+    }
+
+    test("boundary samples lie on the boundary") {
+        shape.shouldSampleOnBoundary()
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/tracker/EscapeDirectionSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/tracker/EscapeDirectionSpec.kt
@@ -1,0 +1,54 @@
+package com.typewritermc.region.tracker
+
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.World
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.region.data.RegionDefinitionData
+import com.typewritermc.region.shape.CuboidShape
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * The barrier and the push action ask for this direction exactly when the nearest face is the
+ * floor or the ceiling, because a grounded player pushed into either only feels slowed. A
+ * direction that comes back null or radial there leaves them standing in the region being
+ * shoved into the ground, which is the failure the redirect exists to prevent.
+ */
+class EscapeDirectionSpec : FunSpec({
+    val world = World("world")
+
+    fun trackerFor(halfX: Double, halfY: Double, halfZ: Double): RegionTracker {
+        val definition = RegionDefinitionData(
+            origin = ConstVar(Position(world, 0.0, 64.0, 0.0)),
+            shape = CuboidShape(halfX, halfY, halfZ),
+        )
+        return RegionTracker(null, definition).apply { refresh() }
+    }
+
+    test("a player standing on the floor of a flat room is sent sideways, not nowhere") {
+        val tracker = trackerFor(30.0, 3.0, 30.0)
+        val direction = tracker.horizontalEscapeDirection(Position(world, 0.0, 61.1, 0.0)).shouldNotBeNull()
+
+        direction.y shouldBe 0.0
+        (direction.length > 0.9) shouldBe true
+    }
+
+    test("the direction points at the nearest wall") {
+        val tracker = trackerFor(30.0, 3.0, 30.0)
+        val direction = tracker.horizontalEscapeDirection(Position(world, 25.0, 61.1, 5.0)).shouldNotBeNull()
+
+        direction.x shouldBe (1.0 plusOrMinus 1e-9)
+        direction.y shouldBe 0.0
+        direction.z shouldBe (0.0 plusOrMinus 1e-9)
+    }
+
+    test("a player under the ceiling is sent sideways too") {
+        val tracker = trackerFor(30.0, 3.0, 30.0)
+        val direction = tracker.horizontalEscapeDirection(Position(world, -8.0, 66.9, 0.0)).shouldNotBeNull()
+
+        direction.x shouldBe (-1.0 plusOrMinus 1e-9)
+        direction.y shouldBe 0.0
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/tracker/InlineRegionBoundsSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/tracker/InlineRegionBoundsSpec.kt
@@ -1,0 +1,46 @@
+package com.typewritermc.region.tracker
+
+import com.google.gson.JsonParser
+import com.typewritermc.core.serialization.createDataSerializerGson
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.World
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.engine.paper.loader.serializers.VectorSerializer
+import com.typewritermc.region.data.RegionDefinitionData
+import com.typewritermc.region.shape.Shape
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * The engine only classifies a player against a tracker when the player is inside its world
+ * AABB, and that AABB comes from the shape's local bounds. An inline definition's shape is
+ * the only one that is read from json, so a shape that loses its bounds there silently
+ * shrinks the region's reach to nothing without changing where the region draws.
+ */
+class InlineRegionBoundsSpec : FunSpec({
+    val gson = createDataSerializerGson(listOf(VectorSerializer()))
+
+    test("an inline sphere reaches as far as its radius, whatever bounds the json carries") {
+        val json = JsonParser.parseString(
+            """
+            {"case":"sphere_shape","value":{"radius":20.0,"localBounds":{
+            "minX":0.0,"minY":0.0,"minZ":0.0,"maxX":0.0,"maxY":0.0,"maxZ":0.0}}}
+            """.trimIndent(),
+        )
+        val shape = gson.fromJson(json, Shape::class.java)
+
+        val definition = RegionDefinitionData(
+            origin = ConstVar(Position(World("world"), 100.0, 64.0, -40.0)),
+            shape = shape,
+        )
+        val tracker = RegionTracker(null, definition)
+        tracker.refresh()
+
+        val aabb = tracker.cachedAabb.shouldNotBeNull()
+        aabb.minX shouldBe 80.0
+        aabb.maxX shouldBe 120.0
+        aabb.minZ shouldBe -60.0
+        aabb.maxZ shouldBe -20.0
+    }
+})

--- a/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/tracker/RotatedTrackerBoundsSpec.kt
+++ b/extensions/RegionExtension/src/test/kotlin/com/typewritermc/region/tracker/RotatedTrackerBoundsSpec.kt
@@ -1,0 +1,62 @@
+package com.typewritermc.region.tracker
+
+import com.typewritermc.core.utils.point.Position
+import com.typewritermc.core.utils.point.Vector
+import com.typewritermc.core.utils.point.World
+import com.typewritermc.engine.paper.entry.entries.ConstVar
+import com.typewritermc.region.data.RegionDefinitionData
+import com.typewritermc.region.shape.CuboidShape
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * The engine skips a tracker entirely for a player outside its cached AABB, so an AABB that
+ * does not cover the resolved shape means enter and exit events, proximity bands and region
+ * audiences never fire for the part it misses. Every stored rotation angle has to reach the
+ * AABB, roll included: a wide flat region with roll extends much further vertically than its
+ * unrolled bounds.
+ */
+class RotatedTrackerBoundsSpec : FunSpec({
+    val world = World("world")
+
+    fun tracker(yaw: Float, pitch: Float, roll: Float): RegionTracker {
+        val definition = RegionDefinitionData(
+            origin = ConstVar(Position(world, 0.0, 64.0, 0.0)),
+            offset = ConstVar(Vector.ZERO),
+            yaw = ConstVar(yaw),
+            pitch = ConstVar(pitch),
+            roll = ConstVar(roll),
+            shape = CuboidShape(halfX = 10.0, halfY = 1.0, halfZ = 10.0),
+        )
+        return RegionTracker(null, definition).also { it.refresh() }
+    }
+
+    test("a rolled slab's bounds reach as high as the roll tips it") {
+        val aabb = tracker(yaw = 0f, pitch = 0f, roll = 90f).cachedAabb.shouldNotBeNull()
+
+        // Roll turns the 10-wide X half extent into the vertical one.
+        (aabb.maxY - 64.0) shouldBeGreaterThanOrEqual 10.0
+        (64.0 - aabb.minY) shouldBeGreaterThanOrEqual 10.0
+    }
+
+    test("a rolled region covers the corners of its own shape") {
+        val transform = tracker(yaw = 35f, pitch = 20f, roll = 55f).lastTransform.shouldNotBeNull()
+        val aabb = tracker(yaw = 35f, pitch = 20f, roll = 55f).cachedAabb.shouldNotBeNull()
+
+        for (x in listOf(-10.0, 10.0)) for (y in listOf(-1.0, 1.0)) for (z in listOf(-10.0, 10.0)) {
+            val corner = transform.toWorld(Vector(x, y, z))
+            aabb.contains(Position(world, corner.x, corner.y, corner.z)) shouldBe true
+        }
+    }
+
+    test("an unrotated region keeps the bounds its shape describes") {
+        val aabb = tracker(yaw = 0f, pitch = 0f, roll = 0f).cachedAabb.shouldNotBeNull()
+
+        aabb.minX shouldBe -10.0
+        aabb.maxX shouldBe 10.0
+        aabb.minY shouldBe 63.0
+        aabb.maxY shouldBe 65.0
+    }
+})


### PR DESCRIPTION
A region in a story has always been some other plugin's region, WorldGuard's or RPGRegions'. That buys a static cuboid, a hard dependency for anyone who only wanted a boundary trigger, and no answer at all when the volume has to follow an NPC or the player.

A definition is a single entry on a manifest page, and every event, audience, fact, display and flag points back at it. Placement is a Var, so a region sits wherever a variable resolves to. Trackers are keyed by the definition together with the viewer, which means a const placed region shares one tracker for the whole server and only a variable placed one costs a tracker per player. A per world chunk index in front of the AABB test keeps the cost of a move flat as the page count grows.

That covers six shapes, an in game editor, crossings that can be refused and rolled back, region audiences and a barrier, facts and variables, boundary displays and eighteen flags. The pages for all of it are already on develop, so this branch is code only.

Six audience entries land in the BasicExtension instead of here: prevent eating, prevent damage, lock health, prevent hunger loss, prevent block place and prevent block break. They are the player half of the same protection work, and a player rule that exists only inside a region is the wrong shape; any audience should be able to carry it. The BasicExtension had no test source set before this, so it has one now.